### PR TITLE
Scaffold remaining pages for certificate flow

### DIFF
--- a/app/controllers/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/CertificateCheckYourAnswersController.scala
@@ -17,23 +17,24 @@
 package controllers
 
 import controllers.actions.*
-import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateCheckYourAnswersView
 
-class CertificateCheckYourAnswersController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: CertificateCheckYourAnswersView
-                                     ) extends FrontendBaseController with I18nSupport {
+import javax.inject.Inject
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
-    implicit request =>
-      Ok(view())
+class CertificateCheckYourAnswersController @Inject() (
+    override val messagesApi: MessagesApi,
+    identify: IdentifierAction,
+    getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
+    val controllerComponents: MessagesControllerComponents,
+    view: CertificateCheckYourAnswersView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Ok(view())
   }
 }

--- a/app/controllers/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/CertificateCheckYourAnswersController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.*
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.CertificateCheckYourAnswersView
+
+class CertificateCheckYourAnswersController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: CertificateCheckYourAnswersView
+                                     ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+}

--- a/app/controllers/CertificateConfirmationController.scala
+++ b/app/controllers/CertificateConfirmationController.scala
@@ -17,23 +17,24 @@
 package controllers
 
 import controllers.actions.*
-import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateConfirmationView
 
-class CertificateConfirmationController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: CertificateConfirmationView
-                                     ) extends FrontendBaseController with I18nSupport {
+import javax.inject.Inject
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
-    implicit request =>
-      Ok(view())
+class CertificateConfirmationController @Inject() (
+    override val messagesApi: MessagesApi,
+    identify: IdentifierAction,
+    getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
+    val controllerComponents: MessagesControllerComponents,
+    view: CertificateConfirmationView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Ok(view())
   }
 }

--- a/app/controllers/CertificateConfirmationController.scala
+++ b/app/controllers/CertificateConfirmationController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.*
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.CertificateConfirmationView
+
+class CertificateConfirmationController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: CertificateConfirmationView
+                                     ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+}

--- a/app/controllers/CertificateDeclarationSaoController.scala
+++ b/app/controllers/CertificateDeclarationSaoController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.*
+import forms.CertificateDeclarationSaoFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.CertificateDeclarationSaoPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.CertificateDeclarationSaoView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CertificateDeclarationSaoController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: CertificateDeclarationSaoFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: CertificateDeclarationSaoView
+                                    )(using ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    val form = formProvider()
+    val preparedForm = request.userAnswers.get(CertificateDeclarationSaoPage).fold(form)(form.fill)
+    Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
+    val form = formProvider()
+    form.bindFromRequest().fold(
+      formWithErrors =>
+        Future.successful(BadRequest(view(formWithErrors, mode))),
+      value =>
+        for {
+          updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateDeclarationSaoPage, value))
+          _              <- sessionRepository.set(updatedAnswers)
+        } yield Redirect(navigator.nextPage(CertificateDeclarationSaoPage, mode, updatedAnswers))
+    )
+  }
+}

--- a/app/controllers/CertificateDeclarationSaoController.scala
+++ b/app/controllers/CertificateDeclarationSaoController.scala
@@ -18,7 +18,6 @@ package controllers
 
 import controllers.actions.*
 import forms.CertificateDeclarationSaoFormProvider
-import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
 import pages.CertificateDeclarationSaoPage
@@ -30,33 +29,39 @@ import views.html.CertificateDeclarationSaoView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CertificateDeclarationSaoController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: CertificateDeclarationSaoFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: CertificateDeclarationSaoView
-                                    )(using ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+import javax.inject.Inject
+
+class CertificateDeclarationSaoController @Inject() (
+    override val messagesApi: MessagesApi,
+    sessionRepository: SessionRepository,
+    navigator: Navigator,
+    identify: IdentifierAction,
+    getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
+    formProvider: CertificateDeclarationSaoFormProvider,
+    val controllerComponents: MessagesControllerComponents,
+    view: CertificateDeclarationSaoView
+)(using ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
-    val form = formProvider()
+    val form         = formProvider()
     val preparedForm = request.userAnswers.get(CertificateDeclarationSaoPage).fold(form)(form.fill)
     Ok(view(preparedForm, mode))
   }
 
-  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
-    val form = formProvider()
-    form.bindFromRequest().fold(
-      formWithErrors =>
-        Future.successful(BadRequest(view(formWithErrors, mode))),
-      value =>
-        for {
-          updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateDeclarationSaoPage, value))
-          _              <- sessionRepository.set(updatedAnswers)
-        } yield Redirect(navigator.nextPage(CertificateDeclarationSaoPage, mode, updatedAnswers))
-    )
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+      val form = formProvider()
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateDeclarationSaoPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(CertificateDeclarationSaoPage, mode, updatedAnswers))
+        )
   }
 }

--- a/app/controllers/CertificateWhoIsSubmittingController.scala
+++ b/app/controllers/CertificateWhoIsSubmittingController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.*
+import forms.CertificateWhoIsSubmittingFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.CertificateWhoIsSubmittingPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.CertificateWhoIsSubmittingView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CertificateWhoIsSubmittingController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       sessionRepository: SessionRepository,
+                                       navigator: Navigator,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       formProvider: CertificateWhoIsSubmittingFormProvider,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: CertificateWhoIsSubmittingView
+                                     )(using ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    val form = formProvider()
+    val preparedForm = request.userAnswers.get(CertificateWhoIsSubmittingPage).fold(form)(form.fill)
+    Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
+    val form = formProvider()
+    form.bindFromRequest().fold(
+      formWithErrors =>
+        Future.successful(BadRequest(view(formWithErrors, mode))),
+      value =>
+        for {
+          updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateWhoIsSubmittingPage, value))
+          _              <- sessionRepository.set(updatedAnswers)
+        } yield Redirect(navigator.nextPage(CertificateWhoIsSubmittingPage, mode, updatedAnswers))
+    )
+  }
+}

--- a/app/controllers/CertificateWhoIsSubmittingController.scala
+++ b/app/controllers/CertificateWhoIsSubmittingController.scala
@@ -18,7 +18,6 @@ package controllers
 
 import controllers.actions.*
 import forms.CertificateWhoIsSubmittingFormProvider
-import javax.inject.Inject
 import models.Mode
 import navigation.Navigator
 import pages.CertificateWhoIsSubmittingPage
