### PR TITLE
add DSAO test only routes for object-store

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -18,6 +18,7 @@ package config
 
 import controllers.internal.routes
 import play.api.Configuration
+import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -46,6 +47,22 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
   val loginContinueUrl: String = hubBaseUrl
 
   lazy val upscanInitiateV2Url: String = servicesConfig.baseUrl("upscan-initiate") + "/upscan/v2/initiate"
+
+  lazy val internalAuthTestOnlyTokenUrl: String = servicesConfig.baseUrl("internal-auth") + "/test-only/token"
+
+  val internalAuthToken: String = config.get[String]("internal-auth.token")
+
+  val saoObjectStoreInternalAuthTokenRequest: JsObject = Json.obj(
+    "token"       -> internalAuthToken,
+    "principal"   -> "senior-accounting-officer-submission-frontend",
+    "permissions" -> Json.arr(
+      Json.obj(
+        "resourceType"     -> "object-store",
+        "resourceLocation" -> "senior-accounting-officer",
+        "actions"          -> Json.arr("READ", "WRITE")
+      )
+    )
+  )
 
   lazy val upscanCallbackTarget: String =
     s"${servicesConfig.baseUrl("senior-accounting-officer-submission-frontend")}${routes.UploadCallbackController.callback()}"

--- a/app/connectors/InternalAuthTestOnlyConnector.scala
+++ b/app/connectors/InternalAuthTestOnlyConnector.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class InternalAuthTestOnlyConnector @Inject() (
+    httpClient: HttpClientV2,
+    appConfig: AppConfig
+)(using ExecutionContext) {
+
+  def grantSaoObjectStoreAccess()(using HeaderCarrier): Future[HttpResponse] =
+    httpClient
+      .post(url"${appConfig.internalAuthTestOnlyTokenUrl}")
+      .withBody(Json.toJson(appConfig.saoObjectStoreInternalAuthTokenRequest))
+      .execute[HttpResponse]
+}

--- a/app/controllers/testonly/InternalAuthTestOnlyController.scala
+++ b/app/controllers/testonly/InternalAuthTestOnlyController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testonly
+
+import connectors.InternalAuthTestOnlyConnector
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.ExecutionContext
+
+import javax.inject.Inject
+
+class InternalAuthTestOnlyController @Inject() (
+    mcc: MessagesControllerComponents,
+    connector: InternalAuthTestOnlyConnector
+)(using ExecutionContext)
+    extends FrontendController(mcc) {
+
+  def grantSaoObjectStoreAccess(): Action[AnyContent] = Action.async { implicit request =>
+    given hc: uk.gov.hmrc.http.HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    connector.grantSaoObjectStoreAccess().map { response =>
+      Status(response.status)(response.body)
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,7 +49,23 @@ microservice {
       host     = localhost
       port     = 9570
     }
+
+    internal-auth {
+      protocol = http
+      host     = localhost
+      port     = 8470
+    }
+
+    object-store {
+      protocol = http
+      host     = localhost
+      port     = 8464
+    }
   }
+}
+
+internal-auth {
+  token = "1234"
 }
 
 

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -23,3 +23,5 @@ GET         /senior-accounting-officer/submission/test-only/pdf                 
 GET         /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf              controllers.testonly.TestPdfController.openHtml()
 POST        /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf              controllers.testonly.TestPdfController.onSubmit()
 GET         /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf/example      controllers.testonly.TestPdfController.example(rows:Int ?= 10)
+
+POST        /senior-accounting-officer/submission/test-only/internal-auth/object-store        controllers.testonly.InternalAuthTestOnlyController.grantSaoObjectStoreAccess()

--- a/it/test/connectors/InternalAuthTestOnlyConnectorISpec.scala
+++ b/it/test/connectors/InternalAuthTestOnlyConnectorISpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import connectors.InternalAuthTestOnlyConnectorISpec.*
+import play.api.http.HeaderNames
+import play.api.libs.json.Json
+import play.api.test.Helpers.CREATED
+import support.ISpecBase
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+
+class InternalAuthTestOnlyConnectorISpec extends ISpecBase {
+
+  override def additionalConfigs: Map[String, Any] = Map(
+    "microservice.services.internal-auth.port" -> wireMockPort
+  )
+
+  given HeaderCarrier = HeaderCarrier()
+
+  lazy val SUT: InternalAuthTestOnlyConnector = app.injector.instanceOf[InternalAuthTestOnlyConnector]
+
+  "InternalAuthTestOnlyConnector.grantSaoObjectStoreAccess" must {
+    "configure the local internal auth token for SAO object-store access" in {
+      stubFor(
+        post(urlEqualTo("/test-only/token"))
+          .willReturn(aResponse().withStatus(CREATED))
+      )
+
+      val response: HttpResponse = SUT.grantSaoObjectStoreAccess().futureValue
+
+      response.status mustBe CREATED
+
+      verify(
+        1,
+        postRequestedFor(urlEqualTo("/test-only/token"))
+          .withHeader(HeaderNames.USER_AGENT, equalTo("senior-accounting-officer-submission-frontend"))
+          .withRequestBody(equalToJson(expectedRequest.toString))
+      )
+    }
+  }
+}
+
+object InternalAuthTestOnlyConnectorISpec {
+  val expectedRequest = Json.obj(
+    "token" -> "1234",
+    "principal" -> "senior-accounting-officer-submission-frontend",
+    "permissions" -> Json.arr(
+      Json.obj(
+        "resourceType" -> "object-store",
+        "resourceLocation" -> "senior-accounting-officer",
+        "actions" -> Json.arr("READ", "WRITE")
+      )
+    )
+  )
+}

--- a/test/controllers/testonly/InternalAuthTestOnlyControllerSpec.scala
+++ b/test/controllers/testonly/InternalAuthTestOnlyControllerSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testonly
+
+import base.SpecBase
+import connectors.InternalAuthTestOnlyConnector
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+
+import scala.concurrent.Future
+
+class InternalAuthTestOnlyControllerSpec extends SpecBase with MockitoSugar {
+
+  "InternalAuthTestOnlyController.grantSaoObjectStoreAccess" - {
+    "return the downstream internal-auth response status and body" in {
+      val mockConnector = mock[InternalAuthTestOnlyConnector]
+      val application   = applicationBuilder()
+        .overrides(bind[InternalAuthTestOnlyConnector].toInstance(mockConnector))
+        .build()
+
+      running(application) {
+        when(mockConnector.grantSaoObjectStoreAccess()(using any[HeaderCarrier]()))
+          .thenReturn(Future.successful(HttpResponse(CREATED, "configured")))
+
+        val request    = FakeRequest(POST, "/test-only/internal-auth/object-store")
+        val controller = application.injector.instanceOf[InternalAuthTestOnlyController]
+
+        val result = controller.grantSaoObjectStoreAccess()(request)
+
+        status(result) mustBe CREATED
+        contentAsString(result) mustBe "configured"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* adding test only routes for object-store integration

## Jira ticket(s):
* https://jira.tools.tax.service.gov.uk/browse/SAOD-831

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
  https://github.com/hmrc/internal-auth-config/pull/455 - this is merged
