### PR TITLE
Saod 788/additional info cert page

### DIFF
--- a/app/controllers/CertificateAdditionalInformationController.scala
+++ b/app/controllers/CertificateAdditionalInformationController.scala
@@ -21,6 +21,7 @@ import forms.CertificateAdditionalInformationFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.CertificateAdditionalInformationPage
+import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
@@ -45,17 +46,20 @@ class CertificateAdditionalInformationController @Inject() (
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
+
+  val form: Form[Option[String]] = formProvider()
+
   def onPageLoad(mode: Mode): Action[AnyContent] =
     (identify andThen getData andThen requireData andThen requireSubmitCertificateStageUnlocked) { implicit request =>
-      val form         = formProvider()
-      val preparedForm = request.userAnswers.get(CertificateAdditionalInformationPage).fold(form)(form.fill)
+      val preparedForm = request.userAnswers
+        .getNullable(CertificateAdditionalInformationPage)
+        .fold(form)(value => form.fill(Some(value)))
       Ok(view(preparedForm, mode))
     }
 
   def onSubmit(mode: Mode): Action[AnyContent] =
     (identify andThen getData andThen requireData andThen requireSubmitCertificateStageUnlocked).async {
       implicit request =>
-        val form = formProvider()
         form
           .bindFromRequest()
           .fold(

--- a/app/controllers/CertificateAdditionalInformationController.scala
+++ b/app/controllers/CertificateAdditionalInformationController.scala
@@ -47,7 +47,7 @@ class CertificateAdditionalInformationController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  val form: Form[Option[String]] = formProvider()
+  inline def form: Form[Option[String]] = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] =
     (identify andThen getData andThen requireData andThen requireSubmitCertificateStageUnlocked) { implicit request =>

--- a/app/forms/CertificateAdditionalInformationFormProvider.scala
+++ b/app/forms/CertificateAdditionalInformationFormProvider.scala
@@ -23,9 +23,14 @@ import javax.inject.Inject
 
 class CertificateAdditionalInformationFormProvider @Inject() extends Mappings {
 
-  def apply(): Form[String] =
+  val maxLength     = 5000
+  val requiredError = "certificateAdditionalInformation.error.required"
+  val lengthError   = "certificateAdditionalInformation.error.length"
+
+  def apply(): Form[Option[String]] =
     Form(
-      "value" -> text("certificateAdditionalInformation.error.required")
-        .verifying(maxLength(100, "certificateAdditionalInformation.error.length"))
+      "value" -> FormHelpers.mandatoryUnlessSkipped(
+        text(errorKey = requiredError).verifying(maxLength(maxLength, lengthError))
+      )
     )
 }

--- a/app/pages/CertificateAdditionalInformationPage.scala
+++ b/app/pages/CertificateAdditionalInformationPage.scala
@@ -18,7 +18,7 @@ package pages
 
 import play.api.libs.json.JsPath
 
-case object CertificateAdditionalInformationPage extends QuestionPage[String] {
+case object CertificateAdditionalInformationPage extends QuestionPage[Option[String]] {
 
   override def path: JsPath = JsPath \ toString
 

--- a/app/viewmodels/checkAnswers/CertificateAdditionalInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/CertificateAdditionalInformationSummary.scala
@@ -26,18 +26,19 @@ import viewmodels.govuk.summarylist.*
 
 object CertificateAdditionalInformationSummary {
 
-  def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(CertificateAdditionalInformationPage).map { answer =>
-      SummaryListRowViewModel(
-        key = messages("certificateAdditionalInformation.checkYourAnswersLabel").toKey,
-        value = ValueViewModel(answer.toText),
-        actions = Seq(
-          ActionItemViewModel(
-            messages("site.change").toText,
-            routes.CertificateAdditionalInformationController.onPageLoad(CheckMode).url
-          )
-            .withVisuallyHiddenText(messages("certificateAdditionalInformation.change.hidden"))
+  def row(answers: UserAnswers)(using messages: Messages): SummaryListRow =
+    val additionalInformation =
+      answers.getNullable(CertificateAdditionalInformationPage).getOrElse("")
+
+    SummaryListRowViewModel(
+      key = messages("certificateAdditionalInformation.checkYourAnswersLabel").toKey,
+      value = ValueViewModel(additionalInformation.toText),
+      actions = Seq(
+        ActionItemViewModel(
+          messages("site.change").toText,
+          routes.CertificateAdditionalInformationController.onPageLoad(CheckMode).url
         )
+          .withVisuallyHiddenText(messages("certificateAdditionalInformation.change.hidden"))
       )
-    }
+    )
 }

--- a/app/views/CertificateAdditionalInformationView.scala.html
+++ b/app/views/CertificateAdditionalInformationView.scala.html
@@ -51,7 +51,7 @@
             TextareaViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("certificateAdditionalInformation.label").toText)
-                    .withCssClass("govuk-label--s")
+                    .withCssClass(LabelSize.Small.toString)
             )
         )
 

--- a/app/views/CertificateAdditionalInformationView.scala.html
+++ b/app/views/CertificateAdditionalInformationView.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import forms.FormHelpers
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukTextarea
 @import viewmodels.InputWidth.*
 
 @this(
@@ -21,6 +23,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
+    govukTextArea: GovukTextarea,
     govukButton: GovukButton
 )
 
@@ -34,16 +37,35 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @govukInput(
-            InputViewModel(
+        <span class="govuk-caption-l">@messages("certificateAdditionalInformation.caption")</span>
+        <h1 class="govuk-heading-l"> @messages("certificateAdditionalInformation.heading")</h1>
+        <p class="govuk-body">@messages("certificateAdditionalInformation.paragraph1")</p>
+        <p class="govuk-body">@messages("certificateAdditionalInformation.paragraph2")</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>@messages("certificateAdditionalInformation.list1.item1")</li>
+            <li>@messages("certificateAdditionalInformation.list1.item2")</li>
+            <li>@messages("certificateAdditionalInformation.list1.item3")</li>
+        </ul>
+
+        @govukTextArea(
+            TextareaViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("certificateAdditionalInformation.heading").toText).asPageHeading(LabelSize.Large)
+                label = LabelViewModel(messages("certificateAdditionalInformation.label").toText)
+                    .withCssClass("govuk-label--s")
             )
-            .withWidth(Full)
         )
 
-        @govukButton(
-            ButtonViewModel(messages("site.continue").toText).withAttribute("id", "submit")
-        )
+        <div class="govuk-button-group">
+            @govukButton(
+                ButtonViewModel(messages("site.continue").toText)
+                    .withAttribute("id", "submit")
+            )
+            @govukButton(
+                ButtonViewModel(messages("site.skip").toText)
+                    .withName(FormHelpers.skipButtonFieldName)
+                    .withCssClass("govuk-button--secondary")
+                    .withAttribute("id", "skip")
+            )
+        </div>
     }
 }

--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -23,7 +23,7 @@ object ViewUtils {
 
   def title(form: Form[?], title: String, section: Option[String] = None)(using messages: Messages): String =
     titleNoForm(
-      title = s"${errorPrefix(form)} ${messages(title)}",
+      title = s"${errorPrefix(form)}${messages(title)}",
       section = section
     )
 
@@ -31,6 +31,6 @@ object ViewUtils {
     s"${messages(title)} - ${section.fold("")(messages(_) + " - ")}${messages("service.name")} - ${messages("site.govuk")}"
 
   def errorPrefix(form: Form[?])(using messages: Messages): String = {
-    if form.hasErrors || form.hasGlobalErrors then messages("error.title.prefix") else ""
+    if form.hasErrors || form.hasGlobalErrors then messages("error.title.prefix") + " " else ""
   }
 }

--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -30,7 +30,7 @@ object ViewUtils {
   def titleNoForm(title: String, section: Option[String] = None)(using messages: Messages): String =
     s"${messages(title)} - ${section.fold("")(messages(_) + " - ")}${messages("service.name")} - ${messages("site.govuk")}"
 
-  def errorPrefix(form: Form[?])(using messages: Messages): String = {
-    if form.hasErrors || form.hasGlobalErrors then messages("error.title.prefix") + " " else ""
+  private def errorPrefix(form: Form[?])(using messages: Messages): String = {
+    if form.hasErrors || form.hasGlobalErrors then s"${messages("error.title.prefix")} " else ""
   }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -366,11 +366,18 @@ certificateReviewQualified.heading = certificateReviewQualified
 certificateReviewUnqualified.title = certificateReviewUnqualified
 certificateReviewUnqualified.heading = certificateReviewUnqualified
 
-certificateAdditionalInformation.title = certificateAdditionalInformation
-certificateAdditionalInformation.heading = certificateAdditionalInformation
-certificateAdditionalInformation.checkYourAnswersLabel = certificateAdditionalInformation
-certificateAdditionalInformation.error.required = Enter certificateAdditionalInformation
-certificateAdditionalInformation.error.length = CertificateAdditionalInformation must be 100 characters or less
+certificateAdditionalInformation.title = Additional information and explanation
+certificateAdditionalInformation.caption = Submit a certificate
+certificateAdditionalInformation.heading = Additional information and explanation
+certificateAdditionalInformation.paragraph1 = Tell us if there’s anything we should know about your certificate or the companies listed.
+certificateAdditionalInformation.paragraph2 = This could include:
+certificateAdditionalInformation.list1.item1 = an explanation of why the SAO provided a qualified certificate
+certificateAdditionalInformation.list1.item2 = a company’s status changing, such as becoming dormant or going into liquidation
+certificateAdditionalInformation.list1.item3 = anything else relevant to the companies listed or SAO
+certificateAdditionalInformation.label = Provide information about your certificate
+certificateAdditionalInformation.checkYourAnswersLabel = Additional Information
+certificateAdditionalInformation.error.required = Enter information about your certificate or skip
+certificateAdditionalInformation.error.length = Additional Information must be 100 characters or less
 certificateAdditionalInformation.change.hidden = CertificateAdditionalInformation
 
 certificateSaoEmail.title = What is the email address for the SAO?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -377,7 +377,7 @@ certificateAdditionalInformation.list1.item3 = anything else relevant to the com
 certificateAdditionalInformation.label = Provide information about your certificate
 certificateAdditionalInformation.checkYourAnswersLabel = Additional Information
 certificateAdditionalInformation.error.required = Enter information about your certificate or skip
-certificateAdditionalInformation.error.length = Additional Information must be 100 characters or less
+certificateAdditionalInformation.error.length = Additional Information must be 5000 characters or less
 certificateAdditionalInformation.change.hidden = CertificateAdditionalInformation
 
 certificateSaoEmail.title = What is the email address for the SAO?

--- a/test/base/ViewSpecBase.scala
+++ b/test/base/ViewSpecBase.scala
@@ -113,6 +113,37 @@ class ViewSpecBase[T <: BaseScalaTemplate[HtmlFormat.Appendable, Format[HtmlForm
           }
         }
 
+    def createTestsWithSubmissionButtons(
+        action: Call,
+        buttonTexts: Seq[String]
+    )(using
+        pos: Position
+    ): Unit = {
+      def target = doc.getMainContent
+      s"must have a form which submits to '${action.method} ${action.url}'" in {
+        val form = target.select("form")
+        form.attr("method") mustBe action.method
+        form.attr("action") mustBe action.url
+        form.size() mustBe 1
+      }
+      s"must have ${buttonTexts.size} number of buttons" in {
+        val buttons = target.select("button")
+
+        buttons.size() mustBe buttonTexts.size
+      }
+      buttonTexts.zipWithIndex
+        .foreach((buttonText, i) => {
+          s"must have a submit button with text '$buttonText'" in {
+            val button = target.select("button").get(i)
+            withClue(
+              s"Submit Button with text '$buttonText' not found\n"
+            ) {
+              button.text() mustBe buttonText
+            }
+          }
+        })
+    }
+
     def createTestWithIsThisPageNotWorkingProperlyLink(using
         pos: Position
     ): Unit =

--- a/test/controllers/CertificateAdditionalInformationControllerSpec.scala
+++ b/test/controllers/CertificateAdditionalInformationControllerSpec.scala
@@ -39,8 +39,8 @@ class CertificateAdditionalInformationControllerSpec extends SpecBase with Mocki
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  val formProvider       = new CertificateAdditionalInformationFormProvider()
-  val form: Form[String] = formProvider()
+  val formProvider               = new CertificateAdditionalInformationFormProvider()
+  val form: Form[Option[String]] = formProvider()
 
   lazy val certificateAdditionalInformationRoute: String =
     routes.CertificateAdditionalInformationController.onPageLoad(NormalMode).url
@@ -66,7 +66,10 @@ class CertificateAdditionalInformationControllerSpec extends SpecBase with Mocki
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers =
-        userAnswersWithCertificateUploadedTemplate.set(CertificateAdditionalInformationPage, "answer").success.value
+        userAnswersWithCertificateUploadedTemplate
+          .set(CertificateAdditionalInformationPage, Some("answer"))
+          .success
+          .value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -78,7 +81,7 @@ class CertificateAdditionalInformationControllerSpec extends SpecBase with Mocki
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(using
+        contentAsString(result) mustEqual view(form.fill(Some("answer")), NormalMode)(using
           request,
           messages(application)
         ).toString

--- a/test/forms/CertificateAdditionalInformationFormProviderSpec.scala
+++ b/test/forms/CertificateAdditionalInformationFormProviderSpec.scala
@@ -54,12 +54,12 @@ class CertificateAdditionalInformationFormProviderSpec extends StringFieldBehavi
   "error message keys must map to the expected text" - {
     createTestWithErrorMessageAssertion(
       key = requiredKey,
-      message = "Enter certificateAdditionalInformation"
+      message = "Enter information about your certificate or skip"
     )
 
     createTestWithErrorMessageAssertion(
       key = lengthKey,
-      message = "CertificateAdditionalInformation must be 100 characters or less"
+      message = "Additional Information must be 100 characters or less"
     )
   }
 }

--- a/test/forms/CertificateAdditionalInformationFormProviderSpec.scala
+++ b/test/forms/CertificateAdditionalInformationFormProviderSpec.scala
@@ -23,7 +23,7 @@ class CertificateAdditionalInformationFormProviderSpec extends StringFieldBehavi
 
   val requiredKey = "certificateAdditionalInformation.error.required"
   val lengthKey   = "certificateAdditionalInformation.error.length"
-  val maxLength   = 100
+  val maxLength   = 5000
 
   val form = new CertificateAdditionalInformationFormProvider()()
 
@@ -59,7 +59,7 @@ class CertificateAdditionalInformationFormProviderSpec extends StringFieldBehavi
 
     createTestWithErrorMessageAssertion(
       key = lengthKey,
-      message = "Additional Information must be 100 characters or less"
+      message = "Additional Information must be 5000 characters or less"
     )
   }
 }

--- a/test/viewmodels/checkAnswers/CertificateAdditionalInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateAdditionalInformationSummarySpec.scala
@@ -44,7 +44,7 @@ class CertificateAdditionalInformationSummarySpec extends SpecBase with GuiceOne
       def SUT(answer: String = "") = CertificateAdditionalInformationSummary.row(testUserAnswers(answer)).get
 
       "must have expected key" in {
-        SUT().key mustBe "certificateAdditionalInformation".toKey
+        SUT().key mustBe "Additional Information".toKey
       }
 
       "expected value" - {

--- a/test/viewmodels/checkAnswers/CertificateAdditionalInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/CertificateAdditionalInformationSummarySpec.scala
@@ -16,16 +16,12 @@
 
 package viewmodels.checkAnswers
 
-import base.SpecBase
 import controllers.routes
 import models.CheckMode
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import pages.CertificateAdditionalInformationPage
-import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
-class CertificateAdditionalInformationSummarySpec extends SpecBase with GuiceOneAppPerSuite {
-  given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
+class CertificateAdditionalInformationSummarySpec extends CheckYourAnswersSummaryRenderingSupport {
 
   "CertificateAdditionalInformationSummary.row" - {
 
@@ -33,15 +29,15 @@ class CertificateAdditionalInformationSummarySpec extends SpecBase with GuiceOne
       "must return None" in {
         def SUT = CertificateAdditionalInformationSummary.row(emptyUserAnswers)
 
-        SUT mustBe None
+        renderSummaryRow(SUT).renderedKeyText mustBe "Additional Information"
       }
     }
 
     "when there is a user answer for CertificateAdditionalInformationPage" - {
       def testUserAnswers(answer: String) =
-        emptyUserAnswers.set(CertificateAdditionalInformationPage, answer).get
+        emptyUserAnswers.set(CertificateAdditionalInformationPage, Some(answer)).get
 
-      def SUT(answer: String = "") = CertificateAdditionalInformationSummary.row(testUserAnswers(answer)).get
+      def SUT(answer: String = "") = CertificateAdditionalInformationSummary.row(testUserAnswers(answer))
 
       "must have expected key" in {
         SUT().key mustBe "Additional Information".toKey

--- a/test/views/CertificateAdditionalInformationViewSpec.scala
+++ b/test/views/CertificateAdditionalInformationViewSpec.scala
@@ -126,6 +126,7 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
 
           doc.createTestsWithLargeCaption(pageCaption)
 
+          doc.createTestMustShowNumberOfTextareas(1)
           doc.createTestMustShowTextarea(
             name = "value",
             label = textAreaLabel,

--- a/test/views/CertificateAdditionalInformationViewSpec.scala
+++ b/test/views/CertificateAdditionalInformationViewSpec.scala
@@ -28,10 +28,10 @@ import views.html.CertificateAdditionalInformationView
 
 class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateAdditionalInformationView] {
 
-  private val formProvider       = app.injector.instanceOf[CertificateAdditionalInformationFormProvider]
-  private val form: Form[String] = formProvider()
+  private val formProvider               = app.injector.instanceOf[CertificateAdditionalInformationFormProvider]
+  private val form: Form[Option[String]] = formProvider()
 
-  private def generateView(form: Form[String], mode: Mode): Document = {
+  private def generateView(form: Form[Option[String]], mode: Mode): Document = {
     val view = SUT(form, mode)
     Jsoup.parse(view.toString)
   }

--- a/test/views/CertificateAdditionalInformationViewSpec.scala
+++ b/test/views/CertificateAdditionalInformationViewSpec.scala
@@ -21,6 +21,7 @@ import forms.CertificateAdditionalInformationFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.scalactic.source.Position
 import play.api.data.Form
 import views.CertificateAdditionalInformationViewSpec.*
 import views.html.CertificateAdditionalInformationView
@@ -50,17 +51,20 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
             hasError = false
           )
 
-          doc.createTestsWithASingleTextInput(
+          doc.createTestMustShowNumberOfTextareas(1)
+          doc.createTestMustShowTextarea(
             name = "value",
-            label = pageHeading,
+            label = textAreaLabel,
             value = "",
             hint = None,
             hasError = false
           )
 
-          doc.createTestsWithSubmissionButton(
+          doc.createTestsWithLargeCaption(pageCaption)
+
+          doc.createTestsWithSubmissionButtons(
             action = controllers.routes.CertificateAdditionalInformationController.onSubmit(mode),
-            buttonText = "Continue"
+            buttonTexts = Seq("Continue", "Skip")
           )
 
           doc.createTestsWithOrWithoutError(
@@ -79,17 +83,29 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
             hasError = false
           )
 
-          doc.createTestsWithASingleTextInput(
+          doc.createTestsWithLargeCaption(pageCaption)
+
+          doc.createTestsWithParagraphs(
+            paragraphs
+          )
+
+          doc.createTestsWithBulletPoints(
+            bulletPoints
+          )
+
+          doc.createTestMustShowNumberOfTextareas(1)
+
+          doc.createTestMustShowTextarea(
             name = "value",
-            label = pageHeading,
+            label = textAreaLabel,
             value = testInputValue,
             hint = None,
             hasError = false
           )
 
-          doc.createTestsWithSubmissionButton(
+          doc.createTestsWithSubmissionButtons(
             action = controllers.routes.CertificateAdditionalInformationController.onSubmit(mode),
-            buttonText = "Continue"
+            buttonTexts = Seq("Continue", "Skip")
           )
 
           doc.createTestsWithOrWithoutError(
@@ -108,17 +124,19 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
             hasError = true
           )
 
-          doc.createTestsWithASingleTextInput(
+          doc.createTestsWithLargeCaption(pageCaption)
+
+          doc.createTestMustShowTextarea(
             name = "value",
-            label = pageHeading,
+            label = textAreaLabel,
             value = "",
             hint = None,
             hasError = true
           )
 
-          doc.createTestsWithSubmissionButton(
+          doc.createTestsWithSubmissionButtons(
             action = controllers.routes.CertificateAdditionalInformationController.onSubmit(mode),
-            buttonText = "Continue"
+            buttonTexts = Seq("Continue", "Skip")
           )
 
           doc.createTestsWithOrWithoutError(
@@ -131,7 +149,18 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
 }
 
 object CertificateAdditionalInformationViewSpec {
-  val pageHeading    = "certificateAdditionalInformation"
-  val pageTitle      = "certificateAdditionalInformation"
-  val testInputValue = "myTestInputValue"
+  val pageCaption             = "Submit a certificate"
+  val pageHeading             = "Additional information and explanation"
+  val pageTitle               = "Additional information and explanation"
+  val testInputValue          = "myTestInputValue"
+  val textAreaLabel           = "Provide information about your certificate"
+  val paragraphs: Seq[String] = Seq(
+    "Tell us if there’s anything we should know about your certificate or the companies listed.",
+    "This could include:"
+  )
+  val bulletPoints: Seq[String] = Seq(
+    "an explanation of why the SAO provided a qualified certificate",
+    "a company’s status changing, such as becoming dormant or going into liquidation",
+    "anything else relevant to the companies listed or SAO"
+  )
 }

--- a/test/views/CertificateAdditionalInformationViewSpec.scala
+++ b/test/views/CertificateAdditionalInformationViewSpec.scala
@@ -62,6 +62,14 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
 
           doc.createTestsWithLargeCaption(pageCaption)
 
+          doc.createTestsWithParagraphs(
+            paragraphs
+          )
+
+          doc.createTestsWithBulletPoints(
+            bulletPoints
+          )
+
           doc.createTestsWithSubmissionButtons(
             action = controllers.routes.CertificateAdditionalInformationController.onSubmit(mode),
             buttonTexts = Seq("Continue", "Skip")
@@ -125,6 +133,14 @@ class CertificateAdditionalInformationViewSpec extends ViewSpecBase[CertificateA
           )
 
           doc.createTestsWithLargeCaption(pageCaption)
+
+          doc.createTestsWithParagraphs(
+            paragraphs
+          )
+
+          doc.createTestsWithBulletPoints(
+            bulletPoints
+          )
 
           doc.createTestMustShowNumberOfTextareas(1)
           doc.createTestMustShowTextarea(

--- a/test/views/NotificationAdditionalInformationViewSpec.scala
+++ b/test/views/NotificationAdditionalInformationViewSpec.scala
@@ -23,7 +23,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalactic.source.Position
 import play.api.data.Form
-import play.api.mvc.Call
 import views.NotificationAdditionalInformationViewSpec.*
 import views.html.NotificationAdditionalInformationView
 
@@ -143,41 +142,6 @@ class NotificationAdditionalInformationViewSpec extends ViewSpecBase[Notificatio
           )
         }
       }
-    }
-  }
-
-  extension (doc: Document) {
-    def createTestsWithSubmissionButtons(
-        action: Call,
-        buttonTexts: Seq[String]
-    )(using
-        pos: Position
-    ): Unit = {
-      def target = doc.getMainContent
-      s"must have a form which submits to '${action.method} ${action.url}'" in {
-        val form = target.select("form")
-        form.attr("method") mustBe action.method
-        form.attr("action") mustBe action.url
-        form.size() mustBe 1
-      }
-
-      s"must have ${buttonTexts.size} number of buttons" in {
-        val buttons = target.select("button")
-
-        buttons.size() mustBe buttonTexts.size
-      }
-
-      buttonTexts.zipWithIndex
-        .foreach((buttonText, i) => {
-          s"must have a submit button with text '$buttonText'" in {
-            val button = target.select("button").get(i)
-            withClue(
-              s"Submit Button with text '$buttonText' not found\n"
-            ) {
-              button.text() mustBe buttonText
-            }
-          }
-        })
     }
   }
 }


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Additional information page for certificate journey 
* Skip logic when no information is entered 

## Jira ticket(s):
* [SAOD-788](https://jira.tools.tax.service.gov.uk/browse/SAOD-788)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