@@ -30,33 +29,39 @@ import views.html.CertificateWhoIsSubmittingView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CertificateWhoIsSubmittingController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       sessionRepository: SessionRepository,
-                                       navigator: Navigator,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
-                                       formProvider: CertificateWhoIsSubmittingFormProvider,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: CertificateWhoIsSubmittingView
-                                     )(using ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+import javax.inject.Inject
+
+class CertificateWhoIsSubmittingController @Inject() (
+    override val messagesApi: MessagesApi,
+    sessionRepository: SessionRepository,
+    navigator: Navigator,
+    identify: IdentifierAction,
+    getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
+    formProvider: CertificateWhoIsSubmittingFormProvider,
+    val controllerComponents: MessagesControllerComponents,
+    view: CertificateWhoIsSubmittingView
+)(using ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
-    val form = formProvider()
+    val form         = formProvider()
     val preparedForm = request.userAnswers.get(CertificateWhoIsSubmittingPage).fold(form)(form.fill)
     Ok(view(preparedForm, mode))
   }
 
-  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
-    val form = formProvider()
-    form.bindFromRequest().fold(
-      formWithErrors =>
-        Future.successful(BadRequest(view(formWithErrors, mode))),
-      value =>
-        for {
-          updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateWhoIsSubmittingPage, value))
-          _              <- sessionRepository.set(updatedAnswers)
-        } yield Redirect(navigator.nextPage(CertificateWhoIsSubmittingPage, mode, updatedAnswers))
-    )
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+      val form = formProvider()
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateWhoIsSubmittingPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(CertificateWhoIsSubmittingPage, mode, updatedAnswers))
+        )
   }
 }

--- a/app/forms/CertificateDeclarationSaoFormProvider.scala
+++ b/app/forms/CertificateDeclarationSaoFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class CertificateDeclarationSaoFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("certificateDeclarationSao.error.required")
+        .verifying(maxLength(100, "certificateDeclarationSao.error.length"))
+    )
+}

--- a/app/forms/CertificateDeclarationSaoFormProvider.scala
+++ b/app/forms/CertificateDeclarationSaoFormProvider.scala
@@ -16,10 +16,10 @@
 
 package forms
 
-import javax.inject.Inject
-
 import forms.mappings.Mappings
 import play.api.data.Form
+
+import javax.inject.Inject
 
 class CertificateDeclarationSaoFormProvider @Inject() extends Mappings {
 

--- a/app/forms/CertificateWhoIsSubmittingFormProvider.scala
+++ b/app/forms/CertificateWhoIsSubmittingFormProvider.scala
@@ -16,11 +16,11 @@
 
 package forms
 
-import javax.inject.Inject
-
 import forms.mappings.Mappings
-import play.api.data.Form
 import models.CertificateWhoIsSubmitting
+import play.api.data.Form
+
+import javax.inject.Inject
 
 class CertificateWhoIsSubmittingFormProvider @Inject() extends Mappings {
 

--- a/app/forms/CertificateWhoIsSubmittingFormProvider.scala
+++ b/app/forms/CertificateWhoIsSubmittingFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+import models.CertificateWhoIsSubmitting
+
+class CertificateWhoIsSubmittingFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[CertificateWhoIsSubmitting] =
+    Form(
+      "value" -> enumerable[CertificateWhoIsSubmitting]("certificateWhoIsSubmitting.error.required")
+    )
+}

--- a/app/models/CertificateWhoIsSubmitting.scala
+++ b/app/models/CertificateWhoIsSubmitting.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+
+enum CertificateWhoIsSubmitting(override val toString: String) {
+  case Sao extends CertificateWhoIsSubmitting("sao")
+  case Standin extends CertificateWhoIsSubmitting("standIn")
+}
+
+object CertificateWhoIsSubmitting extends Enumerable.Implicits[CertificateWhoIsSubmitting] {
+
+  override def members: Array[CertificateWhoIsSubmitting] = CertificateWhoIsSubmitting.values
+
+  def options(using messages: Messages): Seq[RadioItem] = values.map { value =>
+    RadioItem(
+      content = Text(messages(s"certificateWhoIsSubmitting.${value.toString}")),
+      value   = Some(value.toString),
+      id      = Some(s"value_${value.ordinal}")
+    )
+  }
+
+}

--- a/app/models/CertificateWhoIsSubmitting.scala
+++ b/app/models/CertificateWhoIsSubmitting.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
 enum CertificateWhoIsSubmitting(override val toString: String) {
-  case Sao extends CertificateWhoIsSubmitting("sao")
+  case Sao     extends CertificateWhoIsSubmitting("sao")
   case Standin extends CertificateWhoIsSubmitting("standIn")
 }
 
@@ -32,8 +32,8 @@ object CertificateWhoIsSubmitting extends Enumerable.Implicits[CertificateWhoIsS
   def options(using messages: Messages): Seq[RadioItem] = values.map { value =>
     RadioItem(
       content = Text(messages(s"certificateWhoIsSubmitting.${value.toString}")),
-      value   = Some(value.toString),
-      id      = Some(s"value_${value.ordinal}")
+      value = Some(value.toString),
+      id = Some(s"value_${value.ordinal}")
     )
   }
 

--- a/app/pages/CertificateDeclarationSaoPage.scala
+++ b/app/pages/CertificateDeclarationSaoPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object CertificateDeclarationSaoPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "certificateDeclarationSao"
+}

--- a/app/pages/CertificateWhoIsSubmittingPage.scala
+++ b/app/pages/CertificateWhoIsSubmittingPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import models.CertificateWhoIsSubmitting
+import play.api.libs.json.JsPath
+
+case object CertificateWhoIsSubmittingPage extends QuestionPage[CertificateWhoIsSubmitting] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "certificateWhoIsSubmitting"
+}

--- a/app/viewmodels/checkAnswers/CertificateDeclarationSaoSummary.scala
+++ b/app/viewmodels/checkAnswers/CertificateDeclarationSaoSummary.scala
@@ -20,23 +20,24 @@ import controllers.routes
 import models.{CheckMode, UserAnswers}
 import pages.CertificateDeclarationSaoPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.summarylist.*
 import viewmodels.converters.*
