### PR TITLE
Navigation for certificate flow

### DIFF
--- a/app/controllers/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/CertificateCheckYourAnswersController.scala
@@ -21,8 +21,11 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateCheckYourAnswersView
+import pages.CertificateCheckYourAnswersPage
 
 import javax.inject.Inject
+import navigation.Navigator
+import models.NormalMode
 
 class CertificateCheckYourAnswersController @Inject() (
     override val messagesApi: MessagesApi,
@@ -30,11 +33,16 @@ class CertificateCheckYourAnswersController @Inject() (
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
+    navigator: Navigator,
     view: CertificateCheckYourAnswersView
 ) extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     Ok(view())
+  }
+
+  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Redirect(navigator.nextPage(CertificateCheckYourAnswersPage, NormalMode, request.userAnswers))
   }
 }

--- a/app/controllers/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/CertificateCheckYourAnswersController.scala
@@ -17,15 +17,15 @@
 package controllers
 
 import controllers.actions.*
+import models.NormalMode
+import navigation.Navigator
+import pages.CertificateCheckYourAnswersPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateCheckYourAnswersView
-import pages.CertificateCheckYourAnswersPage
 
 import javax.inject.Inject
-import navigation.Navigator
-import models.NormalMode
 
 class CertificateCheckYourAnswersController @Inject() (
     override val messagesApi: MessagesApi,

--- a/app/controllers/CertificateConfirmationController.scala
+++ b/app/controllers/CertificateConfirmationController.scala
@@ -17,15 +17,15 @@
 package controllers
 
 import controllers.actions.*
+import models.NormalMode
+import navigation.Navigator
+import pages.CertificateConfirmationPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateConfirmationView
 
 import javax.inject.Inject
-import navigation.Navigator
-import models.NormalMode
-import pages.CertificateConfirmationPage
 
 class CertificateConfirmationController @Inject() (
     override val messagesApi: MessagesApi,

--- a/app/controllers/CertificateConfirmationController.scala
+++ b/app/controllers/CertificateConfirmationController.scala
@@ -23,6 +23,9 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateConfirmationView
 
 import javax.inject.Inject
+import navigation.Navigator
+import models.NormalMode
+import pages.CertificateConfirmationPage
 
 class CertificateConfirmationController @Inject() (
     override val messagesApi: MessagesApi,
@@ -30,11 +33,16 @@ class CertificateConfirmationController @Inject() (
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
-    view: CertificateConfirmationView
+    view: CertificateConfirmationView,
+    navigator: Navigator
 ) extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     Ok(view())
+  }
+
+  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Redirect(navigator.nextPage(CertificateConfirmationPage, NormalMode, request.userAnswers))
   }
 }

--- a/app/controllers/CertificateReviewQualifiedController.scala
+++ b/app/controllers/CertificateReviewQualifiedController.scala
@@ -23,10 +23,14 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateReviewQualifiedView
 
 import javax.inject.Inject
+import navigation.Navigator
+import pages.CertificateReviewQualifiedPage
+import models.NormalMode
 
 class CertificateReviewQualifiedController @Inject() (
     override val messagesApi: MessagesApi,
     identify: IdentifierAction,
+    navigator: Navigator,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
@@ -36,5 +40,9 @@ class CertificateReviewQualifiedController @Inject() (
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     Ok(view())
+  }
+
+  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Redirect(navigator.nextPage(CertificateReviewQualifiedPage, NormalMode, request.userAnswers))
   }
 }

--- a/app/controllers/CertificateReviewQualifiedController.scala
+++ b/app/controllers/CertificateReviewQualifiedController.scala
@@ -17,15 +17,15 @@
 package controllers
 
 import controllers.actions.*
+import models.NormalMode
+import navigation.Navigator
+import pages.CertificateReviewQualifiedPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateReviewQualifiedView
 
 import javax.inject.Inject
