### PR TITLE
Update error messages for second sao end date

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -345,10 +345,10 @@ notificationMoreSaoSecondEndDate.caption = Submit a notification
 notificationMoreSaoSecondEndDate.heading = When did {0} stop being the SAO?
 notificationMoreSaoSecondEndDate.hint = For example 01 6 2024
 notificationMoreSaoSecondEndDate.checkYourAnswersLabel = NotificationMoreSaoSecondEndDate
-notificationMoreSaoSecondEndDate.error.required.all = Enter the notificationMoreSaoSecondEndDate
-notificationMoreSaoSecondEndDate.error.required.two = The notificationMoreSaoSecondEndDate must include {0} and {1}
-notificationMoreSaoSecondEndDate.error.required = The notificationMoreSaoSecondEndDate must include {0}
-notificationMoreSaoSecondEndDate.error.invalid = Enter a real NotificationMoreSaoSecondEndDate
+notificationMoreSaoSecondEndDate.error.required.all = The date must be a real date
+notificationMoreSaoSecondEndDate.error.required.two = The date must include {0} and {1}
+notificationMoreSaoSecondEndDate.error.required = The date must include {0}
+notificationMoreSaoSecondEndDate.error.invalid = Enter the date in the correct format
 notificationMoreSaoSecondEndDate.change.hidden = NotificationMoreSaoSecondEndDate
 
 confirmYourNotification.title = Confirm notification and submit

--- a/test/forms/NotificationMoreSaoSecondEndDateFormProviderSpec.scala
+++ b/test/forms/NotificationMoreSaoSecondEndDateFormProviderSpec.scala
@@ -47,22 +47,22 @@ class NotificationMoreSaoSecondEndDateFormProviderSpec extends DateBehaviours {
   "error message keys must map to the expected text" - {
     createTestWithErrorMessageAssertion(
       key = requiredAllKey,
-      message = "Enter the notificationMoreSaoSecondEndDate"
+      message = "The date must be a real date"
     )
 
     createTestWithErrorMessageAssertion(
       key = requiredTwoKey,
-      message = "The notificationMoreSaoSecondEndDate must include {0} and {1}"
+      message = "The date must include {0} and {1}"
     )
 
     createTestWithErrorMessageAssertion(
       key = requiredKey,
-      message = "The notificationMoreSaoSecondEndDate must include {0}"
+      message = "The date must include {0}"
     )
 
     createTestWithErrorMessageAssertion(
       key = invalidKey,
-      message = "Enter a real NotificationMoreSaoSecondEndDate"
+      message = "Enter the date in the correct format"
     )
   }
 }


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* These changes update the error messages as per the mural board V0.6

## Jira ticket(s):
* [SAOD-735](https://jira.tools.tax.service.gov.uk/browse/SAOD-735)

## Checklist
* [x] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