+import viewmodels.govuk.summarylist.*
 
 object CertificateDeclarationSaoSummary {
 
   def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(CertificateDeclarationSaoPage).map {
-      answer =>
-        SummaryListRowViewModel(
-          key     = messages("certificateDeclarationSao.checkYourAnswersLabel").toKey,
-          value   = ValueViewModel(answer.toText),
-          actions = Seq(
-            ActionItemViewModel(messages("site.change").toText, routes.CertificateDeclarationSaoController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("certificateDeclarationSao.change.hidden"))
+    answers.get(CertificateDeclarationSaoPage).map { answer =>
+      SummaryListRowViewModel(
+        key = messages("certificateDeclarationSao.checkYourAnswersLabel").toKey,
+        value = ValueViewModel(answer.toText),
+        actions = Seq(
+          ActionItemViewModel(
+            messages("site.change").toText,
+            routes.CertificateDeclarationSaoController.onPageLoad(CheckMode).url
           )
+            .withVisuallyHiddenText(messages("certificateDeclarationSao.change.hidden"))
         )
+      )
     }
 }

--- a/app/viewmodels/checkAnswers/CertificateDeclarationSaoSummary.scala
+++ b/app/viewmodels/checkAnswers/CertificateDeclarationSaoSummary.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.CertificateDeclarationSaoPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.converters.*
+
+object CertificateDeclarationSaoSummary {
+
+  def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
+    answers.get(CertificateDeclarationSaoPage).map {
+      answer =>
+        SummaryListRowViewModel(
+          key     = messages("certificateDeclarationSao.checkYourAnswersLabel").toKey,
+          value   = ValueViewModel(answer.toText),
+          actions = Seq(
+            ActionItemViewModel(messages("site.change").toText, routes.CertificateDeclarationSaoController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("certificateDeclarationSao.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummary.scala
+++ b/app/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummary.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.CertificateWhoIsSubmittingPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist.*
+import viewmodels.converters.*
+
+object CertificateWhoIsSubmittingSummary {
+
+  def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
+    answers.get(CertificateWhoIsSubmittingPage).map {
+      answer =>
+        val value = ValueViewModel(
+          HtmlContent(
+            HtmlFormat.escape(messages(s"certificateWhoIsSubmitting.$answer"))
+          )
+        )
+        SummaryListRowViewModel(
+          key     = messages("certificateWhoIsSubmitting.checkYourAnswersLabel").toKey,
+          value   = value,
+          actions = Seq(
+            ActionItemViewModel(messages("site.change").toText, routes.CertificateWhoIsSubmittingController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("certificateWhoIsSubmitting.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummary.scala
+++ b/app/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummary.scala
@@ -23,26 +23,28 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.summarylist.*
 import viewmodels.converters.*
+import viewmodels.govuk.summarylist.*
 
 object CertificateWhoIsSubmittingSummary {
 
   def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(CertificateWhoIsSubmittingPage).map {
-      answer =>
-        val value = ValueViewModel(
-          HtmlContent(
-            HtmlFormat.escape(messages(s"certificateWhoIsSubmitting.$answer"))
-          )
+    answers.get(CertificateWhoIsSubmittingPage).map { answer =>
+      val value = ValueViewModel(
+        HtmlContent(
+          HtmlFormat.escape(messages(s"certificateWhoIsSubmitting.$answer"))
         )
-        SummaryListRowViewModel(
-          key     = messages("certificateWhoIsSubmitting.checkYourAnswersLabel").toKey,
-          value   = value,
-          actions = Seq(
-            ActionItemViewModel(messages("site.change").toText, routes.CertificateWhoIsSubmittingController.onPageLoad(CheckMode).url)
-              .withVisuallyHiddenText(messages("certificateWhoIsSubmitting.change.hidden"))
+      )
+      SummaryListRowViewModel(
+        key = messages("certificateWhoIsSubmitting.checkYourAnswersLabel").toKey,
+        value = value,
+        actions = Seq(
+          ActionItemViewModel(
+            messages("site.change").toText,
+            routes.CertificateWhoIsSubmittingController.onPageLoad(CheckMode).url
           )
+            .withVisuallyHiddenText(messages("certificateWhoIsSubmitting.change.hidden"))
         )
+      )
     }
 }

--- a/app/views/CertificateCheckYourAnswersView.scala.html
+++ b/app/views/CertificateCheckYourAnswersView.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(using request: Request[?], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("certificateCheckYourAnswers.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("certificateCheckYourAnswers.heading")</h1>
+}

--- a/app/views/CertificateConfirmationView.scala.html
+++ b/app/views/CertificateConfirmationView.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(using request: Request[?], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("certificateConfirmation.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("certificateConfirmation.heading")</h1>
+}

--- a/app/views/CertificateDeclarationSaoView.scala.html
+++ b/app/views/CertificateDeclarationSaoView.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth.*
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[?], mode: Mode)(using request: Request[?], messages: Messages)
+
+@layout(pageTitle = title(form, messages("certificateDeclarationSao.title"))) {
+
+    @formHelper(action = routes.CertificateDeclarationSaoController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("certificateDeclarationSao.heading").toText).asPageHeading(LabelSize.Large)
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue").toText)
+        )
+    }
+}

--- a/app/views/CertificateWhoIsSubmittingView.scala.html
+++ b/app/views/CertificateWhoIsSubmittingView.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[?], mode: Mode)(using request: Request[?], messages: Messages)
+
+@layout(pageTitle = title(form, messages("certificateWhoIsSubmitting.title"))) {
+
+    @formHelper(action = routes.CertificateWhoIsSubmittingController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
+        }
+
+        @govukRadios(
+            RadiosViewModel(
+                field  = form("value"),
+                legend = LegendViewModel(messages("certificateWhoIsSubmitting.heading").toText).asPageHeading(LegendSize.Large),
+                items  = CertificateWhoIsSubmitting.options
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue").toText)
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -151,3 +151,17 @@ GET        /certificateDeclarationStandIn                        controllers.Cer
 POST       /certificateDeclarationStandIn                        controllers.CertificateDeclarationStandInController.onSubmit(mode: Mode = NormalMode)
 GET        /changeCertificateDeclarationStandIn                  controllers.CertificateDeclarationStandInController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeCertificateDeclarationStandIn                  controllers.CertificateDeclarationStandInController.onSubmit(mode: Mode = CheckMode)
+
+GET        /certificateWhoIsSubmitting                        controllers.CertificateWhoIsSubmittingController.onPageLoad(mode: Mode = NormalMode)
+POST       /certificateWhoIsSubmitting                        controllers.CertificateWhoIsSubmittingController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCertificateWhoIsSubmitting                  controllers.CertificateWhoIsSubmittingController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCertificateWhoIsSubmitting                  controllers.CertificateWhoIsSubmittingController.onSubmit(mode: Mode = CheckMode)
+
+GET        /certificateCheckYourAnswers                       controllers.CertificateCheckYourAnswersController.onPageLoad()
+
+GET        /certificateConfirmation                       controllers.CertificateConfirmationController.onPageLoad()
+
+GET        /certificateDeclarationSao                        controllers.CertificateDeclarationSaoController.onPageLoad(mode: Mode = NormalMode)
+POST       /certificateDeclarationSao                        controllers.CertificateDeclarationSaoController.onSubmit(mode: Mode = NormalMode)
+GET        /changeCertificateDeclarationSao                  controllers.CertificateDeclarationSaoController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeCertificateDeclarationSao                  controllers.CertificateDeclarationSaoController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -406,3 +406,24 @@ certificateDeclarationStandIn.error.StandInName.length = StandInName must be 100
 certificateDeclarationStandIn.error.SaoName.length = SaoName must be 100 characters or less
 certificateDeclarationStandIn.StandInName.change.hidden = StandInName
 certificateDeclarationStandIn.SaoName.change.hidden = SaoName
+
+certificateWhoIsSubmitting.title = certificateWhoIsSubmitting
+certificateWhoIsSubmitting.heading = certificateWhoIsSubmitting
+certificateWhoIsSubmitting.sao = Option 1
+certificateWhoIsSubmitting.standIn = Option 2
+certificateWhoIsSubmitting.checkYourAnswersLabel = certificateWhoIsSubmitting
+certificateWhoIsSubmitting.error.required = Select certificateWhoIsSubmitting
+certificateWhoIsSubmitting.change.hidden = CertificateWhoIsSubmitting
+
+certificateCheckYourAnswers.title = certificateCheckYourAnswers
+certificateCheckYourAnswers.heading = certificateCheckYourAnswers
+
+certificateConfirmation.title = certificateConfirmation
+certificateConfirmation.heading = certificateConfirmation
+
+certificateDeclarationSao.title = certificateDeclarationSao
+certificateDeclarationSao.heading = certificateDeclarationSao
+certificateDeclarationSao.checkYourAnswersLabel = certificateDeclarationSao
+certificateDeclarationSao.error.required = Enter certificateDeclarationSao
+certificateDeclarationSao.error.length = CertificateDeclarationSao must be 100 characters or less
+certificateDeclarationSao.change.hidden = CertificateDeclarationSao

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -22,6 +22,11 @@ import org.scalacheck.{Arbitrary, Gen}
 
 trait ModelGenerators {
 
+  given arbitraryCertificateWhoIsSubmitting: Arbitrary[CertificateWhoIsSubmitting] =
+    Arbitrary {
+      Gen.oneOf(CertificateWhoIsSubmitting.values.toSeq)
+    }
+
   given arbitraryCertificateDeclarationStandIn: Arbitrary[CertificateDeclarationStandIn] =
     Arbitrary {
       for {

--- a/test/controllers/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CertificateCheckYourAnswersControllerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import views.html.CertificateCheckYourAnswersView
+
+class CertificateCheckYourAnswersControllerSpec extends SpecBase {
+
+  "CertificateCheckYourAnswers Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.CertificateCheckYourAnswersController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CertificateCheckYourAnswersView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/CertificateConfirmationControllerSpec.scala
+++ b/test/controllers/CertificateConfirmationControllerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import views.html.CertificateConfirmationView
+
+class CertificateConfirmationControllerSpec extends SpecBase {
+
+  "CertificateConfirmation Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.CertificateConfirmationController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CertificateConfirmationView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/CertificateDeclarationSaoControllerSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.CertificateDeclarationSaoFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.CertificateDeclarationSaoPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import repositories.SessionRepository
+import views.html.CertificateDeclarationSaoView
+
+import scala.concurrent.Future
+
+class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new CertificateDeclarationSaoFormProvider()
+  val form = formProvider()
+
+  lazy val certificateDeclarationSaoRoute = routes.CertificateDeclarationSaoController.onPageLoad(NormalMode).url
+
+  "CertificateDeclarationSao Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateDeclarationSaoRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CertificateDeclarationSaoView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(CertificateDeclarationSaoPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateDeclarationSaoRoute)
+
+        val view = application.injector.instanceOf[CertificateDeclarationSaoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateDeclarationSaoRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateDeclarationSaoRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[CertificateDeclarationSaoView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateDeclarationSaoRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateDeclarationSaoRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/CertificateDeclarationSaoControllerSpec.scala
@@ -32,13 +32,14 @@ import repositories.SessionRepository
 import views.html.CertificateDeclarationSaoView
 
 import scala.concurrent.Future
+import play.api.data.Form
 
 class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  val formProvider = new CertificateDeclarationSaoFormProvider()
-  val form: Any    = formProvider()
+  val formProvider       = new CertificateDeclarationSaoFormProvider()
+  val form: Form[String] = formProvider()
 
   lazy val certificateDeclarationSaoRoute: String =
     routes.CertificateDeclarationSaoController.onPageLoad(NormalMode).url

--- a/test/controllers/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/CertificateDeclarationSaoControllerSpec.scala
@@ -35,12 +35,13 @@ import scala.concurrent.Future
 
 class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar {
 
-  def onwardRoute = Call("GET", "/foo")
+  def onwardRoute: Call = Call("GET", "/foo")
 
   val formProvider = new CertificateDeclarationSaoFormProvider()
-  val form = formProvider()
+  val form: Any    = formProvider()
 
-  lazy val certificateDeclarationSaoRoute = routes.CertificateDeclarationSaoController.onPageLoad(NormalMode).url
+  lazy val certificateDeclarationSaoRoute: String =
+    routes.CertificateDeclarationSaoController.onPageLoad(NormalMode).url
 
   "CertificateDeclarationSao Controller" - {
 
@@ -74,7 +75,10 @@ class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(using request, messages(application)).toString
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(using
+          request,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.CertificateWhoIsSubmittingFormProvider
-import models.{NormalMode, CertificateWhoIsSubmitting, UserAnswers}
+import models.{CertificateWhoIsSubmitting, NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -35,12 +35,13 @@ import scala.concurrent.Future
 
 class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSugar {
 
-  def onwardRoute = Call("GET", "/foo")
+  def onwardRoute: Call = Call("GET", "/foo")
 
-  lazy val certificateWhoIsSubmittingRoute = routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode).url
+  lazy val certificateWhoIsSubmittingRoute: String =
+    routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode).url
 
   val formProvider = new CertificateWhoIsSubmittingFormProvider()
-  val form = formProvider()
+  val form: Any    = formProvider()
 
   "CertificateWhoIsSubmitting Controller" - {
 
@@ -62,7 +63,10 @@ class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSuga
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.values.head).success.value
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.values.head)
+        .success
+        .value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -74,7 +78,10 @@ class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSuga
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill(CertificateWhoIsSubmitting.values.head), NormalMode)(using request, messages(application)).toString
+        contentAsString(result) mustEqual view(form.fill(CertificateWhoIsSubmitting.values.head), NormalMode)(using
+          request,
+          messages(application)
+        ).toString
       }
     }
 

--- a/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import forms.CertificateWhoIsSubmittingFormProvider
+import models.{NormalMode, CertificateWhoIsSubmitting, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.CertificateWhoIsSubmittingPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import repositories.SessionRepository
+import views.html.CertificateWhoIsSubmittingView
+
+import scala.concurrent.Future
+
+class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  lazy val certificateWhoIsSubmittingRoute = routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode).url
+
+  val formProvider = new CertificateWhoIsSubmittingFormProvider()
+  val form = formProvider()
+
+  "CertificateWhoIsSubmitting Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateWhoIsSubmittingRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CertificateWhoIsSubmittingView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.values.head).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateWhoIsSubmittingRoute)
+
+        val view = application.injector.instanceOf[CertificateWhoIsSubmittingView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(CertificateWhoIsSubmitting.values.head), NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateWhoIsSubmittingRoute)
+            .withFormUrlEncodedBody(("value", CertificateWhoIsSubmitting.values.head.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateWhoIsSubmittingRoute)
+            .withFormUrlEncodedBody(("value", "invalid value"))
+
+        val boundForm = form.bind(Map("value" -> "invalid value"))
+
+        val view = application.injector.instanceOf[CertificateWhoIsSubmittingView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateWhoIsSubmittingRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateWhoIsSubmittingRoute)
+            .withFormUrlEncodedBody(("value", CertificateWhoIsSubmitting.values.head.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
@@ -32,6 +32,7 @@ import repositories.SessionRepository
 import views.html.CertificateWhoIsSubmittingView
 
 import scala.concurrent.Future
+import play.api.data.Form
 
 class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSugar {
 
@@ -40,8 +41,8 @@ class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSuga
   lazy val certificateWhoIsSubmittingRoute: String =
     routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode).url
 
-  val formProvider = new CertificateWhoIsSubmittingFormProvider()
-  val form: Any    = formProvider()
+  val formProvider                           = new CertificateWhoIsSubmittingFormProvider()
+  val form: Form[CertificateWhoIsSubmitting] = formProvider()
 
   "CertificateWhoIsSubmitting Controller" - {
 

--- a/test/forms/CertificateDeclarationSaoFormProviderSpec.scala
+++ b/test/forms/CertificateDeclarationSaoFormProviderSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class CertificateDeclarationSaoFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "certificateDeclarationSao.error.required"
+  val lengthKey = "certificateDeclarationSao.error.length"
+  val maxLength = 100
+
+  val form = new CertificateDeclarationSaoFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+
+  "error message keys must map to the expected text" - {
+    createTestWithErrorMessageAssertion(
+      key = requiredKey,
+      message = "Enter certificateDeclarationSao"
+    )
+
+    createTestWithErrorMessageAssertion(
+      key = lengthKey,
+      message = "CertificateDeclarationSao must be 100 characters or less"
+    )
+  }
+}

--- a/test/forms/CertificateDeclarationSaoFormProviderSpec.scala
+++ b/test/forms/CertificateDeclarationSaoFormProviderSpec.scala
@@ -22,8 +22,8 @@ import play.api.data.FormError
 class CertificateDeclarationSaoFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "certificateDeclarationSao.error.required"
-  val lengthKey = "certificateDeclarationSao.error.length"
-  val maxLength = 100
+  val lengthKey   = "certificateDeclarationSao.error.length"
+  val maxLength   = 100
 
   val form = new CertificateDeclarationSaoFormProvider()()
 

--- a/test/forms/CertificateWhoIsSubmittingFormProviderSpec.scala
+++ b/test/forms/CertificateWhoIsSubmittingFormProviderSpec.scala
@@ -22,7 +22,7 @@ import play.api.data.FormError
 
 class CertificateWhoIsSubmittingFormProviderSpec extends OptionFieldBehaviours {
 
-  val form = new CertificateWhoIsSubmittingFormProvider()()
+  val form        = new CertificateWhoIsSubmittingFormProvider()()
   val requiredKey = "certificateWhoIsSubmitting.error.required"
 
   ".value" - {
@@ -32,7 +32,7 @@ class CertificateWhoIsSubmittingFormProviderSpec extends OptionFieldBehaviours {
     behave like optionsField[CertificateWhoIsSubmitting](
       form,
       fieldName,
-      validValues  = CertificateWhoIsSubmitting.values,
+      validValues = CertificateWhoIsSubmitting.values,
       invalidError = FormError(fieldName, "error.invalid")
     )
 

--- a/test/forms/CertificateWhoIsSubmittingFormProviderSpec.scala
+++ b/test/forms/CertificateWhoIsSubmittingFormProviderSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import forms.behaviours.OptionFieldBehaviours
+import models.CertificateWhoIsSubmitting
+import play.api.data.FormError
+
+class CertificateWhoIsSubmittingFormProviderSpec extends OptionFieldBehaviours {
+
+  val form = new CertificateWhoIsSubmittingFormProvider()()
+  val requiredKey = "certificateWhoIsSubmitting.error.required"
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like optionsField[CertificateWhoIsSubmitting](
+      form,
+      fieldName,
+      validValues  = CertificateWhoIsSubmitting.values,
+      invalidError = FormError(fieldName, "error.invalid")
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+
+  "error message keys must map to the expected text" - {
+    createTestWithErrorMessageAssertion(
+      key = requiredKey,
+      message = "Select certificateWhoIsSubmitting"
+    )
+  }
+}

--- a/test/models/CertificateWhoIsSubmittingSpec.scala
+++ b/test/models/CertificateWhoIsSubmittingSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.OptionValues
+import play.api.libs.json.{JsError, JsString, Json}
+
+class CertificateWhoIsSubmittingSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with OptionValues {
+
+  "CertificateWhoIsSubmitting" - {
+
+    "must deserialise valid values" in {
+
+      val gen = Gen.oneOf(CertificateWhoIsSubmitting.values.toSeq)
+
+      forAll(gen) {
+        certificateWhoIsSubmitting =>
+
+          JsString(certificateWhoIsSubmitting.toString).validate[CertificateWhoIsSubmitting].asOpt.value mustEqual certificateWhoIsSubmitting
+      }
+    }
+
+    "must fail to deserialise invalid values" in {
+
+      val gen = arbitrary[String] suchThat (!CertificateWhoIsSubmitting.values.map(_.toString).contains(_))
+
+      forAll(gen) {
+        invalidValue =>
+
+          JsString(invalidValue).validate[CertificateWhoIsSubmitting] mustEqual JsError("error.invalid")
+      }
+    }
+
+    "must serialise" in {
+
+      val gen = Gen.oneOf(CertificateWhoIsSubmitting.values.toSeq)
+
+      forAll(gen) {
+        certificateWhoIsSubmitting =>
+
+          Json.toJson(certificateWhoIsSubmitting) mustEqual JsString(certificateWhoIsSubmitting.toString)
+      }
+    }
+  }
+}

--- a/test/models/CertificateWhoIsSubmittingSpec.scala
+++ b/test/models/CertificateWhoIsSubmittingSpec.scala
@@ -18,10 +18,10 @@ package models
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.OptionValues
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.{JsError, JsString, Json}
 
 class CertificateWhoIsSubmittingSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with OptionValues {
@@ -32,10 +32,11 @@ class CertificateWhoIsSubmittingSpec extends AnyFreeSpec with Matchers with Scal
 
       val gen = Gen.oneOf(CertificateWhoIsSubmitting.values.toSeq)
 
-      forAll(gen) {
-        certificateWhoIsSubmitting =>
-
-          JsString(certificateWhoIsSubmitting.toString).validate[CertificateWhoIsSubmitting].asOpt.value mustEqual certificateWhoIsSubmitting
+      forAll(gen) { certificateWhoIsSubmitting =>
+        JsString(certificateWhoIsSubmitting.toString)
+          .validate[CertificateWhoIsSubmitting]
+          .asOpt
+          .value mustEqual certificateWhoIsSubmitting
       }
     }
 
@@ -43,10 +44,8 @@ class CertificateWhoIsSubmittingSpec extends AnyFreeSpec with Matchers with Scal
 
       val gen = arbitrary[String] suchThat (!CertificateWhoIsSubmitting.values.map(_.toString).contains(_))
 
-      forAll(gen) {
-        invalidValue =>
-
-          JsString(invalidValue).validate[CertificateWhoIsSubmitting] mustEqual JsError("error.invalid")
+      forAll(gen) { invalidValue =>
+        JsString(invalidValue).validate[CertificateWhoIsSubmitting] mustEqual JsError("error.invalid")
       }
     }
 
@@ -54,10 +53,8 @@ class CertificateWhoIsSubmittingSpec extends AnyFreeSpec with Matchers with Scal
 
       val gen = Gen.oneOf(CertificateWhoIsSubmitting.values.toSeq)
 
-      forAll(gen) {
-        certificateWhoIsSubmitting =>
-
-          Json.toJson(certificateWhoIsSubmitting) mustEqual JsString(certificateWhoIsSubmitting.toString)
+      forAll(gen) { certificateWhoIsSubmitting =>
+        Json.toJson(certificateWhoIsSubmitting) mustEqual JsString(certificateWhoIsSubmitting.toString)
       }
     }
   }

--- a/test/viewmodels/checkAnswers/CertificateDeclarationSaoSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateDeclarationSaoSummarySpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import base.SpecBase
+import controllers.routes
+import models.CheckMode
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import pages.CertificateDeclarationSaoPage
+import play.api.i18n.{Messages, MessagesApi}
+import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
+
+class CertificateDeclarationSaoSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+  given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
+
+  "CertificateDeclarationSaoSummary.row" - {
+
+    "when there is no answer for CertificateDeclarationSaoPage" - {
+      "must return None" in {
+        def SUT = CertificateDeclarationSaoSummary.row(emptyUserAnswers)
+
+        SUT mustBe None
+      }
+    }
+
+    "when there is a user answer for CertificateDeclarationSaoPage" - {
+      def testUserAnswers(answer: String) =
+        emptyUserAnswers.set(CertificateDeclarationSaoPage, answer).get
+
+      def SUT(answer: String = "") = CertificateDeclarationSaoSummary.row(testUserAnswers(answer)).get
+
+      "must have expected key" in {
+        SUT().key mustBe "certificateDeclarationSao".toKey
+      }
+
+      "expected value" - {
+        "must show 'testCertificateDeclarationSao' when user answers is 'testCertificateDeclarationSao'" in {
+          SUT(answer = "testCertificateDeclarationSao").value.content mustBe "testCertificateDeclarationSao".toText
+        }
+      }
+
+      "expected action" - {
+        def actions = SUT().actions
+
+        "must only have one action" in {
+          withClue("must be 1 action\n") {
+            actions.size mustBe 1
+          }
+          withClue("must be 1 item in the action\n") {
+            actions.head.items.size mustBe 1
+          }
+        }
+
+        def action = actions.head.items.head
+
+        "must have expected text" in {
+          action.content mustBe "Change".toText
+        }
+
+        "must have expected url" in {
+          action.href mustBe routes.CertificateDeclarationSaoController
+            .onPageLoad(CheckMode)
+            .url
+        }
+
+        "must have expected hidden text" in {
+          action.visuallyHiddenText.get mustBe "CertificateDeclarationSao"
+        }
+      }
+    }
+  }
+
+}

--- a/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers
+
+import base.SpecBase
+import controllers.routes
+import models.{CheckMode, CertificateWhoIsSubmitting}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import pages.CertificateWhoIsSubmittingPage
+import play.api.i18n.{Messages, MessagesApi}
+import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+
+class CertificateWhoIsSubmittingSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+  given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
+
+  "CertificateWhoIsSubmittingSummary.row" - {
+
+    "when there is no answer for CertificateWhoIsSubmittingPage" - {
+      "must return None" in {
+        def SUT = CertificateWhoIsSubmittingSummary.row(emptyUserAnswers)
+
+        SUT mustBe None
+      }
+    }
+
+    "when there is a user answer for CertificateWhoIsSubmittingPage" - {
+      def testUserAnswers(answer: CertificateWhoIsSubmitting) =
+        emptyUserAnswers.set(CertificateWhoIsSubmittingPage, answer).get
+
+      def SUT(answer: CertificateWhoIsSubmitting = CertificateWhoIsSubmitting.Sao) = CertificateWhoIsSubmittingSummary.row(testUserAnswers(answer)).get
+
+      "must have expected key" in {
+        SUT().key mustBe "certificateWhoIsSubmitting".toKey
+      }
+
+      "expected value" - {
+        "must show 'Option1' when user answers is sao" in {
+          SUT(answer = CertificateWhoIsSubmitting.Sao).value.content mustBe HtmlContent("Option 1")
+        }
+
+        "must show 'Option2' when user answers is standIn" in {
+          SUT(answer = CertificateWhoIsSubmitting.Standin).value.content mustBe HtmlContent("Option 2")
+        }
+      }
+
+      "expected action" - {
+        def actions = SUT().actions
+
+        "must only have one action" in {
+          withClue("must be 1 action\n") {
+            actions.size mustBe 1
+          }
+          withClue("must be 1 item in the action\n") {
+            actions.head.items.size mustBe 1
+          }
+        }
+
+        def action = actions.head.items.head
+
+        "must have expected text" in {
+          action.content mustBe "Change".toText
+        }
+
+        "must have expected url" in {
+          action.href mustBe routes.CertificateWhoIsSubmittingController
+            .onPageLoad(CheckMode)
+            .url
+        }
+
+        "must have expected hidden text" in {
+          action.visuallyHiddenText.get mustBe "CertificateWhoIsSubmitting"
+        }
+      }
+    }
+  }
+
+}

--- a/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers
 
 import base.SpecBase
 import controllers.routes
-import models.{CheckMode, CertificateWhoIsSubmitting}
+import models.{CertificateWhoIsSubmitting, CheckMode}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import pages.CertificateWhoIsSubmittingPage
 import play.api.i18n.{Messages, MessagesApi}
@@ -42,7 +42,8 @@ class CertificateWhoIsSubmittingSummarySpec extends SpecBase with GuiceOneAppPer
       def testUserAnswers(answer: CertificateWhoIsSubmitting) =
         emptyUserAnswers.set(CertificateWhoIsSubmittingPage, answer).get
 
-      def SUT(answer: CertificateWhoIsSubmitting = CertificateWhoIsSubmitting.Sao) = CertificateWhoIsSubmittingSummary.row(testUserAnswers(answer)).get
+      def SUT(answer: CertificateWhoIsSubmitting = CertificateWhoIsSubmitting.Sao) =
+        CertificateWhoIsSubmittingSummary.row(testUserAnswers(answer)).get
 
       "must have expected key" in {
         SUT().key mustBe "certificateWhoIsSubmitting".toKey

--- a/test/views/CertificateCheckYourAnswersViewSpec.scala
+++ b/test/views/CertificateCheckYourAnswersViewSpec.scala
@@ -19,9 +19,8 @@ package views
 import base.ViewSpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.i18n.Messages
-import views.html.CertificateCheckYourAnswersView
 import views.CertificateCheckYourAnswersViewSpec.*
+import views.html.CertificateCheckYourAnswersView
 
 class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckYourAnswersView] {
 
@@ -44,5 +43,5 @@ class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckY
 
 object CertificateCheckYourAnswersViewSpec {
   val pageHeading = "certificateCheckYourAnswers"
-  val pageTitle = "certificateCheckYourAnswers"
+  val pageTitle   = "certificateCheckYourAnswers"
 }

--- a/test/views/CertificateCheckYourAnswersViewSpec.scala
+++ b/test/views/CertificateCheckYourAnswersViewSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.Messages
+import views.html.CertificateCheckYourAnswersView
+import views.CertificateCheckYourAnswersViewSpec.*
+
+class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckYourAnswersView] {
+
+  private def generateView(): Document = Jsoup.parse(SUT().toString)
+
+  "CertificateCheckYourAnswersView" - {
+    val doc: Document = generateView()
+
+    doc.createTestsWithStandardPageElements(
+      pageTitle = pageTitle,
+      pageHeading = pageHeading,
+      showBackLink = true,
+      showIsThisPageNotWorkingProperlyLink = true,
+      hasError = false
+    )
+
+    doc.createTestsWithOrWithoutError(hasError = false)
+  }
+}
+
+object CertificateCheckYourAnswersViewSpec {
+  val pageHeading = "certificateCheckYourAnswers"
+  val pageTitle = "certificateCheckYourAnswers"
+}

--- a/test/views/CertificateConfirmationViewSpec.scala
+++ b/test/views/CertificateConfirmationViewSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.i18n.Messages
+import views.html.CertificateConfirmationView
+import views.CertificateConfirmationViewSpec.*
+
+class CertificateConfirmationViewSpec extends ViewSpecBase[CertificateConfirmationView] {
+
+  private def generateView(): Document = Jsoup.parse(SUT().toString)
+
+  "CertificateConfirmationView" - {
+    val doc: Document = generateView()
+
+    doc.createTestsWithStandardPageElements(
+      pageTitle = pageTitle,
+      pageHeading = pageHeading,
+      showBackLink = true,
+      showIsThisPageNotWorkingProperlyLink = true,
+      hasError = false
+    )
+
+    doc.createTestsWithOrWithoutError(hasError = false)
+  }
+}
+
+object CertificateConfirmationViewSpec {
+  val pageHeading = "certificateConfirmation"
+  val pageTitle = "certificateConfirmation"
+}

--- a/test/views/CertificateConfirmationViewSpec.scala
+++ b/test/views/CertificateConfirmationViewSpec.scala
@@ -19,9 +19,8 @@ package views
 import base.ViewSpecBase
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.i18n.Messages
-import views.html.CertificateConfirmationView
 import views.CertificateConfirmationViewSpec.*
+import views.html.CertificateConfirmationView
 
 class CertificateConfirmationViewSpec extends ViewSpecBase[CertificateConfirmationView] {
 
@@ -44,5 +43,5 @@ class CertificateConfirmationViewSpec extends ViewSpecBase[CertificateConfirmati
 
 object CertificateConfirmationViewSpec {
   val pageHeading = "certificateConfirmation"
-  val pageTitle = "certificateConfirmation"
+  val pageTitle   = "certificateConfirmation"
 }

--- a/test/views/CertificateDeclarationSaoViewSpec.scala
+++ b/test/views/CertificateDeclarationSaoViewSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.inject.Injector
+import play.api.data.Form
+import models.{NormalMode, CheckMode, Mode}
+import pages.CertificateDeclarationSaoPage
+import forms.CertificateDeclarationSaoFormProvider
+import views.html.CertificateDeclarationSaoView
+import views.CertificateDeclarationSaoViewSpec.*
+
+
+class CertificateDeclarationSaoViewSpec extends ViewSpecBase[CertificateDeclarationSaoView] {
+
+  private val formProvider = app.injector.instanceOf[CertificateDeclarationSaoFormProvider]
+  private val form: Form[String] = formProvider()
+
+  private def generateView(form: Form[String], mode: Mode): Document = {
+    val view = SUT(form, mode)
+    Jsoup.parse(view.toString)
+  }
+
+  "CertificateDeclarationSaoView" - {
+
+    Mode.values.foreach { mode =>
+      s"when using $mode" - {
+        "when the form is not filled in" - {
+          val doc = generateView(form, mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = false
+          )
+
+          doc.createTestsWithASingleTextInput(
+            name = "value",
+            label = pageHeading,
+            value = "",
+            hint = None,
+            hasError = false
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateDeclarationSaoController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = false
+          )
+        }
+
+        "when the form is filled in" - {
+          val doc = generateView(form.bind(Map("value" -> testInputValue)), mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = false
+          )
+
+          doc.createTestsWithASingleTextInput(
+            name = "value",
+            label = pageHeading,
+            value = testInputValue,
+            hint = None,
+            hasError = false
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateDeclarationSaoController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = false
+          )
+        }
+
+        "when the form has errors" - {
+          val doc = generateView(form.withError("value", "broken"), mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = true
+          )
+
+          doc.createTestsWithASingleTextInput(
+            name = "value",
+            label = pageHeading,
+            value = "",
+            hint = None,
+            hasError = true
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateDeclarationSaoController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = true
+          )
+        }
+      }
+    }
+  }
+}
+
+object CertificateDeclarationSaoViewSpec {
+  val pageHeading = "certificateDeclarationSao"
+  val pageTitle = "certificateDeclarationSao"
+  val testInputValue = "myTestInputValue"
+}

--- a/test/views/CertificateDeclarationSaoViewSpec.scala
+++ b/test/views/CertificateDeclarationSaoViewSpec.scala
@@ -17,20 +17,17 @@
 package views
 
 import base.ViewSpecBase
+import forms.CertificateDeclarationSaoFormProvider
+import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.inject.Injector
 import play.api.data.Form
-import models.{NormalMode, CheckMode, Mode}
-import pages.CertificateDeclarationSaoPage
-import forms.CertificateDeclarationSaoFormProvider
-import views.html.CertificateDeclarationSaoView
 import views.CertificateDeclarationSaoViewSpec.*
-
+import views.html.CertificateDeclarationSaoView
 
 class CertificateDeclarationSaoViewSpec extends ViewSpecBase[CertificateDeclarationSaoView] {
 
-  private val formProvider = app.injector.instanceOf[CertificateDeclarationSaoFormProvider]
+  private val formProvider       = app.injector.instanceOf[CertificateDeclarationSaoFormProvider]
   private val form: Form[String] = formProvider()
 
   private def generateView(form: Form[String], mode: Mode): Document = {
@@ -134,7 +131,7 @@ class CertificateDeclarationSaoViewSpec extends ViewSpecBase[CertificateDeclarat
 }
 
 object CertificateDeclarationSaoViewSpec {
-  val pageHeading = "certificateDeclarationSao"
-  val pageTitle = "certificateDeclarationSao"
+  val pageHeading    = "certificateDeclarationSao"
+  val pageTitle      = "certificateDeclarationSao"
   val testInputValue = "myTestInputValue"
 }

--- a/test/views/CertificateWhoIsSubmittingViewSpec.scala
+++ b/test/views/CertificateWhoIsSubmittingViewSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.inject.Injector
+import play.api.data.Form
+import forms.CertificateWhoIsSubmittingFormProvider
+import models.CertificateWhoIsSubmitting
+import models.{NormalMode, CheckMode, Mode}
+import pages.CertificateWhoIsSubmittingPage
+import views.html.CertificateWhoIsSubmittingView
+import views.CertificateWhoIsSubmittingViewSpec.*
+
+
+class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSubmittingView] {
+
+  private val formProvider = app.injector.instanceOf[CertificateWhoIsSubmittingFormProvider]
+  private val form: Form[CertificateWhoIsSubmitting] = formProvider()
+
+  private def generateView(form: Form[CertificateWhoIsSubmitting], mode: Mode): Document = {
+    val view = SUT(form, mode)
+    Jsoup.parse(view.toString)
+  }
+
+  "CertificateWhoIsSubmittingView" - {
+
+    Mode.values.foreach { mode =>
+      s"when using $mode" - {
+        "when the form is not filled in" - {
+          val doc = generateView(form, mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = false
+          )
+
+          doc.createTestsWithRadioButtons(
+            name = "value",
+            radios = List(
+              radio(value = option1key, label = option1Label),
+              radio(value = option2key, label = option2Label),
+            ),
+            isChecked = None,
+            hasError = false
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateWhoIsSubmittingController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = false
+          )
+        }
+
+        "when the form is filled in" - {
+          val doc = generateView(form.bind(Map("value" -> option1key)), mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = false
+          )
+
+          doc.createTestsWithRadioButtons(
+            name = "value",
+            radios = List(
+              radio(value = option1key, label = option1Label),
+              radio(value = option2key, label = option2Label),
+            ),
+            isChecked = Some(radio(value = option1key, label = option1Label)),
+            hasError = false
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateWhoIsSubmittingController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = false
+          )
+        }
+
+        "when the form has errors" - {
+          val doc = generateView(form.withError("value", "broken"), mode)
+
+          doc.createTestsWithStandardPageElements(
+            pageTitle = pageTitle,
+            pageHeading = pageHeading,
+            showBackLink = true,
+            showIsThisPageNotWorkingProperlyLink = true,
+            hasError = true
+          )
+
+          doc.createTestsWithRadioButtons(
+            name = "value",
+            radios = List(
+              radio(value = option1key, label = option1Label),
+              radio(value = option2key, label = option2Label),
+            ),
+            isChecked = None,
+            hasError = true
+          )
+
+          doc.createTestsWithSubmissionButton(
+            action = controllers.routes.CertificateWhoIsSubmittingController.onSubmit(mode),
+            buttonText = "Continue"
+          )
+
+          doc.createTestsWithOrWithoutError(
+            hasError = true
+          )
+        }
+      }
+    }
+
+  }
+}
+
+object CertificateWhoIsSubmittingViewSpec {
+  val pageHeading = "certificateWhoIsSubmitting"
+  val pageTitle = "certificateWhoIsSubmitting"
+  val option1key = "sao"
+  val option1Label = "Option 1"
+  val option2key = "standIn"
+  val option2Label = "Option 2"
+}

--- a/test/views/CertificateWhoIsSubmittingViewSpec.scala
+++ b/test/views/CertificateWhoIsSubmittingViewSpec.scala
@@ -17,21 +17,18 @@
 package views
 
 import base.ViewSpecBase
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import play.api.inject.Injector
-import play.api.data.Form
 import forms.CertificateWhoIsSubmittingFormProvider
 import models.CertificateWhoIsSubmitting
-import models.{NormalMode, CheckMode, Mode}
-import pages.CertificateWhoIsSubmittingPage
-import views.html.CertificateWhoIsSubmittingView
+import models.Mode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.data.Form
 import views.CertificateWhoIsSubmittingViewSpec.*
-
+import views.html.CertificateWhoIsSubmittingView
 
 class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSubmittingView] {
 
-  private val formProvider = app.injector.instanceOf[CertificateWhoIsSubmittingFormProvider]
+  private val formProvider                           = app.injector.instanceOf[CertificateWhoIsSubmittingFormProvider]
   private val form: Form[CertificateWhoIsSubmitting] = formProvider()
 
   private def generateView(form: Form[CertificateWhoIsSubmitting], mode: Mode): Document = {
@@ -58,7 +55,7 @@ class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSu
             name = "value",
             radios = List(
               radio(value = option1key, label = option1Label),
-              radio(value = option2key, label = option2Label),
+              radio(value = option2key, label = option2Label)
             ),
             isChecked = None,
             hasError = false
@@ -89,7 +86,7 @@ class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSu
             name = "value",
             radios = List(
               radio(value = option1key, label = option1Label),
-              radio(value = option2key, label = option2Label),
+              radio(value = option2key, label = option2Label)
             ),
             isChecked = Some(radio(value = option1key, label = option1Label)),
             hasError = false
@@ -120,7 +117,7 @@ class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSu
             name = "value",
             radios = List(
               radio(value = option1key, label = option1Label),
-              radio(value = option2key, label = option2Label),
+              radio(value = option2key, label = option2Label)
             ),
             isChecked = None,
             hasError = true
@@ -142,10 +139,10 @@ class CertificateWhoIsSubmittingViewSpec extends ViewSpecBase[CertificateWhoIsSu
 }
 
 object CertificateWhoIsSubmittingViewSpec {
-  val pageHeading = "certificateWhoIsSubmitting"
-  val pageTitle = "certificateWhoIsSubmitting"
-  val option1key = "sao"
+  val pageHeading  = "certificateWhoIsSubmitting"
+  val pageTitle    = "certificateWhoIsSubmitting"
+  val option1key   = "sao"
   val option1Label = "Option 1"
-  val option2key = "standIn"
+  val option2key   = "standIn"
   val option2Label = "Option 2"
 }


### PR DESCRIPTION
## List the changes made in comparison to main:
* New pages have been scaffolded to complete the certificate flow
* Navigation is still outstanding

## Jira ticket(s):
* [SAOD-820](https://jira.tools.tax.service.gov.uk/browse/SAOD-820)

## Checklist
* [x] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [ ] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below

<!-- Message of single commit: -->

scaffold remaining pages