-import navigation.Navigator
-import pages.CertificateReviewQualifiedPage
-import models.NormalMode
 
 class CertificateReviewQualifiedController @Inject() (
     override val messagesApi: MessagesApi,

--- a/app/controllers/CertificateReviewUnqualifiedController.scala
+++ b/app/controllers/CertificateReviewUnqualifiedController.scala
@@ -23,6 +23,9 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateReviewUnqualifiedView
 
 import javax.inject.Inject
+import navigation.Navigator
+import pages.CertificateReviewUnqualifiedPage
+import models.NormalMode
 
 class CertificateReviewUnqualifiedController @Inject() (
     override val messagesApi: MessagesApi,
@@ -30,11 +33,16 @@ class CertificateReviewUnqualifiedController @Inject() (
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
-    view: CertificateReviewUnqualifiedView
+    view: CertificateReviewUnqualifiedView,
+    navigator: Navigator
 ) extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     Ok(view())
+  }
+
+  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Redirect(navigator.nextPage(CertificateReviewUnqualifiedPage, NormalMode, request.userAnswers))
   }
 }

--- a/app/controllers/CertificateReviewUnqualifiedController.scala
+++ b/app/controllers/CertificateReviewUnqualifiedController.scala
@@ -17,15 +17,15 @@
 package controllers
 
 import controllers.actions.*
+import models.NormalMode
+import navigation.Navigator
+import pages.CertificateReviewUnqualifiedPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.CertificateReviewUnqualifiedView
 
 import javax.inject.Inject
-import navigation.Navigator
-import pages.CertificateReviewUnqualifiedPage
-import models.NormalMode
 
 class CertificateReviewUnqualifiedController @Inject() (
     override val messagesApi: MessagesApi,

--- a/app/models/CertificateWhoIsSubmitting.scala
+++ b/app/models/CertificateWhoIsSubmitting.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
 enum CertificateWhoIsSubmitting(override val toString: String) {
   case Sao     extends CertificateWhoIsSubmitting("sao")
-  case Standin extends CertificateWhoIsSubmitting("standIn")
+  case StandIn extends CertificateWhoIsSubmitting("standIn")
 }
 
 object CertificateWhoIsSubmitting extends Enumerable.Implicits[CertificateWhoIsSubmitting] {

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -105,6 +105,21 @@ class Navigator @Inject() () {
       _ => routes.CertificateReviewUnqualifiedController.onPageLoad()
     case CertificateReviewUnqualifiedPage =>
       _ => routes.CertificateTaskListController.onPageLoad()
+    case CertificateAdditionalInformationPage =>
+      _ => routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode)
+    case CertificateWhoIsSubmittingPage =>
+      userAnswers =>
+        userAnswers.get(CertificateWhoIsSubmittingPage) match {
+          case Some(CertificateWhoIsSubmitting.Sao) =>
+            routes.CertificateDeclarationSaoController.onPageLoad(NormalMode)
+          case Some(CertificateWhoIsSubmitting.StandIn) =>
+            routes.CertificateDeclarationStandInController.onPageLoad(NormalMode)
+          case _ => ???
+        }
+    case CertificateDeclarationSaoPage | CertificateDeclarationStandInPage =>
+      _ => routes.CertificateCheckYourAnswersController.onPageLoad()
+    case CertificateSubmittedPage =>
+      _ => routes.CertificateTaskListController.onPageLoad()
     case _ =>
       _ => ???
   }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -96,6 +96,15 @@ class Navigator @Inject() () {
               routes.NotificationUploadFormController.onPageLoad()
             case _ => routes.SubmitNotificationStartController.onPageLoad()
           }
+    // certificate flow
+    case CertificateSaoFullNamePage =>
+      _ => routes.CertificateSaoEmailController.onPageLoad(NormalMode)
+    case CertificateSaoEmailPage =>
+      _ => routes.CertificateTaskListController.onPageLoad()
+    case CertificateReviewQualifiedPage =>
+      _ => routes.CertificateReviewUnqualifiedController.onPageLoad()
+    case CertificateReviewUnqualifiedPage =>
+      _ => routes.CertificateTaskListController.onPageLoad()
     case _ =>
       _ => ???
   }

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -118,7 +118,9 @@ class Navigator @Inject() () {
         }
     case CertificateDeclarationSaoPage | CertificateDeclarationStandInPage =>
       _ => routes.CertificateCheckYourAnswersController.onPageLoad()
-    case CertificateSubmittedPage =>
+    case CertificateCheckYourAnswersPage =>
+      _ => routes.CertificateConfirmationController.onPageLoad()
+    case CertificateConfirmationPage =>
       _ => routes.CertificateTaskListController.onPageLoad()
     case _ =>
       _ => ???

--- a/app/pages/CertificateCheckYourAnswersPage.scala
+++ b/app/pages/CertificateCheckYourAnswersPage.scala
@@ -1,5 +1,5 @@
-@*
- * Copyright 2026 HM Revenue & Customs
+/*
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,22 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this(
-    layout: templates.Layout,
-    govukButton: GovukButton,
-    formHelper: FormWithCSRF
-)
+package pages
 
-@()(using request: Request[?], messages: Messages)
-
-@layout(pageTitle = titleNoForm(messages("certificateReviewUnqualified.title"))) {
-
-    <h1 class="govuk-heading-xl">@messages("certificateReviewUnqualified.heading")</h1>
-    @formHelper(action = routes.CertificateReviewUnqualifiedController.onSubmit()) {
-        @govukButton(
-            ButtonViewModel(messages("site.continue").toText)
-        )
-    }
-}
+case object CertificateCheckYourAnswersPage extends Page

--- a/app/pages/CertificateConfirmationPage.scala
+++ b/app/pages/CertificateConfirmationPage.scala
@@ -1,5 +1,5 @@
-@*
- * Copyright 2026 HM Revenue & Customs
+/*
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,22 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this(
-    layout: templates.Layout,
-    govukButton: GovukButton,
-    formHelper: FormWithCSRF
-)
+package pages
 
-@()(using request: Request[?], messages: Messages)
-
-@layout(pageTitle = titleNoForm(messages("certificateReviewUnqualified.title"))) {
-
-    <h1 class="govuk-heading-xl">@messages("certificateReviewUnqualified.heading")</h1>
-    @formHelper(action = routes.CertificateReviewUnqualifiedController.onSubmit()) {
-        @govukButton(
-            ButtonViewModel(messages("site.continue").toText)
-        )
-    }
-}
+case object CertificateConfirmationPage extends Page

--- a/app/pages/CertificateSubmittedPage.scala
+++ b/app/pages/CertificateSubmittedPage.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+case object CertificateSubmittedPage extends Page

--- a/app/views/CertificateCheckYourAnswersView.scala.html
+++ b/app/views/CertificateCheckYourAnswersView.scala.html
@@ -15,8 +15,9 @@
  *@
 
 @this(
-        layout: templates.Layout,
-        govukButton: GovukButton
+    layout: templates.Layout,
+    govukButton: GovukButton,
+    formHelper: FormWithCSRF
 )
 
 @()(using request: Request[?], messages: Messages)
@@ -24,4 +25,9 @@
 @layout(pageTitle = titleNoForm(messages("certificateCheckYourAnswers.title"))) {
 
     <h1 class="govuk-heading-xl">@messages("certificateCheckYourAnswers.heading")</h1>
+    @formHelper(action = routes.CertificateCheckYourAnswersController.onSubmit()) {
+        @govukButton(
+            ButtonViewModel(messages("site.continue").toText)
+        )
+    }
 }

--- a/app/views/CertificateConfirmationView.scala.html
+++ b/app/views/CertificateConfirmationView.scala.html
@@ -15,8 +15,9 @@
  *@
 
 @this(
-        layout: templates.Layout,
-        govukButton: GovukButton
+    layout: templates.Layout,
+    govukButton: GovukButton,
+    formHelper: FormWithCSRF
 )
 
 @()(using request: Request[?], messages: Messages)
@@ -24,4 +25,9 @@
 @layout(pageTitle = titleNoForm(messages("certificateConfirmation.title"))) {
 
     <h1 class="govuk-heading-xl">@messages("certificateConfirmation.heading")</h1>
+    @formHelper(action = routes.CertificateConfirmationController.onSubmit()) {
+        @govukButton(
+            ButtonViewModel(messages("site.continue").toText)
+        )
+    }
 }

--- a/app/views/CertificateReviewQualifiedView.scala.html
+++ b/app/views/CertificateReviewQualifiedView.scala.html
@@ -15,8 +15,9 @@
  *@
 
 @this(
-        layout: templates.Layout,
-        govukButton: GovukButton
+    layout: templates.Layout,
+    govukButton: GovukButton,
+    formHelper: FormWithCSRF
 )
 
 @()(using request: Request[?], messages: Messages)
@@ -24,4 +25,9 @@
 @layout(pageTitle = titleNoForm(messages("certificateReviewQualified.title"))) {
 
     <h1 class="govuk-heading-xl">@messages("certificateReviewQualified.heading")</h1>
+    @formHelper(action = routes.CertificateReviewQualifiedController.onSubmit()) {
+        @govukButton(
+            ButtonViewModel(messages("site.continue").toText)
+        )
+    }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -129,8 +129,10 @@ GET        /changeCertificateAdditionalInformation                  controllers.
 POST       /changeCertificateAdditionalInformation                  controllers.CertificateAdditionalInformationController.onSubmit(mode: Mode = CheckMode)
 
 GET        /certificateReviewQualified                       controllers.CertificateReviewQualifiedController.onPageLoad()
+POST        /certificateReviewQualified                       controllers.CertificateReviewQualifiedController.onSubmit()
 
 GET        /certificateReviewUnqualified                       controllers.CertificateReviewUnqualifiedController.onPageLoad()
+POST        /certificateReviewUnqualified                       controllers.CertificateReviewUnqualifiedController.onSubmit()
 
 GET        /certificateSaoEmail                        controllers.CertificateSaoEmailController.onPageLoad(mode: Mode = NormalMode)
 POST       /certificateSaoEmail                        controllers.CertificateSaoEmailController.onSubmit(mode: Mode = NormalMode)
@@ -158,8 +160,10 @@ GET        /changeCertificateWhoIsSubmitting                  controllers.Certif
 POST       /changeCertificateWhoIsSubmitting                  controllers.CertificateWhoIsSubmittingController.onSubmit(mode: Mode = CheckMode)
 
 GET        /certificateCheckYourAnswers                       controllers.CertificateCheckYourAnswersController.onPageLoad()
+POST        /certificateCheckYourAnswers                       controllers.CertificateCheckYourAnswersController.onSubmit()
 
 GET        /certificateConfirmation                       controllers.CertificateConfirmationController.onPageLoad()
+POST        /certificateConfirmation                       controllers.CertificateConfirmationController.onSubmit()
 
 GET        /certificateDeclarationSao                        controllers.CertificateDeclarationSaoController.onPageLoad(mode: Mode = NormalMode)
 POST       /certificateDeclarationSao                        controllers.CertificateDeclarationSaoController.onSubmit(mode: Mode = NormalMode)

--- a/test/controllers/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CertificateCheckYourAnswersControllerSpec.scala
@@ -17,11 +17,17 @@
 package controllers
 
 import base.SpecBase
+import navigation.FakeNavigator
+import navigation.Navigator
+import play.api.inject.bind
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.CertificateCheckYourAnswersView
 
 class CertificateCheckYourAnswersControllerSpec extends SpecBase {
+
+  def onwardRoute: Call = Call("GET", "/foo")
 
   "CertificateCheckYourAnswers Controller" - {
 
@@ -38,6 +44,26 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page for a POST" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, routes.CertificateCheckYourAnswersController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
       }
     }
   }

--- a/test/controllers/CertificateConfirmationControllerSpec.scala
+++ b/test/controllers/CertificateConfirmationControllerSpec.scala
@@ -17,11 +17,17 @@
 package controllers
 
 import base.SpecBase
+import navigation.FakeNavigator
+import navigation.Navigator
+import play.api.inject.bind
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.CertificateConfirmationView
 
 class CertificateConfirmationControllerSpec extends SpecBase {
+
+  def onwardRoute: Call = Call("GET", "/foo")
 
   "CertificateConfirmation Controller" - {
 
@@ -38,6 +44,26 @@ class CertificateConfirmationControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page for a POST" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, routes.CertificateConfirmationController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
       }
     }
   }

--- a/test/controllers/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/CertificateDeclarationSaoControllerSpec.scala
@@ -24,6 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.CertificateDeclarationSaoPage
+import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -32,7 +33,6 @@ import repositories.SessionRepository
 import views.html.CertificateDeclarationSaoView
 
 import scala.concurrent.Future
-import play.api.data.Form
 
 class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar {
 

--- a/test/controllers/CertificateReviewQualifiedControllerSpec.scala
+++ b/test/controllers/CertificateReviewQualifiedControllerSpec.scala
@@ -17,11 +17,17 @@
 package controllers
 
 import base.SpecBase
+import navigation.FakeNavigator
+import navigation.Navigator
+import play.api.inject.bind
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.CertificateReviewQualifiedView
 
 class CertificateReviewQualifiedControllerSpec extends SpecBase {
+
+  def onwardRoute: Call = Call("GET", "/foo")
 
   "CertificateReviewQualified Controller" - {
 
@@ -38,6 +44,26 @@ class CertificateReviewQualifiedControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page for a POST" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, routes.CertificateReviewQualifiedController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
       }
     }
   }

--- a/test/controllers/CertificateReviewUnqualifiedControllerSpec.scala
+++ b/test/controllers/CertificateReviewUnqualifiedControllerSpec.scala
@@ -17,11 +17,17 @@
 package controllers
 
 import base.SpecBase
+import navigation.FakeNavigator
+import navigation.Navigator
+import play.api.inject.bind
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.CertificateReviewUnqualifiedView
 
 class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
+
+  def onwardRoute: Call = Call("GET", "/foo")
 
   "CertificateReviewUnqualified Controller" - {
 
@@ -38,6 +44,26 @@ class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view()(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page for a POST" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, routes.CertificateReviewUnqualifiedController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
       }
     }
   }

--- a/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/CertificateWhoIsSubmittingControllerSpec.scala
@@ -24,6 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.CertificateWhoIsSubmittingPage
+import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
@@ -32,7 +33,6 @@ import repositories.SessionRepository
 import views.html.CertificateWhoIsSubmittingView
 
 import scala.concurrent.Future
-import play.api.data.Form
 
 class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSugar {
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -18,8 +18,8 @@ package navigation
 
 import base.SpecBase
 import controllers.routes
-import models.upload.UploadTemplateTableData
 import models.*
+import models.upload.UploadTemplateTableData
 import pages.*
 
 import java.time.LocalDate

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -308,6 +308,60 @@ class NavigatorSpec extends SpecBase {
           UserAnswers("id")
         ) mustBe routes.JourneyRecoveryController.onPageLoad()
       }
+
+      // certificate flow
+
+      "when on CertificateSaoFullName, must go to CertificateSaoEmail page" in {
+        navigator.nextPage(
+          CertificateSaoFullNamePage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateSaoEmailController.onPageLoad(NormalMode)
+      }
+
+      "when on CertificateSaoEmail, must go to CertificateTaskList page" in {
+        navigator.nextPage(
+          CertificateSaoEmailPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateTaskListController.onPageLoad()
+      }
+
+      "when on CertificateReviewQualified, must go to CertificateReviewUnqualified page" in {
+        navigator.nextPage(
+          CertificateReviewQualifiedPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateReviewUnqualifiedController.onPageLoad()
+      }
+
+      "when on CertificateReviewUnqualified, must go to CertificateTaskList page" in {
+        navigator.nextPage(
+          CertificateReviewUnqualifiedPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateTaskListController.onPageLoad()
+      }
+
+      // TODO: additional info to who is submitting
+
+      // "when on CertificateAdditionalInformation, must go to CertificateWhoIsSubmitting page" in {
+      //   navigator.nextPage(
+      //     CertificateAdditionalInformationPage,
+      //     NormalMode,
+      //     UserAnswers("id")
+      //   ) mustBe routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode)
+      // }
+
+      // TODO: who is submitting -> confirm sao
+      // TODO: who is submitting -> confirm stand in
+
+      // TODO: confirm sao -> check answers
+      // TODO: confirm stand in -> check answers
+
+      // TODO: check answers -> certificate submitted
+
+      // TODO: certificate submitted -> task list
     }
 
     "in Check mode" - {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -19,7 +19,7 @@ package navigation
 import base.SpecBase
 import controllers.routes
 import models.upload.UploadTemplateTableData
-import models.{CheckMode, NormalMode, UserAnswers}
+import models.*
 import pages.*
 
 import java.time.LocalDate
@@ -343,25 +343,53 @@ class NavigatorSpec extends SpecBase {
         ) mustBe routes.CertificateTaskListController.onPageLoad()
       }
 
-      // TODO: additional info to who is submitting
+      "when on CertificateAdditionalInformation, must go to CertificateWhoIsSubmitting page" in {
+        navigator.nextPage(
+          CertificateAdditionalInformationPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode)
+      }
 
-      // "when on CertificateAdditionalInformation, must go to CertificateWhoIsSubmitting page" in {
-      //   navigator.nextPage(
-      //     CertificateAdditionalInformationPage,
-      //     NormalMode,
-      //     UserAnswers("id")
-      //   ) mustBe routes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode)
-      // }
+      "when on CertificateWhoIsSubmitting, must go to CertificateDeclarationSao page" in {
+        navigator.nextPage(
+          CertificateWhoIsSubmittingPage,
+          NormalMode,
+          UserAnswers("id").set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.Sao).get
+        ) mustBe routes.CertificateDeclarationSaoController.onPageLoad(NormalMode)
+      }
 
-      // TODO: who is submitting -> confirm sao
-      // TODO: who is submitting -> confirm stand in
+      "when on CertificateWhoIsSubmitting, must go to CertificateDeclarationStandIn page" in {
+        navigator.nextPage(
+          CertificateWhoIsSubmittingPage,
+          NormalMode,
+          UserAnswers("id").set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.StandIn).get
+        ) mustBe routes.CertificateDeclarationStandInController.onPageLoad(NormalMode)
+      }
 
-      // TODO: confirm sao -> check answers
-      // TODO: confirm stand in -> check answers
+      "when on CertificateDeclarationSao, must go to CertificateCheckYourAnswers page" in {
+        navigator.nextPage(
+          CertificateDeclarationSaoPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateCheckYourAnswersController.onPageLoad()
+      }
 
-      // TODO: check answers -> certificate submitted
+      "when on CertificateDeclarationStandIn, must go to CertificateCheckYourAnswers page" in {
+        navigator.nextPage(
+          CertificateDeclarationStandInPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateCheckYourAnswersController.onPageLoad()
+      }
 
-      // TODO: certificate submitted -> task list
+      "when on CertificateSubmitted, must go to CertificateTaskList page" in {
+        navigator.nextPage(
+          CertificateSubmittedPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateTaskListController.onPageLoad()
+      }
     }
 
     "in Check mode" - {

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -383,9 +383,17 @@ class NavigatorSpec extends SpecBase {
         ) mustBe routes.CertificateCheckYourAnswersController.onPageLoad()
       }
 
-      "when on CertificateSubmitted, must go to CertificateTaskList page" in {
+      "when on CertificateCheckYourAnswers, must go to CertificateConfirmation page" in {
         navigator.nextPage(
-          CertificateSubmittedPage,
+          CertificateCheckYourAnswersPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.CertificateConfirmationController.onPageLoad()
+      }
+
+      "when on CertificateConfirmation, must go to CertificateTaskList page" in {
+        navigator.nextPage(
+          CertificateConfirmationPage,
           NormalMode,
           UserAnswers("id")
         ) mustBe routes.CertificateTaskListController.onPageLoad()

--- a/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateWhoIsSubmittingSummarySpec.scala
@@ -55,7 +55,7 @@ class CertificateWhoIsSubmittingSummarySpec extends SpecBase with GuiceOneAppPer
         }
 
         "must show 'Option2' when user answers is standIn" in {
-          SUT(answer = CertificateWhoIsSubmitting.Standin).value.content mustBe HtmlContent("Option 2")
+          SUT(answer = CertificateWhoIsSubmitting.StandIn).value.content mustBe HtmlContent("Option 2")
         }
       }
 


### PR DESCRIPTION
## List the changes made in comparison to main:
* adds navigation for the certificate flow
* does not provide a journey to the beginning of the certificate flow

## Jira ticket(s):
* [SAOD-820](https://jira.tools.tax.service.gov.uk/browse/SAOD-820)

## Checklist
* [x] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below