### PR TITLE
Nojira/refactor notification file names

### DIFF
--- a/app/controllers/notification/NotificationMoreSaoFirstStartDateController.scala
+++ b/app/controllers/notification/NotificationMoreSaoFirstStartDateController.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import forms.notification.NotificationMoreSaoFirstStartDateFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.{MoreSaoSubmitNotificationFullNamePage, NotificationMoreSaoFirstStartDatePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMoreSaoFirstStartDatePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
@@ -50,7 +50,7 @@ class NotificationMoreSaoFirstStartDateController @Inject() (
     val form         = formProvider()
     val preparedForm = request.userAnswers.get(NotificationMoreSaoFirstStartDatePage).fold(form)(form.fill)
     request.userAnswers
-      .get(MoreSaoSubmitNotificationFullNamePage)
+      .get(NotificationMultiSaoLastOfficerNamePage)
       .fold(
         Redirect(routes.JourneyRecoveryController.onPageLoad())
       )(saoName => Ok(view(saoName, preparedForm, mode)))
@@ -60,7 +60,7 @@ class NotificationMoreSaoFirstStartDateController @Inject() (
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
       val form = formProvider()
-      request.userAnswers.get(MoreSaoSubmitNotificationFullNamePage) match {
+      request.userAnswers.get(NotificationMultiSaoLastOfficerNamePage) match {
         case Some(saoName) =>
           form
             .bindFromRequest()

--- a/app/controllers/notification/NotificationMultiSaoAreAllAddedController.scala
+++ b/app/controllers/notification/NotificationMultiSaoAreAllAddedController.scala
@@ -17,37 +17,37 @@
 package controllers.notification
 
 import controllers.actions.*
-import forms.notification.NotificationMoreSaoAreAllAddedFormProvider
+import forms.notification.NotificationMultiSaoAreAllAddedFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.NotificationMoreSaoAreAllAddedPage
+import pages.notification.NotificationMultiSaoAreAllAddedPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.NotificationMoreSaoAreAllAddedView
+import views.html.notification.NotificationMultiSaoAreAllAddedView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class NotificationMoreSaoAreAllAddedController @Inject() (
+class NotificationMultiSaoAreAllAddedController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: NotificationMoreSaoAreAllAddedFormProvider,
+    formProvider: NotificationMultiSaoAreAllAddedFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: NotificationMoreSaoAreAllAddedView
+    view: NotificationMultiSaoAreAllAddedView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
   def onPageLoad(mode: Mode, saoIndex: Int): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
       val form         = formProvider()
-      val preparedForm = request.userAnswers.get(NotificationMoreSaoAreAllAddedPage(saoIndex)).fold(form)(form.fill)
+      val preparedForm = request.userAnswers.get(NotificationMultiSaoAreAllAddedPage(saoIndex)).fold(form)(form.fill)
       Ok(view(preparedForm, mode, saoIndex))
   }
 
@@ -61,9 +61,9 @@ class NotificationMoreSaoAreAllAddedController @Inject() (
           value =>
             for {
               updatedAnswers <- Future
-                .fromTry(request.userAnswers.set(NotificationMoreSaoAreAllAddedPage(saoIndex), value))
+                .fromTry(request.userAnswers.set(NotificationMultiSaoAreAllAddedPage(saoIndex), value))
               _ <- sessionRepository.set(updatedAnswers)
-            } yield Redirect(navigator.nextPage(NotificationMoreSaoAreAllAddedPage(saoIndex), mode, updatedAnswers))
+            } yield Redirect(navigator.nextPage(NotificationMultiSaoAreAllAddedPage(saoIndex), mode, updatedAnswers))
         )
   }
 }

--- a/app/controllers/notification/NotificationMultiSaoLastOfficerNameController.scala
+++ b/app/controllers/notification/NotificationMultiSaoLastOfficerNameController.scala
@@ -17,36 +17,36 @@
 package controllers.notification
 
 import controllers.actions.*
-import forms.notification.MoreSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerNameFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.MoreSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationMultiSaoLastOfficerNamePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.MoreSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationMultiSaoLastOfficerNameView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class MoreSaoSubmitNotificationFullNameController @Inject() (
+class NotificationMultiSaoLastOfficerNameController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: MoreSaoSubmitNotificationFullNameFormProvider,
+    formProvider: NotificationMultiSaoLastOfficerNameFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: MoreSaoSubmitNotificationFullNameView
+    view: NotificationMultiSaoLastOfficerNameView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     val form         = formProvider()
-    val preparedForm = request.userAnswers.get(MoreSaoSubmitNotificationFullNamePage).fold(form)(form.fill)
+    val preparedForm = request.userAnswers.get(NotificationMultiSaoLastOfficerNamePage).fold(form)(form.fill)
     Ok(view(preparedForm, mode))
   }
 
@@ -59,9 +59,9 @@ class MoreSaoSubmitNotificationFullNameController @Inject() (
           formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
           value =>
             for {
-              updatedAnswers <- Future.fromTry(request.userAnswers.set(MoreSaoSubmitNotificationFullNamePage, value))
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(NotificationMultiSaoLastOfficerNamePage, value))
               _              <- sessionRepository.set(updatedAnswers)
-            } yield Redirect(navigator.nextPage(MoreSaoSubmitNotificationFullNamePage, mode, updatedAnswers))
+            } yield Redirect(navigator.nextPage(NotificationMultiSaoLastOfficerNamePage, mode, updatedAnswers))
         )
   }
 }

--- a/app/controllers/notification/NotificationMultiSaoLastOfficerStartDateController.scala
+++ b/app/controllers/notification/NotificationMultiSaoLastOfficerStartDateController.scala
@@ -18,37 +18,37 @@ package controllers.notification
 
 import controllers.actions.*
 import controllers.routes
-import forms.notification.NotificationMoreSaoFirstStartDateFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerStartDateFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMoreSaoFirstStartDatePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMultiSaoLastOfficerStartDatePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.NotificationMoreSaoFirstStartDateView
+import views.html.notification.NotificationMultiSaoLastOfficerStartDateView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class NotificationMoreSaoFirstStartDateController @Inject() (
+class NotificationMultiSaoLastOfficerStartDateController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: NotificationMoreSaoFirstStartDateFormProvider,
+    formProvider: NotificationMultiSaoLastOfficerStartDateFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: NotificationMoreSaoFirstStartDateView
+    view: NotificationMultiSaoLastOfficerStartDateView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     val form         = formProvider()
-    val preparedForm = request.userAnswers.get(NotificationMoreSaoFirstStartDatePage).fold(form)(form.fill)
+    val preparedForm = request.userAnswers.get(NotificationMultiSaoLastOfficerStartDatePage).fold(form)(form.fill)
     request.userAnswers
       .get(NotificationMultiSaoLastOfficerNamePage)
       .fold(
@@ -69,9 +69,9 @@ class NotificationMoreSaoFirstStartDateController @Inject() (
               value =>
                 for {
                   updatedAnswers <- Future
-                    .fromTry(request.userAnswers.set(NotificationMoreSaoFirstStartDatePage, value))
+                    .fromTry(request.userAnswers.set(NotificationMultiSaoLastOfficerStartDatePage, value))
                   _ <- sessionRepository.set(updatedAnswers)
-                } yield Redirect(navigator.nextPage(NotificationMoreSaoFirstStartDatePage, mode, updatedAnswers))
+                } yield Redirect(navigator.nextPage(NotificationMultiSaoLastOfficerStartDatePage, mode, updatedAnswers))
             )
 
         case None => Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))

--- a/app/controllers/notification/NotificationMultiSaoPreviousOfficerEndDateController.scala
+++ b/app/controllers/notification/NotificationMultiSaoPreviousOfficerEndDateController.scala
@@ -18,30 +18,30 @@ package controllers.notification
 
 import controllers.actions.*
 import controllers.routes
-import forms.notification.NotificationMoreSaoSecondEndDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerEndDateFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.{NotificationMoreSaoSecondEndDatePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{NotificationMultiSaoPreviousOfficerEndDatePage, NotificationMultiSaoPreviousOfficerNamePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.NotificationMoreSaoSecondEndDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerEndDateView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class NotificationMoreSaoSecondEndDateController @Inject() (
+class NotificationMultiSaoPreviousOfficerEndDateController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: NotificationMoreSaoSecondEndDateFormProvider,
+    formProvider: NotificationMultiSaoPreviousOfficerEndDateFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: NotificationMoreSaoSecondEndDateView
+    view: NotificationMultiSaoPreviousOfficerEndDateView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
@@ -49,7 +49,8 @@ class NotificationMoreSaoSecondEndDateController @Inject() (
   def onPageLoad(mode: Mode, saoIndex: Int): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
       val form         = formProvider()
-      val preparedForm = request.userAnswers.get(NotificationMoreSaoSecondEndDatePage(saoIndex)).fold(form)(form.fill)
+      val preparedForm =
+        request.userAnswers.get(NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex)).fold(form)(form.fill)
       request.userAnswers
         .get(NotificationMultiSaoPreviousOfficerNamePage(saoIndex)) match {
         case Some(saoName) => Ok(view(saoName, preparedForm, mode, saoIndex))
@@ -74,10 +75,10 @@ class NotificationMoreSaoSecondEndDateController @Inject() (
               value =>
                 for {
                   updatedAnswers <- Future
-                    .fromTry(request.userAnswers.set(NotificationMoreSaoSecondEndDatePage(saoIndex), value))
+                    .fromTry(request.userAnswers.set(NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex), value))
                   _ <- sessionRepository.set(updatedAnswers)
                 } yield Redirect(
-                  navigator.nextPage(NotificationMoreSaoSecondEndDatePage(saoIndex), mode, updatedAnswers)
+                  navigator.nextPage(NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex), mode, updatedAnswers)
                 )
             )
       }

--- a/app/controllers/notification/NotificationMultiSaoPreviousOfficerNameController.scala
+++ b/app/controllers/notification/NotificationMultiSaoPreviousOfficerNameController.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import forms.notification.NotificationMultiSaoPreviousOfficerNameFormProvider
 import models.{Mode, UserAnswers}
 import navigation.Navigator
-import pages.notification.{MoreSaoSubmitNotificationFullNamePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMultiSaoPreviousOfficerNamePage}
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -51,7 +51,7 @@ class NotificationMultiSaoPreviousOfficerNameController @Inject() (
 
   private def saoNameForPage(saoIndex: Int, userAnswers: UserAnswers): Option[String] =
     if saoIndex == 0 then {
-      userAnswers.get(MoreSaoSubmitNotificationFullNamePage)
+      userAnswers.get(NotificationMultiSaoLastOfficerNamePage)
     } else {
       userAnswers.get(NotificationMultiSaoPreviousOfficerNamePage(saoIndex - 1))
     }

--- a/app/controllers/notification/NotificationMultiSaoPreviousOfficerStartDateController.scala
+++ b/app/controllers/notification/NotificationMultiSaoPreviousOfficerStartDateController.scala
@@ -18,30 +18,33 @@ package controllers.notification
 
 import controllers.actions.*
 import controllers.routes
-import forms.notification.NotificationMoreSaoSecondStartDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerStartDateFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.{NotificationMoreSaoSecondStartDatePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{
+  NotificationMultiSaoPreviousOfficerNamePage,
+  NotificationMultiSaoPreviousOfficerStartDatePage
+}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.NotificationMoreSaoSecondStartDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerStartDateView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class NotificationMoreSaoSecondStartDateController @Inject() (
+class NotificationMultiSaoPreviousOfficerStartDateController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: NotificationMoreSaoSecondStartDateFormProvider,
+    formProvider: NotificationMultiSaoPreviousOfficerStartDateFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: NotificationMoreSaoSecondStartDateView
+    view: NotificationMultiSaoPreviousOfficerStartDateView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
@@ -49,7 +52,8 @@ class NotificationMoreSaoSecondStartDateController @Inject() (
   def onPageLoad(mode: Mode, saoIndex: Int): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
       val form         = formProvider()
-      val preparedForm = request.userAnswers.get(NotificationMoreSaoSecondStartDatePage(saoIndex)).fold(form)(form.fill)
+      val preparedForm =
+        request.userAnswers.get(NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex)).fold(form)(form.fill)
       request.userAnswers
         .get(NotificationMultiSaoPreviousOfficerNamePage(saoIndex)) match {
         case Some(saoName) => Ok(view(saoName, preparedForm, mode, saoIndex))
@@ -70,10 +74,10 @@ class NotificationMoreSaoSecondStartDateController @Inject() (
               value =>
                 for {
                   updatedAnswers <- Future
-                    .fromTry(request.userAnswers.set(NotificationMoreSaoSecondStartDatePage(saoIndex), value))
+                    .fromTry(request.userAnswers.set(NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex), value))
                   _ <- sessionRepository.set(updatedAnswers)
                 } yield Redirect(
-                  navigator.nextPage(NotificationMoreSaoSecondStartDatePage(saoIndex), mode, updatedAnswers)
+                  navigator.nextPage(NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex), mode, updatedAnswers)
                 )
             )
       }

--- a/app/controllers/notification/NotificationSingleSaoOfficerNameController.scala
+++ b/app/controllers/notification/NotificationSingleSaoOfficerNameController.scala
@@ -17,31 +17,31 @@
 package controllers.notification
 
 import controllers.actions.*
-import forms.notification.OneSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationSingleSaoOfficerNameFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.notification.OneSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationSingleSaoOfficerNamePage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.OneSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationSingleSaoOfficerNameView
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-class OneSaoSubmitNotificationFullNameController @Inject() (
+class NotificationSingleSaoOfficerNameController @Inject() (
     override val messagesApi: MessagesApi,
     sessionRepository: SessionRepository,
     navigator: Navigator,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    formProvider: OneSaoSubmitNotificationFullNameFormProvider,
+    formProvider: NotificationSingleSaoOfficerNameFormProvider,
     val controllerComponents: MessagesControllerComponents,
-    view: OneSaoSubmitNotificationFullNameView
+    view: NotificationSingleSaoOfficerNameView
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
@@ -49,7 +49,7 @@ class OneSaoSubmitNotificationFullNameController @Inject() (
   val form: Form[String] = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
-    val preparedForm = request.userAnswers.get(OneSaoSubmitNotificationFullNamePage).fold(form)(form.fill)
+    val preparedForm = request.userAnswers.get(NotificationSingleSaoOfficerNamePage).fold(form)(form.fill)
     Ok(view(preparedForm, mode))
   }
 
@@ -61,9 +61,9 @@ class OneSaoSubmitNotificationFullNameController @Inject() (
           formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
           value =>
             for {
-              updatedAnswers <- Future.fromTry(request.userAnswers.set(OneSaoSubmitNotificationFullNamePage, value))
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(NotificationSingleSaoOfficerNamePage, value))
               _              <- sessionRepository.set(updatedAnswers)
-            } yield Redirect(navigator.nextPage(OneSaoSubmitNotificationFullNamePage, mode, updatedAnswers))
+            } yield Redirect(navigator.nextPage(NotificationSingleSaoOfficerNamePage, mode, updatedAnswers))
         )
   }
 }

--- a/app/forms/notification/NotificationMultiSaoAreAllAddedFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoAreAllAddedFormProvider.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package pages.notification
+package forms.notification
 
-import pages.QuestionPage
-import play.api.libs.json.JsPath
+import forms.mappings.Mappings
+import play.api.data.Form
 
-final case class NotificationMoreSaoAreAllAddedPage(saoIndex: Int) extends QuestionPage[Boolean] {
+import javax.inject.Inject
 
-  val key = "notificationMoreSaoAreAllAdded"
+class NotificationMultiSaoAreAllAddedFormProvider @Inject() extends Mappings {
 
-  override def path: JsPath = JsPath \ key \ saoIndex
-
-  override def toString: String = s"$key[$saoIndex]"
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("notificationMultiSaoAreAllAdded.error.required")
+    )
 }

--- a/app/forms/notification/NotificationMultiSaoLastOfficerNameFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoLastOfficerNameFormProvider.scala
@@ -21,11 +21,11 @@ import play.api.data.Form
 
 import javax.inject.Inject
 
-class MoreSaoSubmitNotificationFullNameFormProvider @Inject() extends Mappings {
+class NotificationMultiSaoLastOfficerNameFormProvider @Inject() extends Mappings {
 
   def apply(): Form[String] =
     Form(
-      "value" -> text("moreSaoSubmitNotificationFullName.error.required")
-        .verifying(maxLength(254, "moreSaoSubmitNotificationFullName.error.length"))
+      "value" -> text("notificationMultiSaoLastOfficerName.error.required")
+        .verifying(maxLength(254, "notificationMultiSaoLastOfficerName.error.length"))
     )
 }

--- a/app/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProvider.scala
@@ -28,9 +28,13 @@ class NotificationMultiSaoLastOfficerStartDateFormProvider @Inject() extends Map
   def apply()(using messages: Messages): Form[LocalDate] =
     Form(
       "value" -> localDate(
+        // LDS ignore
         invalidKey = "notificationMultiSaoLastOfficerStartDate.error.invalid",
+        // LDS ignore
         allRequiredKey = "notificationMultiSaoLastOfficerStartDate.error.required.all",
+        // LDS ignore
         twoRequiredKey = "notificationMultiSaoLastOfficerStartDate.error.required.two",
+        // LDS ignore
         requiredKey = "notificationMultiSaoLastOfficerStartDate.error.required"
       )
     )

--- a/app/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProvider.scala
@@ -23,15 +23,15 @@ import play.api.i18n.Messages
 import java.time.LocalDate
 import javax.inject.Inject
 
-class NotificationMoreSaoFirstStartDateFormProvider @Inject() extends Mappings {
+class NotificationMultiSaoLastOfficerStartDateFormProvider @Inject() extends Mappings {
 
   def apply()(using messages: Messages): Form[LocalDate] =
     Form(
       "value" -> localDate(
-        invalidKey = "notificationMoreSaoFirstStartDate.error.invalid",
-        allRequiredKey = "notificationMoreSaoFirstStartDate.error.required.all",
-        twoRequiredKey = "notificationMoreSaoFirstStartDate.error.required.two",
-        requiredKey = "notificationMoreSaoFirstStartDate.error.required"
+        invalidKey = "notificationMultiSaoLastOfficerStartDate.error.invalid",
+        allRequiredKey = "notificationMultiSaoLastOfficerStartDate.error.required.all",
+        twoRequiredKey = "notificationMultiSaoLastOfficerStartDate.error.required.two",
+        requiredKey = "notificationMultiSaoLastOfficerStartDate.error.required"
       )
     )
 }

--- a/app/forms/notification/NotificationMultiSaoPreviousOfficerEndDateFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoPreviousOfficerEndDateFormProvider.scala
@@ -23,15 +23,15 @@ import play.api.i18n.Messages
 import java.time.LocalDate
 import javax.inject.Inject
 
-class NotificationMoreSaoSecondEndDateFormProvider @Inject() extends Mappings {
+class NotificationMultiSaoPreviousOfficerEndDateFormProvider @Inject() extends Mappings {
 
   def apply()(using messages: Messages): Form[LocalDate] =
     Form(
       "value" -> localDate(
-        invalidKey = "notificationMoreSaoSecondEndDate.error.invalid",
-        allRequiredKey = "notificationMoreSaoSecondEndDate.error.required.all",
-        twoRequiredKey = "notificationMoreSaoSecondEndDate.error.required.two",
-        requiredKey = "notificationMoreSaoSecondEndDate.error.required"
+        invalidKey = "notificationMultiSaoPreviousOfficerEndDate.error.invalid",
+        allRequiredKey = "notificationMultiSaoPreviousOfficerEndDate.error.required.all",
+        twoRequiredKey = "notificationMultiSaoPreviousOfficerEndDate.error.required.two",
+        requiredKey = "notificationMultiSaoPreviousOfficerEndDate.error.required"
       )
     )
 }

--- a/app/forms/notification/NotificationMultiSaoPreviousOfficerStartDateFormProvider.scala
+++ b/app/forms/notification/NotificationMultiSaoPreviousOfficerStartDateFormProvider.scala
@@ -23,15 +23,15 @@ import play.api.i18n.Messages
 import java.time.LocalDate
 import javax.inject.Inject
 
-class NotificationMoreSaoSecondStartDateFormProvider @Inject() extends Mappings {
+class NotificationMultiSaoPreviousOfficerStartDateFormProvider @Inject() extends Mappings {
 
   def apply()(using messages: Messages): Form[LocalDate] =
     Form(
       "value" -> localDate(
-        invalidKey = "notificationMoreSaoSecondStartDate.error.invalid",
-        allRequiredKey = "notificationMoreSaoSecondStartDate.error.required.all",
-        twoRequiredKey = "notificationMoreSaoSecondStartDate.error.required.two",
-        requiredKey = "notificationMoreSaoSecondStartDate.error.required"
+        invalidKey = "notificationMultiSaoPreviousOfficerStartDate.error.invalid",
+        allRequiredKey = "notificationMultiSaoPreviousOfficerStartDate.error.required.all",
+        twoRequiredKey = "notificationMultiSaoPreviousOfficerStartDate.error.required.two",
+        requiredKey = "notificationMultiSaoPreviousOfficerStartDate.error.required"
       )
     )
 }

--- a/app/forms/notification/NotificationSingleSaoOfficerNameFormProvider.scala
+++ b/app/forms/notification/NotificationSingleSaoOfficerNameFormProvider.scala
@@ -21,11 +21,11 @@ import play.api.data.Form
 
 import javax.inject.Inject
 
-class OneSaoSubmitNotificationFullNameFormProvider @Inject() extends Mappings {
+class NotificationSingleSaoOfficerNameFormProvider @Inject() extends Mappings {
 
   def apply(): Form[String] =
     Form(
-      "value" -> text("oneSaoSubmitNotificationFullName.error.required")
-        .verifying(maxLength(254, "oneSaoSubmitNotificationFullName.error.length"))
+      "value" -> text("notificationSingleSaoOfficerName.error.required")
+        .verifying(maxLength(254, "notificationSingleSaoOfficerName.error.length"))
     )
 }

--- a/app/models/notification/NotificationStage.scala
+++ b/app/models/notification/NotificationStage.scala
@@ -69,7 +69,7 @@ object NotificationStage {
   private def isProvideSaoDetailsComplete(userAnswers: UserAnswers): Boolean =
     userAnswers.get(NotificationMoreThanOneSaoPage).exists {
       case false =>
-        userAnswers.get(OneSaoSubmitNotificationFullNamePage).exists(_.trim.nonEmpty)
+        userAnswers.get(NotificationSingleSaoOfficerNamePage).exists(_.trim.nonEmpty)
       case true =>
         userAnswers.get(NotificationMultiSaoLastOfficerNamePage).exists(_.trim.nonEmpty) &&
         hasCompletedMoreSaoDetails(userAnswers)

--- a/app/models/notification/NotificationStage.scala
+++ b/app/models/notification/NotificationStage.scala
@@ -71,7 +71,7 @@ object NotificationStage {
       case false =>
         userAnswers.get(OneSaoSubmitNotificationFullNamePage).exists(_.trim.nonEmpty)
       case true =>
-        userAnswers.get(MoreSaoSubmitNotificationFullNamePage).exists(_.trim.nonEmpty) &&
+        userAnswers.get(NotificationMultiSaoLastOfficerNamePage).exists(_.trim.nonEmpty) &&
         hasCompletedMoreSaoDetails(userAnswers)
     }
 

--- a/app/models/notification/NotificationStage.scala
+++ b/app/models/notification/NotificationStage.scala
@@ -76,7 +76,7 @@ object NotificationStage {
     }
 
   private def hasCompletedMoreSaoDetails(userAnswers: UserAnswers): Boolean =
-    (userAnswers.data \ NotificationMoreSaoAreAllAddedPage(0).key)
+    (userAnswers.data \ NotificationMultiSaoAreAllAddedPage(0).key)
       .asOpt[Seq[Boolean]]
       .exists(_.contains(true))
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -78,8 +78,8 @@ class Navigator @Inject() () {
     case NotificationMultiSaoPreviousOfficerNamePage(saoIndex) =>
       _ => notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode, saoIndex)
     case NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex) =>
-      _ => notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(NormalMode, saoIndex)
-    case NotificationMoreSaoSecondEndDatePage(saoIndex) =>
+      _ => notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode, saoIndex)
+    case NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex) =>
       _ => notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode, saoIndex)
     case NotificationMoreSaoAreAllAddedPage(saoIndex) =>
       userAnswers =>

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -76,8 +76,8 @@ class Navigator @Inject() () {
     case NotificationMultiSaoLastOfficerStartDatePage =>
       _ => notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)
     case NotificationMultiSaoPreviousOfficerNamePage(saoIndex) =>
-      _ => notificationRoutes.NotificationMoreSaoSecondStartDateController.onPageLoad(NormalMode, saoIndex)
-    case NotificationMoreSaoSecondStartDatePage(saoIndex) =>
+      _ => notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode, saoIndex)
+    case NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex) =>
       _ => notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(NormalMode, saoIndex)
     case NotificationMoreSaoSecondEndDatePage(saoIndex) =>
       _ => notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode, saoIndex)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -72,8 +72,8 @@ class Navigator @Inject() () {
     case OneSaoSubmitNotificationFullNamePage =>
       _ => notificationRoutes.NotificationTaskListController.onPageLoad()
     case NotificationMultiSaoLastOfficerNamePage =>
-      _ => notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode)
-    case NotificationMoreSaoFirstStartDatePage =>
+      _ => notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode)
+    case NotificationMultiSaoLastOfficerStartDatePage =>
       _ => notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)
     case NotificationMultiSaoPreviousOfficerNamePage(saoIndex) =>
       _ => notificationRoutes.NotificationMoreSaoSecondStartDateController.onPageLoad(NormalMode, saoIndex)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -66,10 +66,10 @@ class Navigator @Inject() () {
       userAnswers =>
         userAnswers.get(NotificationMoreThanOneSaoPage) match {
           case Some(true)  => notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(NormalMode)
-          case Some(false) => notificationRoutes.OneSaoSubmitNotificationFullNameController.onPageLoad(NormalMode)
+          case Some(false) => notificationRoutes.NotificationSingleSaoOfficerNameController.onPageLoad(NormalMode)
           case _           => ???
         }
-    case OneSaoSubmitNotificationFullNamePage =>
+    case NotificationSingleSaoOfficerNamePage =>
       _ => notificationRoutes.NotificationTaskListController.onPageLoad()
     case NotificationMultiSaoLastOfficerNamePage =>
       _ => notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -80,10 +80,10 @@ class Navigator @Inject() () {
     case NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex) =>
       _ => notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode, saoIndex)
     case NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex) =>
-      _ => notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode, saoIndex)
-    case NotificationMoreSaoAreAllAddedPage(saoIndex) =>
+      _ => notificationRoutes.NotificationMultiSaoAreAllAddedController.onPageLoad(NormalMode, saoIndex)
+    case NotificationMultiSaoAreAllAddedPage(saoIndex) =>
       userAnswers =>
-        userAnswers.get(NotificationMoreSaoAreAllAddedPage(saoIndex)) match {
+        userAnswers.get(NotificationMultiSaoAreAllAddedPage(saoIndex)) match {
           case Some(true)  => notificationRoutes.NotificationTaskListController.onPageLoad()
           case Some(false) =>
             notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode, saoIndex + 1)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -65,13 +65,13 @@ class Navigator @Inject() () {
     case NotificationMoreThanOneSaoPage =>
       userAnswers =>
         userAnswers.get(NotificationMoreThanOneSaoPage) match {
-          case Some(true)  => notificationRoutes.MoreSaoSubmitNotificationFullNameController.onPageLoad(NormalMode)
+          case Some(true)  => notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(NormalMode)
           case Some(false) => notificationRoutes.OneSaoSubmitNotificationFullNameController.onPageLoad(NormalMode)
           case _           => ???
         }
     case OneSaoSubmitNotificationFullNamePage =>
       _ => notificationRoutes.NotificationTaskListController.onPageLoad()
-    case MoreSaoSubmitNotificationFullNamePage =>
+    case NotificationMultiSaoLastOfficerNamePage =>
       _ => notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode)
     case NotificationMoreSaoFirstStartDatePage =>
       _ => notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)

--- a/app/pages/notification/NotificationMultiSaoAreAllAddedPage.scala
+++ b/app/pages/notification/NotificationMultiSaoAreAllAddedPage.scala
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package forms.notification
+package pages.notification
 
-import forms.mappings.Mappings
-import play.api.data.Form
+import pages.QuestionPage
+import play.api.libs.json.JsPath
 
-import javax.inject.Inject
+final case class NotificationMultiSaoAreAllAddedPage(saoIndex: Int) extends QuestionPage[Boolean] {
 
-class NotificationMoreSaoAreAllAddedFormProvider @Inject() extends Mappings {
+  val key = "notificationMultiSaoAreAllAdded"
 
-  def apply(): Form[Boolean] =
-    Form(
-      "value" -> boolean("notificationMoreSaoAreAllAdded.error.required")
-    )
+  override def path: JsPath = JsPath \ key \ saoIndex
+
+  override def toString: String = s"$key[$saoIndex]"
 }

--- a/app/pages/notification/NotificationMultiSaoLastOfficerNamePage.scala
+++ b/app/pages/notification/NotificationMultiSaoLastOfficerNamePage.scala
@@ -19,9 +19,9 @@ package pages.notification
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object MoreSaoSubmitNotificationFullNamePage extends QuestionPage[String] {
+case object NotificationMultiSaoLastOfficerNamePage extends QuestionPage[String] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "moreSaoSubmitNotificationFullName"
+  override def toString: String = "notificationMultiSaoLastOfficerName"
 }

--- a/app/pages/notification/NotificationMultiSaoLastOfficerStartDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoLastOfficerStartDatePage.scala
@@ -21,9 +21,9 @@ import play.api.libs.json.JsPath
 
 import java.time.LocalDate
 
-case object NotificationMoreSaoFirstStartDatePage extends QuestionPage[LocalDate] {
+case object NotificationMultiSaoLastOfficerStartDatePage extends QuestionPage[LocalDate] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "notificationMoreSaoFirstStartDate"
+  override def toString: String = "notificationMultiSaoLastOfficerStartDate"
 }

--- a/app/pages/notification/NotificationMultiSaoPreviousOfficerEndDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoPreviousOfficerEndDatePage.scala
@@ -21,9 +21,9 @@ import play.api.libs.json.JsPath
 
 import java.time.LocalDate
 
-final case class NotificationMoreSaoSecondEndDatePage(saoIndex: Int) extends QuestionPage[LocalDate] {
+final case class NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex: Int) extends QuestionPage[LocalDate] {
 
-  val key = "notificationMoreSaoSecondEndDate"
+  val key = "notificationMultiSaoPreviousOfficerEndDate"
 
   override def path: JsPath = JsPath \ key \ saoIndex
 

--- a/app/pages/notification/NotificationMultiSaoPreviousOfficerStartDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoPreviousOfficerStartDatePage.scala
@@ -21,9 +21,9 @@ import play.api.libs.json.JsPath
 
 import java.time.LocalDate
 
-final case class NotificationMoreSaoSecondStartDatePage(saoIndex: Int) extends QuestionPage[LocalDate] {
+final case class NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex: Int) extends QuestionPage[LocalDate] {
 
-  val key = "notificationMoreSaoSecondStartDate"
+  val key = "notificationMultiSaoPreviousOfficerStartDate"
 
   override def path: JsPath = JsPath \ key \ saoIndex
 

--- a/app/pages/notification/NotificationSingleSaoOfficerNamePage.scala
+++ b/app/pages/notification/NotificationSingleSaoOfficerNamePage.scala
@@ -19,9 +19,9 @@ package pages.notification
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object OneSaoSubmitNotificationFullNamePage extends QuestionPage[String] {
+case object NotificationSingleSaoOfficerNamePage extends QuestionPage[String] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "oneSaoSubmitNotificationFullName"
+  override def toString: String = "notificationSingleSaoOfficerName"
 }

--- a/app/services/UploadTemplatePlaybackService.scala
+++ b/app/services/UploadTemplatePlaybackService.scala
@@ -40,7 +40,7 @@ class UploadTemplatePlaybackService @Inject() () {
 
   private def getSaoName(userAnswers: UserAnswers): Option[String] =
     userAnswers.get(NotificationMoreThanOneSaoPage).flatMap {
-      case true  => userAnswers.get(MoreSaoSubmitNotificationFullNamePage)
+      case true  => userAnswers.get(NotificationMultiSaoLastOfficerNamePage)
       case false => userAnswers.get(OneSaoSubmitNotificationFullNamePage)
     }
 }

--- a/app/services/UploadTemplatePlaybackService.scala
+++ b/app/services/UploadTemplatePlaybackService.scala
@@ -41,6 +41,6 @@ class UploadTemplatePlaybackService @Inject() () {
   private def getSaoName(userAnswers: UserAnswers): Option[String] =
     userAnswers.get(NotificationMoreThanOneSaoPage).flatMap {
       case true  => userAnswers.get(NotificationMultiSaoLastOfficerNamePage)
-      case false => userAnswers.get(OneSaoSubmitNotificationFullNamePage)
+      case false => userAnswers.get(NotificationSingleSaoOfficerNamePage)
     }
 }

--- a/app/viewmodels/checkAnswers/notification/NotificationMultiSaoAreAllAddedSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationMultiSaoAreAllAddedSummary.scala
@@ -18,26 +18,26 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.NotificationMoreSaoAreAllAddedPage
+import pages.notification.NotificationMultiSaoAreAllAddedPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object NotificationMoreSaoAreAllAddedSummary {
+object NotificationMultiSaoAreAllAddedSummary {
 
   def row(answers: UserAnswers, saoIndex: Int)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(NotificationMoreSaoAreAllAddedPage(saoIndex)).map { answer =>
+    answers.get(NotificationMultiSaoAreAllAddedPage(saoIndex)).map { answer =>
       val value = if answer then "site.yes" else "site.no"
       SummaryListRowViewModel(
-        key = messages("notificationMoreSaoAreAllAdded.checkYourAnswersLabel").toKey,
+        key = messages("notificationMultiSaoAreAllAdded.checkYourAnswersLabel").toKey,
         value = ValueViewModel(messages(value).toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationMultiSaoAreAllAddedController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("notificationMoreSaoAreAllAdded.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationMultiSaoAreAllAdded.change.hidden"))
         )
       )
     }

--- a/app/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerNameSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerNameSummary.scala
@@ -18,25 +18,25 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.MoreSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationMultiSaoLastOfficerNamePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object MoreSaoSubmitNotificationFullNameSummary {
+object NotificationMultiSaoLastOfficerNameSummary {
 
   def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(MoreSaoSubmitNotificationFullNamePage).map { answer =>
+    answers.get(NotificationMultiSaoLastOfficerNamePage).map { answer =>
       SummaryListRowViewModel(
-        key = messages("moreSaoSubmitNotificationFullName.checkYourAnswersLabel").toKey,
+        key = messages("notificationMultiSaoLastOfficerName.checkYourAnswersLabel").toKey,
         value = ValueViewModel(answer.toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.MoreSaoSubmitNotificationFullNameController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("moreSaoSubmitNotificationFullName.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationMultiSaoLastOfficerName.change.hidden"))
         )
       )
     }

--- a/app/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerStartDateSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerStartDateSummary.scala
@@ -18,27 +18,27 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.NotificationMoreSaoFirstStartDatePage
+import pages.notification.NotificationMultiSaoLastOfficerStartDatePage
 import play.api.i18n.{Lang, Messages}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.DateTimeFormats.dateTimeFormat
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object NotificationMoreSaoFirstStartDateSummary {
+object NotificationMultiSaoLastOfficerStartDateSummary {
 
   def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(NotificationMoreSaoFirstStartDatePage).map { answer =>
+    answers.get(NotificationMultiSaoLastOfficerStartDatePage).map { answer =>
       given Lang = messages.lang
       SummaryListRowViewModel(
-        key = messages("notificationMoreSaoFirstStartDate.checkYourAnswersLabel").toKey,
+        key = messages("notificationMultiSaoLastOfficerStartDate.checkYourAnswersLabel").toKey,
         value = ValueViewModel(answer.format(dateTimeFormat()).toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("notificationMoreSaoFirstStartDate.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationMultiSaoLastOfficerStartDate.change.hidden"))
         )
       )
     }

--- a/app/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerEndDateSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerEndDateSummary.scala
@@ -18,27 +18,27 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.NotificationMoreSaoSecondEndDatePage
+import pages.notification.NotificationMultiSaoPreviousOfficerEndDatePage
 import play.api.i18n.{Lang, Messages}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.DateTimeFormats.dateTimeFormat
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object NotificationMoreSaoSecondEndDateSummary {
+object NotificationMultiSaoPreviousOfficerEndDateSummary {
 
   def row(answers: UserAnswers, saoIndex: Int)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(NotificationMoreSaoSecondEndDatePage(saoIndex)).map { answer =>
+    answers.get(NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex)).map { answer =>
       given Lang = messages.lang
       SummaryListRowViewModel(
-        key = messages("notificationMoreSaoSecondEndDate.checkYourAnswersLabel").toKey,
+        key = messages("notificationMultiSaoPreviousOfficerEndDate.checkYourAnswersLabel").toKey,
         value = ValueViewModel(answer.format(dateTimeFormat()).toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("notificationMoreSaoSecondEndDate.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationMultiSaoPreviousOfficerEndDate.change.hidden"))
         )
       )
     }

--- a/app/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerStartDateSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerStartDateSummary.scala
@@ -18,27 +18,27 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.NotificationMoreSaoSecondStartDatePage
+import pages.notification.NotificationMultiSaoPreviousOfficerStartDatePage
 import play.api.i18n.{Lang, Messages}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.DateTimeFormats.dateTimeFormat
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object NotificationMoreSaoSecondStartDateSummary {
+object NotificationMultiSaoPreviousOfficerStartDateSummary {
 
   def row(answers: UserAnswers, saoIndex: Int)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(NotificationMoreSaoSecondStartDatePage(saoIndex: Int)).map { answer =>
+    answers.get(NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex: Int)).map { answer =>
       given Lang = messages.lang
       SummaryListRowViewModel(
-        key = messages("notificationMoreSaoSecondStartDate.checkYourAnswersLabel").toKey,
+        key = messages("notificationMultiSaoPreviousOfficerStartDate.checkYourAnswersLabel").toKey,
         value = ValueViewModel(answer.format(dateTimeFormat()).toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.NotificationMoreSaoSecondStartDateController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("notificationMoreSaoSecondStartDate.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationMultiSaoPreviousOfficerStartDate.change.hidden"))
         )
       )
     }

--- a/app/viewmodels/checkAnswers/notification/NotificationSingleSaoOfficerNameSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationSingleSaoOfficerNameSummary.scala
@@ -18,25 +18,25 @@ package viewmodels.checkAnswers.notification
 
 import controllers.notification.routes as notificationRoutes
 import models.{CheckMode, UserAnswers}
-import pages.notification.OneSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationSingleSaoOfficerNamePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*
 import viewmodels.govuk.summarylist.*
 
-object OneSaoSubmitNotificationFullNameSummary {
+object NotificationSingleSaoOfficerNameSummary {
 
   def row(answers: UserAnswers)(using messages: Messages): Option[SummaryListRow] =
-    answers.get(OneSaoSubmitNotificationFullNamePage).map { answer =>
+    answers.get(NotificationSingleSaoOfficerNamePage).map { answer =>
       SummaryListRowViewModel(
-        key = messages("oneSaoSubmitNotificationFullName.checkYourAnswersLabel").toKey,
+        key = messages("notificationSingleSaoOfficerName.checkYourAnswersLabel").toKey,
         value = ValueViewModel(answer.toText),
         actions = Seq(
           ActionItemViewModel(
             messages("site.change").toText,
-            notificationRoutes.OneSaoSubmitNotificationFullNameController.onPageLoad(CheckMode).url
+            notificationRoutes.NotificationSingleSaoOfficerNameController.onPageLoad(CheckMode).url
           )
-            .withVisuallyHiddenText(messages("oneSaoSubmitNotificationFullName.change.hidden"))
+            .withVisuallyHiddenText(messages("notificationSingleSaoOfficerName.change.hidden"))
         )
       )
     }

--- a/app/views/notification/NotificationMultiSaoAreAllAddedView.scala.html
+++ b/app/views/notification/NotificationMultiSaoAreAllAddedView.scala.html
@@ -26,18 +26,18 @@
 
 @(form: Form[?], mode: Mode, saoIndex: Int)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("notificationMoreSaoAreAllAdded.title"))) {
+@layout(pageTitle = title(form, messages("notificationMultiSaoAreAllAdded.title"))) {
 
-    @formHelper(action = notificationRoutes.NotificationMoreSaoAreAllAddedController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
+    @formHelper(action = notificationRoutes.NotificationMultiSaoAreAllAddedController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
-        <span class="govuk-caption-l">@messages("notificationMoreSaoAreAllAdded.caption")</span>
+        <span class="govuk-caption-l">@messages("notificationMultiSaoAreAllAdded.caption")</span>
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("notificationMoreSaoAreAllAdded.heading").toText).asPageHeading(LegendSize.Large)
+                legend = LegendViewModel(messages("notificationMultiSaoAreAllAdded.heading").toText).asPageHeading(LegendSize.Large)
             ).vertical()
         )
 

--- a/app/views/notification/NotificationMultiSaoLastOfficerNameView.scala.html
+++ b/app/views/notification/NotificationMultiSaoLastOfficerNameView.scala.html
@@ -27,23 +27,23 @@
 
 @(form: Form[?], mode: Mode)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("moreSaoSubmitNotificationFullName.title"))) {
+@layout(pageTitle = title(form, messages("notificationMultiSaoLastOfficerName.title"))) {
 
-    @formHelper(action = notificationRoutes.MoreSaoSubmitNotificationFullNameController.onSubmit(mode)) {
+    @formHelper(action = notificationRoutes.NotificationMultiSaoLastOfficerNameController.onSubmit(mode)) {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        <span class="govuk-caption-l">@messages("moreSaoSubmitNotificationFullName.caption")</span>
-        <h1 class="govuk-heading-l">@messages("moreSaoSubmitNotificationFullName.heading")</h1>
+        <span class="govuk-caption-l">@messages("notificationMultiSaoLastOfficerName.caption")</span>
+        <h1 class="govuk-heading-l">@messages("notificationMultiSaoLastOfficerName.heading")</h1>
 
-        <p class="govuk-body">@messages("moreSaoSubmitNotificationFullName.paragraph1")</p>
+        <p class="govuk-body">@messages("notificationMultiSaoLastOfficerName.paragraph1")</p>
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("moreSaoSubmitNotificationFullName.label").toText).withCssClass("govuk-label--m")
+                label = LabelViewModel(messages("notificationMultiSaoLastOfficerName.label").toText).withCssClass("govuk-label--m")
             )
             .withWidth(Fixed20)
         )

--- a/app/views/notification/NotificationMultiSaoLastOfficerStartDateView.scala.html
+++ b/app/views/notification/NotificationMultiSaoLastOfficerStartDateView.scala.html
@@ -26,22 +26,22 @@
 
 @(saoName: String, form: Form[?], mode: Mode)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("notificationMoreSaoFirstStartDate.title"))) {
+@layout(pageTitle = title(form, messages("notificationMultiSaoLastOfficerStartDate.title"))) {
 
-    @formHelper(action = notificationRoutes.NotificationMoreSaoFirstStartDateController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))
         }
 
-        <span class="govuk-caption-l">@messages("notificationMoreSaoFirstStartDate.caption")</span>
+        <span class="govuk-caption-l">@messages("notificationMultiSaoLastOfficerStartDate.caption")</span>
 
         @govukDateInput(
             DateViewModel(
                 field  = form("value"),
-                legend = LegendViewModel(messages("notificationMoreSaoFirstStartDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
+                legend = LegendViewModel(messages("notificationMultiSaoLastOfficerStartDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
             )
-            .withHint(HintViewModel(messages("notificationMoreSaoFirstStartDate.hint").toText))
+            .withHint(HintViewModel(messages("notificationMultiSaoLastOfficerStartDate.hint").toText))
         )
 
         @govukButton(

--- a/app/views/notification/NotificationMultiSaoPreviousOfficerEndDateView.scala.html
+++ b/app/views/notification/NotificationMultiSaoPreviousOfficerEndDateView.scala.html
@@ -26,22 +26,22 @@
 
 @(saoName: String, form: Form[?], mode: Mode, saoIndex: Int)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("notificationMoreSaoSecondEndDate.title"))) {
+@layout(pageTitle = title(form, messages("notificationMultiSaoPreviousOfficerEndDate.title"))) {
 
-    @formHelper(action = notificationRoutes.NotificationMoreSaoSecondEndDateController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
+    @formHelper(action = notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))
         }
 
-<span class="govuk-caption-l">@messages("notificationMoreSaoSecondEndDate.caption")</span>
+<span class="govuk-caption-l">@messages("notificationMultiSaoPreviousOfficerEndDate.caption")</span>
 
         @govukDateInput(
             DateViewModel(
                 field  = form("value"),
-                legend = LegendViewModel(messages("notificationMoreSaoSecondEndDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
+                legend = LegendViewModel(messages("notificationMultiSaoPreviousOfficerEndDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
             )
-            .withHint(HintViewModel(messages("notificationMoreSaoSecondEndDate.hint").toText))
+            .withHint(HintViewModel(messages("notificationMultiSaoPreviousOfficerEndDate.hint").toText))
         )
 
         @govukButton(

--- a/app/views/notification/NotificationMultiSaoPreviousOfficerStartDateView.scala.html
+++ b/app/views/notification/NotificationMultiSaoPreviousOfficerStartDateView.scala.html
@@ -26,22 +26,22 @@
 
 @(saoName: String, form: Form[?], mode: Mode, saoIndex: Int)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("notificationMoreSaoSecondStartDate.title"))) {
+@layout(pageTitle = title(form, messages("notificationMultiSaoPreviousOfficerStartDate.title"))) {
 
-    @formHelper(action = notificationRoutes.NotificationMoreSaoSecondStartDateController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
+    @formHelper(action = notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode, saoIndex), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))
         }
 
-        <span class="govuk-caption-l">@messages("notificationMoreSaoSecondStartDate.caption")</span>
+        <span class="govuk-caption-l">@messages("notificationMultiSaoPreviousOfficerStartDate.caption")</span>
 
         @govukDateInput(
             DateViewModel(
                 field  = form("value"),
-                legend = LegendViewModel(messages("notificationMoreSaoSecondStartDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
+                legend = LegendViewModel(messages("notificationMultiSaoPreviousOfficerStartDate.heading", saoName).toText).asPageHeading(LegendSize.Large)
             )
-            .withHint(HintViewModel(messages("notificationMoreSaoSecondStartDate.hint").toText))
+            .withHint(HintViewModel(messages("notificationMultiSaoPreviousOfficerStartDate.hint").toText))
         )
 
         @govukButton(

--- a/app/views/notification/NotificationSingleSaoOfficerNameView.scala.html
+++ b/app/views/notification/NotificationSingleSaoOfficerNameView.scala.html
@@ -27,20 +27,20 @@
 
 @(form: Form[?], mode: Mode)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = title(form, messages("oneSaoSubmitNotificationFullName.title"))) {
+@layout(pageTitle = title(form, messages("notificationSingleSaoOfficerName.title"))) {
 
-    @formHelper(action = notificationRoutes.OneSaoSubmitNotificationFullNameController.onSubmit(mode)) {
+    @formHelper(action = notificationRoutes.NotificationSingleSaoOfficerNameController.onSubmit(mode)) {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        <span class="govuk-caption-l">@messages("oneSaoSubmitNotificationFullName.caption")</span>
+        <span class="govuk-caption-l">@messages("notificationSingleSaoOfficerName.caption")</span>
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("oneSaoSubmitNotificationFullName.heading").toText).asPageHeading(LabelSize.Large)
+                label = LabelViewModel(messages("notificationSingleSaoOfficerName.heading").toText).asPageHeading(LabelSize.Large)
             )
             .withWidth(Fixed20)
         )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -108,10 +108,10 @@ POST        /certificate/change-declaration                           controller
 
 GET         /certificate/confirmation                                         controllers.CombinedCertificateConfirmationController.onPageLoad()
 
-GET        /notification/more-sao/submit-notification-full-name               controllers.notification.MoreSaoSubmitNotificationFullNameController.onPageLoad(mode: Mode = NormalMode)
-POST       /notification/more-sao/submit-notification-full-name               controllers.notification.MoreSaoSubmitNotificationFullNameController.onSubmit(mode: Mode = NormalMode)
-GET        /notification/more-sao/change-submitNotification-full-name         controllers.notification.MoreSaoSubmitNotificationFullNameController.onPageLoad(mode: Mode = CheckMode)
-POST       /notification/more-sao/change-submit-notification-full-name        controllers.notification.MoreSaoSubmitNotificationFullNameController.onSubmit(mode: Mode = CheckMode)
+GET        /notification/more-sao/submit-notification-full-name               controllers.notification.NotificationMultiSaoLastOfficerNameController.onPageLoad(mode: Mode = NormalMode)
+POST       /notification/more-sao/submit-notification-full-name               controllers.notification.NotificationMultiSaoLastOfficerNameController.onSubmit(mode: Mode = NormalMode)
+GET        /notification/more-sao/change-submitNotification-full-name         controllers.notification.NotificationMultiSaoLastOfficerNameController.onPageLoad(mode: Mode = CheckMode)
+POST       /notification/more-sao/change-submit-notification-full-name        controllers.notification.NotificationMultiSaoLastOfficerNameController.onSubmit(mode: Mode = CheckMode)
 
 GET         /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMoreSaoSecondStartDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
 POST        /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMoreSaoSecondStartDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -62,10 +62,10 @@ POST        /notification/one-sao/submit-notification-full-name               co
 GET         /notification/one-sao/change-submit-notification-full-name        controllers.notification.OneSaoSubmitNotificationFullNameController.onPageLoad(mode: Mode = CheckMode)
 POST        /notification/one-sao/change-submit-notification-full-name        controllers.notification.OneSaoSubmitNotificationFullNameController.onSubmit(mode: Mode = CheckMode)
 
-GET         /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMoreSaoFirstStartDateController.onPageLoad(mode: Mode = NormalMode)
-POST        /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMoreSaoFirstStartDateController.onSubmit(mode: Mode = NormalMode)
-GET         /notification/more-sao/change-submit-notification-first-start-date        controllers.notification.NotificationMoreSaoFirstStartDateController.onPageLoad(mode: Mode = CheckMode)
-POST        /notification/more-sao/change-submit-notification-first-start-date        controllers.notification.NotificationMoreSaoFirstStartDateController.onSubmit(mode: Mode = CheckMode)
+GET         /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(mode: Mode = NormalMode)
+POST        /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode: Mode = NormalMode)
+GET         /notification/more-sao/change-submit-notification-first-start-date        controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(mode: Mode = CheckMode)
+POST        /notification/more-sao/change-submit-notification-first-start-date        controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode: Mode = CheckMode)
 
 GET         /certificate/is-this-the-sao                              controllers.IsThisTheSaoOnCertificateController.onPageLoad(mode: Mode = NormalMode)
 POST        /certificate/is-this-the-sao                              controllers.IsThisTheSaoOnCertificateController.onSubmit(mode: Mode = NormalMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -113,10 +113,10 @@ POST       /notification/more-sao/submit-notification-full-name               co
 GET        /notification/more-sao/change-submitNotification-full-name         controllers.notification.NotificationMultiSaoLastOfficerNameController.onPageLoad(mode: Mode = CheckMode)
 POST       /notification/more-sao/change-submit-notification-full-name        controllers.notification.NotificationMultiSaoLastOfficerNameController.onSubmit(mode: Mode = CheckMode)
 
-GET         /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMoreSaoSecondStartDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-POST        /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMoreSaoSecondStartDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-GET         /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMoreSaoSecondStartDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
-POST        /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMoreSaoSecondStartDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+GET         /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+POST        /notification/multi-sao-second-start-date                                 controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+GET         /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+POST        /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 
 GET        /notificationMoreSaoSecondEndDate                                          controllers.notification.NotificationMoreSaoSecondEndDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
 POST       /notificationMoreSaoSecondEndDate                                          controllers.notification.NotificationMoreSaoSecondEndDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -118,10 +118,10 @@ POST        /notification/multi-sao-second-start-date                           
 GET         /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 POST        /notification/change-multi-sao-second-start-date                          controllers.notification.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 
-GET        /notificationMoreSaoSecondEndDate                                          controllers.notification.NotificationMoreSaoSecondEndDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-POST       /notificationMoreSaoSecondEndDate                                          controllers.notification.NotificationMoreSaoSecondEndDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-GET        /changeNotificationMoreSaoSecondEndDate                                    controllers.notification.NotificationMoreSaoSecondEndDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
-POST       /changeNotificationMoreSaoSecondEndDate                                    controllers.notification.NotificationMoreSaoSecondEndDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+GET        /notificationMultiSaoPreviousOfficerEndDate                                          controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+POST       /notificationMultiSaoPreviousOfficerEndDate                                          controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+GET        /changeNotificationMultiSaoPreviousOfficerEndDate                                    controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+POST       /changeNotificationMultiSaoPreviousOfficerEndDate                                    controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 
 GET        /notification/more-sao/are-all-added                                       controllers.notification.NotificationMoreSaoAreAllAddedController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
 POST       /notification/more-sao/are-all-added                                       controllers.notification.NotificationMoreSaoAreAllAddedController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -57,10 +57,10 @@ GET        /certificate/task-list/3                       controllers.Certificat
 GET        /certificate/task-list/complete                controllers.CertificateTaskListController.onPageLoad(stage: CertificateTaskListStage = CertificateTaskListStage.Complete)
 POST       /certificate/task-list                         controllers.CertificateTaskListController.onSubmit()
 
-GET         /notification/one-sao/submit-notification-full-name               controllers.notification.OneSaoSubmitNotificationFullNameController.onPageLoad(mode: Mode = NormalMode)
-POST        /notification/one-sao/submit-notification-full-name               controllers.notification.OneSaoSubmitNotificationFullNameController.onSubmit(mode: Mode = NormalMode)
-GET         /notification/one-sao/change-submit-notification-full-name        controllers.notification.OneSaoSubmitNotificationFullNameController.onPageLoad(mode: Mode = CheckMode)
-POST        /notification/one-sao/change-submit-notification-full-name        controllers.notification.OneSaoSubmitNotificationFullNameController.onSubmit(mode: Mode = CheckMode)
+GET         /notification/one-sao/submit-notification-full-name               controllers.notification.NotificationSingleSaoOfficerNameController.onPageLoad(mode: Mode = NormalMode)
+POST        /notification/one-sao/submit-notification-full-name               controllers.notification.NotificationSingleSaoOfficerNameController.onSubmit(mode: Mode = NormalMode)
+GET         /notification/one-sao/change-submit-notification-full-name        controllers.notification.NotificationSingleSaoOfficerNameController.onPageLoad(mode: Mode = CheckMode)
+POST        /notification/one-sao/change-submit-notification-full-name        controllers.notification.NotificationSingleSaoOfficerNameController.onSubmit(mode: Mode = CheckMode)
 
 GET         /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(mode: Mode = NormalMode)
 POST        /notification/more-sao/submit-notification-first-start-date               controllers.notification.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode: Mode = NormalMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -123,10 +123,10 @@ POST       /notificationMultiSaoPreviousOfficerEndDate                          
 GET        /changeNotificationMultiSaoPreviousOfficerEndDate                                    controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 POST       /changeNotificationMultiSaoPreviousOfficerEndDate                                    controllers.notification.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 
-GET        /notification/more-sao/are-all-added                                       controllers.notification.NotificationMoreSaoAreAllAddedController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-POST       /notification/more-sao/are-all-added                                       controllers.notification.NotificationMoreSaoAreAllAddedController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
-GET        /notification/more-sao/change-are-all-added                                controllers.notification.NotificationMoreSaoAreAllAddedController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
-POST       /notification/more-sao/change-are-all-added                                controllers.notification.NotificationMoreSaoAreAllAddedController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+GET        /notification/more-sao/are-all-added                                       controllers.notification.NotificationMultiSaoAreAllAddedController.onPageLoad(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+POST       /notification/more-sao/are-all-added                                       controllers.notification.NotificationMultiSaoAreAllAddedController.onSubmit(mode: Mode = NormalMode, saoIndex: Int ?= 0)
+GET        /notification/more-sao/change-are-all-added                                controllers.notification.NotificationMultiSaoAreAllAddedController.onPageLoad(mode: Mode = CheckMode, saoIndex: Int ?= 0)
+POST       /notification/more-sao/change-are-all-added                                controllers.notification.NotificationMultiSaoAreAllAddedController.onSubmit(mode: Mode = CheckMode, saoIndex: Int ?= 0)
 
 GET        /certificateAdditionalInformation                        controllers.CertificateAdditionalInformationController.onPageLoad(mode: Mode = NormalMode)
 POST       /certificateAdditionalInformation                        controllers.CertificateAdditionalInformationController.onSubmit(mode: Mode = NormalMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -312,15 +312,15 @@ notificationMoreSaoFirstStartDate.error.required = The date must include {0}
 notificationMoreSaoFirstStartDate.error.invalid = Enter the date in the correct format
 notificationMoreSaoFirstStartDate.change.hidden = NotificationMoreSaoFirstStartDate
 
-moreSaoSubmitNotificationFullName.title = Submit a notification - SAO full name
-moreSaoSubmitNotificationFullName.caption = Submit a notification
-moreSaoSubmitNotificationFullName.heading = Senior Accounting Officer details
-moreSaoSubmitNotificationFullName.label = What is the name of the last SAO?
-moreSaoSubmitNotificationFullName.paragraph1 = You told us more than one SAO held the role during the financial year. Enter the name of the last person who held the role. We’ll then ask you for details of the others who held the role earlier in the year.
-moreSaoSubmitNotificationFullName.checkYourAnswersLabel = moreSaoSubmitNotificationFullName
-moreSaoSubmitNotificationFullName.error.required = Enter the name of the last SAO
-moreSaoSubmitNotificationFullName.error.length = The name you enter must be 254 characters or less
-moreSaoSubmitNotificationFullName.change.hidden = MoreSaoSubmitNotificationFullName
+notificationMultiSaoLastOfficerName.title = Submit a notification - SAO full name
+notificationMultiSaoLastOfficerName.caption = Submit a notification
+notificationMultiSaoLastOfficerName.heading = Senior Accounting Officer details
+notificationMultiSaoLastOfficerName.label = What is the name of the last SAO?
+notificationMultiSaoLastOfficerName.paragraph1 = You told us more than one SAO held the role during the financial year. Enter the name of the last person who held the role. We’ll then ask you for details of the others who held the role earlier in the year.
+notificationMultiSaoLastOfficerName.checkYourAnswersLabel = notificationMultiSaoLastOfficerName
+notificationMultiSaoLastOfficerName.error.required = Enter the name of the last SAO
+notificationMultiSaoLastOfficerName.error.length = The name you enter must be 254 characters or less
+notificationMultiSaoLastOfficerName.change.hidden = NotificationMultiSaoLastOfficerName
 
 notificationMoreSaoSecondStartDate.title = Submit a notification
 notificationMoreSaoSecondStartDate.heading = When did {0}’s responsibility as the SAO start?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -301,16 +301,16 @@ notificationMultiSaoPreviousOfficerName.error.required = Enter the name of the p
 notificationMultiSaoPreviousOfficerName.error.length = The name you enter must be 254 characters or less
 notificationMultiSaoPreviousOfficerName.change.hidden = NotificationMultiSaoPreviousOfficerName
 
-notificationMoreSaoFirstStartDate.title = Submit a notification
-notificationMoreSaoFirstStartDate.heading = What date did {0} become the SAO?
-notificationMoreSaoFirstStartDate.caption = Submit a notification
-notificationMoreSaoFirstStartDate.hint = For example 01 6 2024
-notificationMoreSaoFirstStartDate.checkYourAnswersLabel = NotificationMoreSaoFirstStartDate
-notificationMoreSaoFirstStartDate.error.required.all = The date must be a real date
-notificationMoreSaoFirstStartDate.error.required.two = The date must include {0} and {1}
-notificationMoreSaoFirstStartDate.error.required = The date must include {0}
-notificationMoreSaoFirstStartDate.error.invalid = Enter the date in the correct format
-notificationMoreSaoFirstStartDate.change.hidden = NotificationMoreSaoFirstStartDate
+notificationMultiSaoLastOfficerStartDate.title = Submit a notification
+notificationMultiSaoLastOfficerStartDate.heading = What date did {0} become the SAO?
+notificationMultiSaoLastOfficerStartDate.caption = Submit a notification
+notificationMultiSaoLastOfficerStartDate.hint = For example 01 6 2024
+notificationMultiSaoLastOfficerStartDate.checkYourAnswersLabel = NotificationMultiSaoLastOfficerStartDate
+notificationMultiSaoLastOfficerStartDate.error.required.all = The date must be a real date
+notificationMultiSaoLastOfficerStartDate.error.required.two = The date must include {0} and {1}
+notificationMultiSaoLastOfficerStartDate.error.required = The date must include {0}
+notificationMultiSaoLastOfficerStartDate.error.invalid = Enter the date in the correct format
+notificationMultiSaoLastOfficerStartDate.change.hidden = NotificationMultiSaoLastOfficerStartDate
 
 notificationMultiSaoLastOfficerName.title = Submit a notification - SAO full name
 notificationMultiSaoLastOfficerName.caption = Submit a notification

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -340,16 +340,16 @@ notificationMoreSaoAreAllAdded.checkYourAnswersLabel = notificationMoreSaoAreAll
 notificationMoreSaoAreAllAdded.error.required = Select ’Yes’ if you have added all the Senior Accounting Officers for the financial year this notification relates to
 notificationMoreSaoAreAllAdded.change.hidden = NotificationMoreSaoAreAllAdded
 
-notificationMoreSaoSecondEndDate.title = Submit a notification
-notificationMoreSaoSecondEndDate.caption = Submit a notification
-notificationMoreSaoSecondEndDate.heading = When did {0} stop being the SAO?
-notificationMoreSaoSecondEndDate.hint = For example 01 6 2024
-notificationMoreSaoSecondEndDate.checkYourAnswersLabel = NotificationMoreSaoSecondEndDate
-notificationMoreSaoSecondEndDate.error.required.all = Enter the end date the SAO was responsible for the group’s tax accounting arrangements
-notificationMoreSaoSecondEndDate.error.required.two = The date must include {0} and {1}
-notificationMoreSaoSecondEndDate.error.required = The date must include {0}
-notificationMoreSaoSecondEndDate.error.invalid = Enter the date in the correct format
-notificationMoreSaoSecondEndDate.change.hidden = NotificationMoreSaoSecondEndDate
+notificationMultiSaoPreviousOfficerEndDate.title = Submit a notification
+notificationMultiSaoPreviousOfficerEndDate.caption = Submit a notification
+notificationMultiSaoPreviousOfficerEndDate.heading = When did {0} stop being the SAO?
+notificationMultiSaoPreviousOfficerEndDate.hint = For example 01 6 2024
+notificationMultiSaoPreviousOfficerEndDate.checkYourAnswersLabel = NotificationMultiSaoPreviousOfficerEndDate
+notificationMultiSaoPreviousOfficerEndDate.error.required.all = Enter the end date the SAO was responsible for the group’s tax accounting arrangements
+notificationMultiSaoPreviousOfficerEndDate.error.required.two = The date must include {0} and {1}
+notificationMultiSaoPreviousOfficerEndDate.error.required = The date must include {0}
+notificationMultiSaoPreviousOfficerEndDate.error.invalid = Enter the date in the correct format
+notificationMultiSaoPreviousOfficerEndDate.change.hidden = NotificationMultiSaoPreviousOfficerEndDate
 
 confirmYourNotification.title = Confirm notification and submit
 confirmYourNotification.caption = Submit a notification

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -284,13 +284,13 @@ uploadTemplateCsvParser.error.taxRegime = Enter 'x' if the company is qualified 
 uploadTemplateCsvParser.error.certificateType = Only 'unqualified' or 'qualified' can be entered in this field. 'Qualified' will be added automatically if you enter an 'x' against a tax regime in columns G to P
 uploadTemplateCsvParser.error.additionalInformation = Explain why the certificate is qualified and a tax regime has been selected
 
-oneSaoSubmitNotificationFullName.title = Submit a notification - SAO full name
-oneSaoSubmitNotificationFullName.heading = What is the name of the SAO?
-oneSaoSubmitNotificationFullName.caption = Submit a notification
-oneSaoSubmitNotificationFullName.checkYourAnswersLabel = oneSaoSubmitNotificationFullName
-oneSaoSubmitNotificationFullName.error.required = Enter the name of the SAO
-oneSaoSubmitNotificationFullName.error.length = The name you enter must be 254 characters or less
-oneSaoSubmitNotificationFullName.change.hidden = OneSaoSubmitNotificationFullName
+notificationSingleSaoOfficerName.title = Submit a notification - SAO full name
+notificationSingleSaoOfficerName.heading = What is the name of the SAO?
+notificationSingleSaoOfficerName.caption = Submit a notification
+notificationSingleSaoOfficerName.checkYourAnswersLabel = notificationSingleSaoOfficerName
+notificationSingleSaoOfficerName.error.required = Enter the name of the SAO
+notificationSingleSaoOfficerName.error.length = The name you enter must be 254 characters or less
+notificationSingleSaoOfficerName.change.hidden = NotificationSingleSaoOfficerName
 
 notificationMultiSaoPreviousOfficerName.title = Senior Accounting Officer full name
 notificationMultiSaoPreviousOfficerName.heading = Who was the SAO before {0}?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -322,16 +322,16 @@ notificationMultiSaoLastOfficerName.error.required = Enter the name of the last 
 notificationMultiSaoLastOfficerName.error.length = The name you enter must be 254 characters or less
 notificationMultiSaoLastOfficerName.change.hidden = NotificationMultiSaoLastOfficerName
 
-notificationMoreSaoSecondStartDate.title = Submit a notification
-notificationMoreSaoSecondStartDate.heading = When did {0}’s responsibility as the SAO start?
-notificationMoreSaoSecondStartDate.caption = Submit a notification
-notificationMoreSaoSecondStartDate.hint = For example 01 6 2024
-notificationMoreSaoSecondStartDate.checkYourAnswersLabel = NotificationMoreSaoSecondStartDate
-notificationMoreSaoSecondStartDate.error.required.all = Enter the start date the SAO was responsible for the group’s tax accounting arrangements
-notificationMoreSaoSecondStartDate.error.required.two = The date must include {0} and {1}
-notificationMoreSaoSecondStartDate.error.required = The date must include {0}
-notificationMoreSaoSecondStartDate.error.invalid = Enter the date in the correct format
-notificationMoreSaoSecondStartDate.change.hidden = NotificationMoreSaoSecondStartDate
+notificationMultiSaoPreviousOfficerStartDate.title = Submit a notification
+notificationMultiSaoPreviousOfficerStartDate.heading = When did {0}’s responsibility as the SAO start?
+notificationMultiSaoPreviousOfficerStartDate.caption = Submit a notification
+notificationMultiSaoPreviousOfficerStartDate.hint = For example 01 6 2024
+notificationMultiSaoPreviousOfficerStartDate.checkYourAnswersLabel = NotificationMultiSaoPreviousOfficerStartDate
+notificationMultiSaoPreviousOfficerStartDate.error.required.all = Enter the start date the SAO was responsible for the group’s tax accounting arrangements
+notificationMultiSaoPreviousOfficerStartDate.error.required.two = The date must include {0} and {1}
+notificationMultiSaoPreviousOfficerStartDate.error.required = The date must include {0}
+notificationMultiSaoPreviousOfficerStartDate.error.invalid = Enter the date in the correct format
+notificationMultiSaoPreviousOfficerStartDate.change.hidden = NotificationMultiSaoPreviousOfficerStartDate
 
 notificationMoreSaoAreAllAdded.title = Submit a notification - Have you added all the SAO for the financial year this notification relates to?
 notificationMoreSaoAreAllAdded.heading = Have you added all the SAO for the financial year this notification relates to?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -333,12 +333,12 @@ notificationMultiSaoPreviousOfficerStartDate.error.required = The date must incl
 notificationMultiSaoPreviousOfficerStartDate.error.invalid = Enter the date in the correct format
 notificationMultiSaoPreviousOfficerStartDate.change.hidden = NotificationMultiSaoPreviousOfficerStartDate
 
-notificationMoreSaoAreAllAdded.title = Submit a notification - Have you added all the SAO for the financial year this notification relates to?
-notificationMoreSaoAreAllAdded.heading = Have you added all the SAO for the financial year this notification relates to?
-notificationMoreSaoAreAllAdded.caption = Submit a notification
-notificationMoreSaoAreAllAdded.checkYourAnswersLabel = notificationMoreSaoAreAllAdded
-notificationMoreSaoAreAllAdded.error.required = Select ’Yes’ if you have added all the Senior Accounting Officers for the financial year this notification relates to
-notificationMoreSaoAreAllAdded.change.hidden = NotificationMoreSaoAreAllAdded
+notificationMultiSaoAreAllAdded.title = Submit a notification - Have you added all the SAO for the financial year this notification relates to?
+notificationMultiSaoAreAllAdded.heading = Have you added all the SAO for the financial year this notification relates to?
+notificationMultiSaoAreAllAdded.caption = Submit a notification
+notificationMultiSaoAreAllAdded.checkYourAnswersLabel = notificationMultiSaoAreAllAdded
+notificationMultiSaoAreAllAdded.error.required = Select ’Yes’ if you have added all the Senior Accounting Officers for the financial year this notification relates to
+notificationMultiSaoAreAllAdded.change.hidden = NotificationMultiSaoAreAllAdded
 
 notificationMultiSaoPreviousOfficerEndDate.title = Submit a notification
 notificationMultiSaoPreviousOfficerEndDate.caption = Submit a notification

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -76,7 +76,7 @@ trait SpecBase
       .set(NotificationMultiSaoPreviousOfficerStartDatePage(0), LocalDate.of(2023, 1, 1))
       .success
       .value
-      .set(NotificationMoreSaoSecondEndDatePage(0), LocalDate.of(2023, 12, 31))
+      .set(NotificationMultiSaoPreviousOfficerEndDatePage(0), LocalDate.of(2023, 12, 31))
       .success
       .value
       .set(NotificationMoreSaoAreAllAddedPage(0), true)

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -67,7 +67,7 @@ trait SpecBase
       .set(NotificationMultiSaoLastOfficerNamePage, "Jackson Brown")
       .success
       .value
-      .set(NotificationMoreSaoFirstStartDatePage, LocalDate.of(2024, 1, 1))
+      .set(NotificationMultiSaoLastOfficerStartDatePage, LocalDate.of(2024, 1, 1))
       .success
       .value
       .set(NotificationMultiSaoPreviousOfficerNamePage(0), "Taylor Green")

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -73,7 +73,7 @@ trait SpecBase
       .set(NotificationMultiSaoPreviousOfficerNamePage(0), "Taylor Green")
       .success
       .value
-      .set(NotificationMoreSaoSecondStartDatePage(0), LocalDate.of(2023, 1, 1))
+      .set(NotificationMultiSaoPreviousOfficerStartDatePage(0), LocalDate.of(2023, 1, 1))
       .success
       .value
       .set(NotificationMoreSaoSecondEndDatePage(0), LocalDate.of(2023, 12, 31))

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -64,7 +64,7 @@ trait SpecBase
       .set(NotificationMoreThanOneSaoPage, true)
       .success
       .value
-      .set(MoreSaoSubmitNotificationFullNamePage, "Jackson Brown")
+      .set(NotificationMultiSaoLastOfficerNamePage, "Jackson Brown")
       .success
       .value
       .set(NotificationMoreSaoFirstStartDatePage, LocalDate.of(2024, 1, 1))

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -49,7 +49,7 @@ trait SpecBase
       .set(NotificationMoreThanOneSaoPage, false)
       .success
       .value
-      .set(OneSaoSubmitNotificationFullNamePage, "Jackson Brown")
+      .set(NotificationSingleSaoOfficerNamePage, "Jackson Brown")
       .success
       .value
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -79,7 +79,7 @@ trait SpecBase
       .set(NotificationMultiSaoPreviousOfficerEndDatePage(0), LocalDate.of(2023, 12, 31))
       .success
       .value
-      .set(NotificationMoreSaoAreAllAddedPage(0), true)
+      .set(NotificationMultiSaoAreAllAddedPage(0), true)
       .success
       .value
 

--- a/test/controllers/notification/MoreSaoSubmitNotificationFullNameControllerSpec.scala
+++ b/test/controllers/notification/MoreSaoSubmitNotificationFullNameControllerSpec.scala
@@ -19,45 +19,45 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.MoreSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerNameFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.MoreSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationMultiSaoLastOfficerNamePage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.MoreSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationMultiSaoLastOfficerNameView
 
 import scala.concurrent.Future
 
-class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with MockitoSugar {
+class NotificationMultiSaoLastOfficerNameControllerSpec extends SpecBase with MockitoSugar {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  val formProvider       = new MoreSaoSubmitNotificationFullNameFormProvider()
+  val formProvider       = new NotificationMultiSaoLastOfficerNameFormProvider()
   val form: Form[String] = formProvider()
 
-  lazy val moreSaoSubmitNotificationFullNameRoute: String =
-    notificationRoutes.MoreSaoSubmitNotificationFullNameController.onPageLoad(NormalMode).url
+  lazy val notificationMultiSaoLastOfficerNameRoute: String =
+    notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(NormalMode).url
 
-  "MoreSaoSubmitNotificationFullName Controller" - {
+  "NotificationMultiSaoLastOfficerName Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, moreSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationMultiSaoLastOfficerNameRoute)
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[MoreSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerNameView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(form, NormalMode)(using request, messages(application)).toString
@@ -66,14 +66,14 @@ class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mock
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(MoreSaoSubmitNotificationFullNamePage, "answer").success.value
+      val userAnswers = UserAnswers(userAnswersId).set(NotificationMultiSaoLastOfficerNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, moreSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationMultiSaoLastOfficerNameRoute)
 
-        val view = application.injector.instanceOf[MoreSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerNameView]
 
         val result = route(application, request).value
 
@@ -101,7 +101,7 @@ class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mock
 
       running(application) {
         val request =
-          FakeRequest(POST, moreSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationMultiSaoLastOfficerNameRoute)
             .withFormUrlEncodedBody(("value", "answer"))
 
         val result = route(application, request).value
@@ -117,12 +117,12 @@ class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mock
 
       running(application) {
         val request =
-          FakeRequest(POST, moreSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationMultiSaoLastOfficerNameRoute)
             .withFormUrlEncodedBody(("value", ""))
 
         val boundForm = form.bind(Map("value" -> ""))
 
-        val view = application.injector.instanceOf[MoreSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerNameView]
 
         val result = route(application, request).value
 
@@ -136,7 +136,7 @@ class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mock
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, moreSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationMultiSaoLastOfficerNameRoute)
 
         val result = route(application, request).value
 
@@ -151,7 +151,7 @@ class MoreSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mock
 
       running(application) {
         val request =
-          FakeRequest(POST, moreSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationMultiSaoLastOfficerNameRoute)
             .withFormUrlEncodedBody(("value", "answer"))
 
         val result = route(application, request).value

--- a/test/controllers/notification/NotificationMoreSaoAreAllAddedControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoAreAllAddedControllerSpec.scala
@@ -19,47 +19,47 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.NotificationMoreSaoAreAllAddedFormProvider
+import forms.notification.NotificationMultiSaoAreAllAddedFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.NotificationMoreSaoAreAllAddedPage
+import pages.notification.NotificationMultiSaoAreAllAddedPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.NotificationMoreSaoAreAllAddedView
+import views.html.notification.NotificationMultiSaoAreAllAddedView
 
 import scala.concurrent.Future
 
-class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with MockitoSugar {
+class NotificationMultiSaoAreAllAddedControllerSpec extends SpecBase with MockitoSugar {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  val formProvider        = new NotificationMoreSaoAreAllAddedFormProvider()
+  val formProvider        = new NotificationMultiSaoAreAllAddedFormProvider()
   val form: Form[Boolean] = formProvider()
 
-  lazy val notificationMoreSaoAreAllAddedRoute: String =
-    notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode).url
+  lazy val notificationMultiSaoAreAllAddedRoute: String =
+    notificationRoutes.NotificationMultiSaoAreAllAddedController.onPageLoad(NormalMode).url
 
   val saoIndex = 0
 
-  "NotificationMoreSaoAreAllAdded Controller" - {
+  "NotificationMultiSaoAreAllAdded Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, notificationMoreSaoAreAllAddedRoute)
+        val request = FakeRequest(GET, notificationMultiSaoAreAllAddedRoute)
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[NotificationMoreSaoAreAllAddedView]
+        val view = application.injector.instanceOf[NotificationMultiSaoAreAllAddedView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(form, NormalMode, saoIndex)(using
@@ -71,14 +71,15 @@ class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with Mockito
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(NotificationMoreSaoAreAllAddedPage(saoIndex), true).success.value
+      val userAnswers =
+        UserAnswers(userAnswersId).set(NotificationMultiSaoAreAllAddedPage(saoIndex), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, notificationMoreSaoAreAllAddedRoute)
+        val request = FakeRequest(GET, notificationMultiSaoAreAllAddedRoute)
 
-        val view = application.injector.instanceOf[NotificationMoreSaoAreAllAddedView]
+        val view = application.injector.instanceOf[NotificationMultiSaoAreAllAddedView]
 
         val result = route(application, request).value
 
@@ -106,7 +107,7 @@ class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with Mockito
 
       running(application) {
         val request =
-          FakeRequest(POST, notificationMoreSaoAreAllAddedRoute)
+          FakeRequest(POST, notificationMultiSaoAreAllAddedRoute)
             .withFormUrlEncodedBody(("value", "true"))
 
         val result = route(application, request).value
@@ -122,12 +123,12 @@ class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with Mockito
 
       running(application) {
         val request =
-          FakeRequest(POST, notificationMoreSaoAreAllAddedRoute)
+          FakeRequest(POST, notificationMultiSaoAreAllAddedRoute)
             .withFormUrlEncodedBody(("value", ""))
 
         val boundForm = form.bind(Map("value" -> ""))
 
-        val view = application.injector.instanceOf[NotificationMoreSaoAreAllAddedView]
+        val view = application.injector.instanceOf[NotificationMultiSaoAreAllAddedView]
 
         val result = route(application, request).value
 
@@ -144,7 +145,7 @@ class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with Mockito
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, notificationMoreSaoAreAllAddedRoute)
+        val request = FakeRequest(GET, notificationMultiSaoAreAllAddedRoute)
 
         val result = route(application, request).value
 
@@ -159,7 +160,7 @@ class NotificationMoreSaoAreAllAddedControllerSpec extends SpecBase with Mockito
 
       running(application) {
         val request =
-          FakeRequest(POST, notificationMoreSaoAreAllAddedRoute)
+          FakeRequest(POST, notificationMultiSaoAreAllAddedRoute)
             .withFormUrlEncodedBody(("value", "true"))
 
         val result = route(application, request).value

--- a/test/controllers/notification/NotificationMoreSaoFirstStartDateControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoFirstStartDateControllerSpec.scala
@@ -19,30 +19,30 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.NotificationMoreSaoFirstStartDateFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerStartDateFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMoreSaoFirstStartDatePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMultiSaoLastOfficerStartDatePage}
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.NotificationMoreSaoFirstStartDateView
+import views.html.notification.NotificationMultiSaoLastOfficerStartDateView
 
 import scala.concurrent.Future
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with MockitoSugar {
+class NotificationMultiSaoLastOfficerStartDateControllerSpec extends SpecBase with MockitoSugar {
 
   private given messages: Messages = stubMessages()
 
-  private val formProvider = new NotificationMoreSaoFirstStartDateFormProvider()
+  private val formProvider = new NotificationMultiSaoLastOfficerStartDateFormProvider()
   private def form         = formProvider()
 
   def onwardRoute: Call = Call("GET", "/foo")
@@ -50,8 +50,8 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
   val validAnswer: LocalDate = LocalDate.now(ZoneOffset.UTC)
   val saoName: String        = "Firstname Lastname"
 
-  lazy val notificationMoreSaoFirstStartDateRoute: String =
-    notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode).url
+  lazy val notificationMultiSaoLastOfficerStartDateRoute: String =
+    notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode).url
 
   val userAnswers: UserAnswers = UserAnswers(userAnswersId)
     .set(NotificationMultiSaoLastOfficerNamePage, saoName)
@@ -59,17 +59,17 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
     .value
 
   def getRequest(): FakeRequest[AnyContentAsEmpty.type] =
-    FakeRequest(GET, notificationMoreSaoFirstStartDateRoute)
+    FakeRequest(GET, notificationMultiSaoLastOfficerStartDateRoute)
 
   def postRequest(): FakeRequest[AnyContentAsFormUrlEncoded] =
-    FakeRequest(POST, notificationMoreSaoFirstStartDateRoute)
+    FakeRequest(POST, notificationMultiSaoLastOfficerStartDateRoute)
       .withFormUrlEncodedBody(
         "value.day"   -> validAnswer.getDayOfMonth.toString,
         "value.month" -> validAnswer.getMonthValue.toString,
         "value.year"  -> validAnswer.getYear.toString
       )
 
-  "NotificationMoreSaoFirstStartDate Controller" - {
+  "NotificationMultiSaoLastOfficerStartDate Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -78,7 +78,7 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
       running(application) {
         val result = route(application, getRequest()).value
 
-        val view = application.injector.instanceOf[NotificationMoreSaoFirstStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerStartDateView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(saoName, form, NormalMode)(using
@@ -101,11 +101,11 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswersWithDate = userAnswers.set(NotificationMoreSaoFirstStartDatePage, validAnswer).success.value
+      val userAnswersWithDate = userAnswers.set(NotificationMultiSaoLastOfficerStartDatePage, validAnswer).success.value
       val application         = applicationBuilder(userAnswers = Some(userAnswersWithDate)).build()
 
       running(application) {
-        val view = application.injector.instanceOf[NotificationMoreSaoFirstStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerStartDateView]
 
         val result = route(application, getRequest()).value
 
@@ -149,13 +149,13 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       val request =
-        FakeRequest(POST, notificationMoreSaoFirstStartDateRoute)
+        FakeRequest(POST, notificationMultiSaoLastOfficerStartDateRoute)
           .withFormUrlEncodedBody(("value", "invalid value"))
 
       running(application) {
         val boundForm = form.bind(Map("value" -> "invalid value"))
 
-        val view = application.injector.instanceOf[NotificationMoreSaoFirstStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoLastOfficerStartDateView]
 
         val result = route(application, request).value
 

--- a/test/controllers/notification/NotificationMoreSaoFirstStartDateControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoFirstStartDateControllerSpec.scala
@@ -25,7 +25,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.{MoreSaoSubmitNotificationFullNamePage, NotificationMoreSaoFirstStartDatePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMoreSaoFirstStartDatePage}
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
@@ -54,7 +54,7 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
     notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode).url
 
   val userAnswers: UserAnswers = UserAnswers(userAnswersId)
-    .set(MoreSaoSubmitNotificationFullNamePage, saoName)
+    .set(NotificationMultiSaoLastOfficerNamePage, saoName)
     .success
     .value
 
@@ -143,7 +143,7 @@ class NotificationMoreSaoFirstStartDateControllerSpec extends SpecBase with Mock
 
       val userAnswers =
         UserAnswers(userAnswersId)
-          .set(MoreSaoSubmitNotificationFullNamePage, saoName)
+          .set(NotificationMultiSaoLastOfficerNamePage, saoName)
           .success
           .value
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()

--- a/test/controllers/notification/NotificationMoreSaoSecondEndDateControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoSecondEndDateControllerSpec.scala
@@ -19,30 +19,30 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.NotificationMoreSaoSecondEndDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerEndDateFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.{NotificationMoreSaoSecondEndDatePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{NotificationMultiSaoPreviousOfficerEndDatePage, NotificationMultiSaoPreviousOfficerNamePage}
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.NotificationMoreSaoSecondEndDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerEndDateView
 
 import scala.concurrent.Future
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with MockitoSugar {
+class NotificationMultiSaoPreviousOfficerEndDateControllerSpec extends SpecBase with MockitoSugar {
 
   private given messages: Messages = stubMessages()
 
-  private val formProvider = new NotificationMoreSaoSecondEndDateFormProvider()
+  private val formProvider = new NotificationMultiSaoPreviousOfficerEndDateFormProvider()
   private def form         = formProvider()
 
   def onwardRoute: Call = Call("GET", "/foo")
@@ -50,8 +50,8 @@ class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with Mocki
   val validAnswer: LocalDate = LocalDate.now(ZoneOffset.UTC)
   val saoName: String        = "Firstname Lastname"
 
-  lazy val notificationMoreSaoSecondEndDateRoute: String =
-    notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(NormalMode).url
+  lazy val notificationMultiSaoPreviousOfficerEndDateRoute: String =
+    notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode).url
 
   val userAnswersWithSaoName: UserAnswers =
     emptyUserAnswers.set(NotificationMultiSaoPreviousOfficerNamePage(0), saoName).success.value
@@ -59,17 +59,17 @@ class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with Mocki
   val saoIndex = 0
 
   def getRequest(): FakeRequest[AnyContentAsEmpty.type] =
-    FakeRequest(GET, notificationMoreSaoSecondEndDateRoute)
+    FakeRequest(GET, notificationMultiSaoPreviousOfficerEndDateRoute)
 
   def postRequest(): FakeRequest[AnyContentAsFormUrlEncoded] =
-    FakeRequest(POST, notificationMoreSaoSecondEndDateRoute)
+    FakeRequest(POST, notificationMultiSaoPreviousOfficerEndDateRoute)
       .withFormUrlEncodedBody(
         "value.day"   -> validAnswer.getDayOfMonth.toString,
         "value.month" -> validAnswer.getMonthValue.toString,
         "value.year"  -> validAnswer.getYear.toString
       )
 
-  "NotificationMoreSaoSecondEndDate Controller" - {
+  "NotificationMultiSaoPreviousOfficerEndDate Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -78,7 +78,7 @@ class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with Mocki
       running(application) {
         val result = route(application, getRequest()).value
 
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondEndDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerEndDateView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(saoName, form, NormalMode, saoIndex)(using
@@ -103,12 +103,12 @@ class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with Mocki
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers =
-        userAnswersWithSaoName.set(NotificationMoreSaoSecondEndDatePage(saoIndex), validAnswer).success.value
+        userAnswersWithSaoName.set(NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex), validAnswer).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondEndDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerEndDateView]
 
         val result = route(application, getRequest()).value
 
@@ -147,13 +147,13 @@ class NotificationMoreSaoSecondEndDateControllerSpec extends SpecBase with Mocki
       val application = applicationBuilder(userAnswers = Some(userAnswersWithSaoName)).build()
 
       val request =
-        FakeRequest(POST, notificationMoreSaoSecondEndDateRoute)
+        FakeRequest(POST, notificationMultiSaoPreviousOfficerEndDateRoute)
           .withFormUrlEncodedBody(("value", "invalid value"))
 
       running(application) {
         val boundForm = form.bind(Map("value" -> "invalid value"))
 
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondEndDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerEndDateView]
 
         val result = route(application, request).value
 

--- a/test/controllers/notification/NotificationMoreSaoSecondStartDateControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoSecondStartDateControllerSpec.scala
@@ -19,38 +19,41 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.NotificationMoreSaoSecondStartDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerStartDateFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.{NotificationMoreSaoSecondStartDatePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{
+  NotificationMultiSaoPreviousOfficerNamePage,
+  NotificationMultiSaoPreviousOfficerStartDatePage
+}
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Call}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.NotificationMoreSaoSecondStartDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerStartDateView
 
 import scala.concurrent.Future
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoSecondStartDateControllerSpec extends SpecBase with MockitoSugar {
+class NotificationMultiSaoPreviousOfficerStartDateControllerSpec extends SpecBase with MockitoSugar {
 
   private given messages: Messages = stubMessages()
 
-  private val formProvider = new NotificationMoreSaoSecondStartDateFormProvider()
+  private val formProvider = new NotificationMultiSaoPreviousOfficerStartDateFormProvider()
   private def form         = formProvider()
 
   def onwardRoute: Call = Call("GET", "/foo")
 
   val validAnswer: LocalDate = LocalDate.now(ZoneOffset.UTC)
 
-  lazy val notificationMoreSaoSecondStartDateRoute: String =
-    notificationRoutes.NotificationMoreSaoSecondStartDateController.onPageLoad(NormalMode).url
+  lazy val notificationMultiSaoPreviousOfficerStartDateRoute: String =
+    notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode).url
 
   val saoName = "Firstname Lastname"
 
@@ -60,17 +63,17 @@ class NotificationMoreSaoSecondStartDateControllerSpec extends SpecBase with Moc
   val saoIndex = 0
 
   def getRequest(): FakeRequest[AnyContentAsEmpty.type] =
-    FakeRequest(GET, notificationMoreSaoSecondStartDateRoute)
+    FakeRequest(GET, notificationMultiSaoPreviousOfficerStartDateRoute)
 
   def postRequest(): FakeRequest[AnyContentAsFormUrlEncoded] =
-    FakeRequest(POST, notificationMoreSaoSecondStartDateRoute)
+    FakeRequest(POST, notificationMultiSaoPreviousOfficerStartDateRoute)
       .withFormUrlEncodedBody(
         "value.day"   -> validAnswer.getDayOfMonth.toString,
         "value.month" -> validAnswer.getMonthValue.toString,
         "value.year"  -> validAnswer.getYear.toString
       )
 
-  "NotificationMoreSaoSecondStartDate Controller" - {
+  "NotificationMultiSaoPreviousOfficerStartDate Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
@@ -79,7 +82,7 @@ class NotificationMoreSaoSecondStartDateControllerSpec extends SpecBase with Moc
       running(application) {
         val result = route(application, getRequest()).value
 
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerStartDateView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(saoName, form, NormalMode, saoIndex)(using
@@ -104,12 +107,15 @@ class NotificationMoreSaoSecondStartDateControllerSpec extends SpecBase with Moc
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers =
-        userAnswersWithSaoName.set(NotificationMoreSaoSecondStartDatePage(saoIndex), validAnswer).success.value
+        userAnswersWithSaoName
+          .set(NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex), validAnswer)
+          .success
+          .value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerStartDateView]
 
         val result = route(application, getRequest()).value
 
@@ -170,13 +176,13 @@ class NotificationMoreSaoSecondStartDateControllerSpec extends SpecBase with Moc
       val application = applicationBuilder(userAnswers = Some(userAnswersWithSaoName)).build()
 
       val request =
-        FakeRequest(POST, notificationMoreSaoSecondStartDateRoute)
+        FakeRequest(POST, notificationMultiSaoPreviousOfficerStartDateRoute)
           .withFormUrlEncodedBody(("value", "invalid value"))
 
       running(application) {
         val boundForm = form.bind(Map("value" -> "invalid value"))
 
-        val view = application.injector.instanceOf[NotificationMoreSaoSecondStartDateView]
+        val view = application.injector.instanceOf[NotificationMultiSaoPreviousOfficerStartDateView]
 
         val result = route(application, request).value
 

--- a/test/controllers/notification/NotificationMultiSaoLastOfficerNameControllerSpec.scala
+++ b/test/controllers/notification/NotificationMultiSaoLastOfficerNameControllerSpec.scala
@@ -25,7 +25,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.{MoreSaoSubmitNotificationFullNamePage, NotificationMultiSaoPreviousOfficerNamePage}
+import pages.notification.{NotificationMultiSaoLastOfficerNamePage, NotificationMultiSaoPreviousOfficerNamePage}
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
@@ -50,7 +50,7 @@ class NotificationMultiSaoPreviousOfficerNameControllerSpec extends SpecBase wit
   val previousSaoName = "Previous Name"
 
   val userAnswersWithSaoName: UserAnswers =
-    emptyUserAnswers.set(MoreSaoSubmitNotificationFullNamePage, saoName).success.value
+    emptyUserAnswers.set(NotificationMultiSaoLastOfficerNamePage, saoName).success.value
 
   val saoIndex = 0
 

--- a/test/controllers/notification/OneSaoSubmitNotificationFullNameControllerSpec.scala
+++ b/test/controllers/notification/OneSaoSubmitNotificationFullNameControllerSpec.scala
@@ -19,45 +19,45 @@ package controllers.notification
 import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
-import forms.notification.OneSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationSingleSaoOfficerNameFormProvider
 import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.notification.OneSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationSingleSaoOfficerNamePage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import repositories.SessionRepository
-import views.html.notification.OneSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationSingleSaoOfficerNameView
 
 import scala.concurrent.Future
 
-class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with MockitoSugar {
+class NotificationSingleSaoOfficerNameControllerSpec extends SpecBase with MockitoSugar {
 
   def onwardRoute: Call = Call("GET", "/foo")
 
-  val formProvider       = new OneSaoSubmitNotificationFullNameFormProvider()
+  val formProvider       = new NotificationSingleSaoOfficerNameFormProvider()
   val form: Form[String] = formProvider()
 
-  lazy val oneSaoSubmitNotificationFullNameRoute: String =
-    notificationRoutes.OneSaoSubmitNotificationFullNameController.onPageLoad(NormalMode).url
+  lazy val notificationSingleSaoOfficerNameRoute: String =
+    notificationRoutes.NotificationSingleSaoOfficerNameController.onPageLoad(NormalMode).url
 
-  "OneSaoSubmitNotificationFullName Controller" - {
+  "NotificationSingleSaoOfficerName Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, oneSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationSingleSaoOfficerNameRoute)
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[OneSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationSingleSaoOfficerNameView]
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(form, NormalMode)(using request, messages(application)).toString
@@ -66,14 +66,14 @@ class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mocki
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(OneSaoSubmitNotificationFullNamePage, "answer").success.value
+      val userAnswers = UserAnswers(userAnswersId).set(NotificationSingleSaoOfficerNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, oneSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationSingleSaoOfficerNameRoute)
 
-        val view = application.injector.instanceOf[OneSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationSingleSaoOfficerNameView]
 
         val result = route(application, request).value
 
@@ -101,7 +101,7 @@ class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mocki
 
       running(application) {
         val request =
-          FakeRequest(POST, oneSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationSingleSaoOfficerNameRoute)
             .withFormUrlEncodedBody(("value", "answer"))
 
         val result = route(application, request).value
@@ -117,12 +117,12 @@ class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mocki
 
       running(application) {
         val request =
-          FakeRequest(POST, oneSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationSingleSaoOfficerNameRoute)
             .withFormUrlEncodedBody(("value", ""))
 
         val boundForm = form.bind(Map("value" -> ""))
 
-        val view = application.injector.instanceOf[OneSaoSubmitNotificationFullNameView]
+        val view = application.injector.instanceOf[NotificationSingleSaoOfficerNameView]
 
         val result = route(application, request).value
 
@@ -136,7 +136,7 @@ class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mocki
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, oneSaoSubmitNotificationFullNameRoute)
+        val request = FakeRequest(GET, notificationSingleSaoOfficerNameRoute)
 
         val result = route(application, request).value
 
@@ -151,7 +151,7 @@ class OneSaoSubmitNotificationFullNameControllerSpec extends SpecBase with Mocki
 
       running(application) {
         val request =
-          FakeRequest(POST, oneSaoSubmitNotificationFullNameRoute)
+          FakeRequest(POST, notificationSingleSaoOfficerNameRoute)
             .withFormUrlEncodedBody(("value", "answer"))
 
         val result = route(application, request).value

--- a/test/controllers/notification/UploadTemplateTableControllerSpec.scala
+++ b/test/controllers/notification/UploadTemplateTableControllerSpec.scala
@@ -74,7 +74,7 @@ class UploadTemplateTableControllerSpec extends SpecBase {
     .set(NotificationMoreThanOneSaoPage, false)
     .success
     .value
-    .set(OneSaoSubmitNotificationFullNamePage, saoName)
+    .set(NotificationSingleSaoOfficerNamePage, saoName)
     .success
     .value
 

--- a/test/controllers/notification/UploadTemplateTableControllerSpec.scala
+++ b/test/controllers/notification/UploadTemplateTableControllerSpec.scala
@@ -116,7 +116,7 @@ class UploadTemplateTableControllerSpec extends SpecBase {
         .set(UploadTemplateTablePage, tableData)
         .success
         .value
-        .set(MoreSaoSubmitNotificationFullNamePage, lastSaoName)
+        .set(NotificationMultiSaoLastOfficerNamePage, lastSaoName)
         .success
         .value
 

--- a/test/forms/notification/NotificationMultiSaoAreAllAddedFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoAreAllAddedFormProviderSpec.scala
@@ -19,12 +19,12 @@ package forms.notification
 import forms.behaviours.BooleanFieldBehaviours
 import play.api.data.FormError
 
-class NotificationMoreSaoAreAllAddedFormProviderSpec extends BooleanFieldBehaviours {
+class NotificationMultiSaoAreAllAddedFormProviderSpec extends BooleanFieldBehaviours {
 
-  val requiredKey = "notificationMoreSaoAreAllAdded.error.required"
+  val requiredKey = "notificationMultiSaoAreAllAdded.error.required"
   val invalidKey  = "error.boolean"
 
-  val form = new NotificationMoreSaoAreAllAddedFormProvider()()
+  val form = new NotificationMultiSaoAreAllAddedFormProvider()()
 
   ".value" - {
 

--- a/test/forms/notification/NotificationMultiSaoLastOfficerNameFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoLastOfficerNameFormProviderSpec.scala
@@ -19,13 +19,13 @@ package forms.notification
 import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 
-class MoreSaoSubmitNotificationFullNameFormProviderSpec extends StringFieldBehaviours {
+class NotificationMultiSaoLastOfficerNameFormProviderSpec extends StringFieldBehaviours {
 
-  val requiredKey = "moreSaoSubmitNotificationFullName.error.required"
-  val lengthKey   = "moreSaoSubmitNotificationFullName.error.length"
+  val requiredKey = "notificationMultiSaoLastOfficerName.error.required"
+  val lengthKey   = "notificationMultiSaoLastOfficerName.error.length"
   val maxLength   = 254
 
-  val form = new MoreSaoSubmitNotificationFullNameFormProvider()()
+  val form = new NotificationMultiSaoLastOfficerNameFormProvider()()
 
   ".value" - {
 

--- a/test/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProviderSpec.scala
@@ -27,10 +27,14 @@ class NotificationMultiSaoLastOfficerStartDateFormProviderSpec extends DateBehav
   private given messages2: Messages = stubMessages()
   val form                          = new NotificationMultiSaoLastOfficerStartDateFormProvider()()
 
+  // LDS ignore
   val requiredAllKey = "notificationMultiSaoLastOfficerStartDate.error.required.all"
+  // LDS ignore
   val requiredTwoKey = "notificationMultiSaoLastOfficerStartDate.error.required.two"
-  val requiredKey    = "notificationMultiSaoLastOfficerStartDate.error.required"
-  val invalidKey     = "notificationMultiSaoLastOfficerStartDate.error.invalid"
+  // LDS ignore
+  val requiredKey = "notificationMultiSaoLastOfficerStartDate.error.required"
+  // LDS ignore
+  val invalidKey = "notificationMultiSaoLastOfficerStartDate.error.invalid"
 
   ".value" - {
 

--- a/test/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoLastOfficerStartDateFormProviderSpec.scala
@@ -22,15 +22,15 @@ import play.api.test.Helpers.stubMessages
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoFirstStartDateFormProviderSpec extends DateBehaviours {
+class NotificationMultiSaoLastOfficerStartDateFormProviderSpec extends DateBehaviours {
 
   private given messages2: Messages = stubMessages()
-  val form                          = new NotificationMoreSaoFirstStartDateFormProvider()()
+  val form                          = new NotificationMultiSaoLastOfficerStartDateFormProvider()()
 
-  val requiredAllKey = "notificationMoreSaoFirstStartDate.error.required.all"
-  val requiredTwoKey = "notificationMoreSaoFirstStartDate.error.required.two"
-  val requiredKey    = "notificationMoreSaoFirstStartDate.error.required"
-  val invalidKey     = "notificationMoreSaoFirstStartDate.error.invalid"
+  val requiredAllKey = "notificationMultiSaoLastOfficerStartDate.error.required.all"
+  val requiredTwoKey = "notificationMultiSaoLastOfficerStartDate.error.required.two"
+  val requiredKey    = "notificationMultiSaoLastOfficerStartDate.error.required"
+  val invalidKey     = "notificationMultiSaoLastOfficerStartDate.error.invalid"
 
   ".value" - {
 

--- a/test/forms/notification/NotificationMultiSaoPreviousOfficerEndDateFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoPreviousOfficerEndDateFormProviderSpec.scala
@@ -22,15 +22,15 @@ import play.api.test.Helpers.stubMessages
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoSecondEndDateFormProviderSpec extends DateBehaviours {
+class NotificationMultiSaoPreviousOfficerEndDateFormProviderSpec extends DateBehaviours {
 
   private given messages2: Messages = stubMessages()
-  val form                          = new NotificationMoreSaoSecondEndDateFormProvider()()
+  val form                          = new NotificationMultiSaoPreviousOfficerEndDateFormProvider()()
 
-  val requiredAllKey = "notificationMoreSaoSecondEndDate.error.required.all"
-  val requiredTwoKey = "notificationMoreSaoSecondEndDate.error.required.two"
-  val requiredKey    = "notificationMoreSaoSecondEndDate.error.required"
-  val invalidKey     = "notificationMoreSaoSecondEndDate.error.invalid"
+  val requiredAllKey = "notificationMultiSaoPreviousOfficerEndDate.error.required.all"
+  val requiredTwoKey = "notificationMultiSaoPreviousOfficerEndDate.error.required.two"
+  val requiredKey    = "notificationMultiSaoPreviousOfficerEndDate.error.required"
+  val invalidKey     = "notificationMultiSaoPreviousOfficerEndDate.error.invalid"
 
   ".value" - {
 

--- a/test/forms/notification/NotificationMultiSaoPreviousOfficerStartDateFormProviderSpec.scala
+++ b/test/forms/notification/NotificationMultiSaoPreviousOfficerStartDateFormProviderSpec.scala
@@ -22,15 +22,15 @@ import play.api.test.Helpers.stubMessages
 
 import java.time.{LocalDate, ZoneOffset}
 
-class NotificationMoreSaoSecondStartDateFormProviderSpec extends DateBehaviours {
+class NotificationMultiSaoPreviousOfficerStartDateFormProviderSpec extends DateBehaviours {
 
   private given messages2: Messages = stubMessages()
-  val form                          = new NotificationMoreSaoSecondStartDateFormProvider()()
+  val form                          = new NotificationMultiSaoPreviousOfficerStartDateFormProvider()()
 
-  val requiredAllKey = "notificationMoreSaoSecondStartDate.error.required.all"
-  val requiredTwoKey = "notificationMoreSaoSecondStartDate.error.required.two"
-  val requiredKey    = "notificationMoreSaoSecondStartDate.error.required"
-  val invalidKey     = "notificationMoreSaoSecondStartDate.error.invalid"
+  val requiredAllKey = "notificationMultiSaoPreviousOfficerStartDate.error.required.all"
+  val requiredTwoKey = "notificationMultiSaoPreviousOfficerStartDate.error.required.two"
+  val requiredKey    = "notificationMultiSaoPreviousOfficerStartDate.error.required"
+  val invalidKey     = "notificationMultiSaoPreviousOfficerStartDate.error.invalid"
 
   ".value input field" - {
 

--- a/test/forms/notification/NotificationSingleSaoOfficerNameFormProviderSpec.scala
+++ b/test/forms/notification/NotificationSingleSaoOfficerNameFormProviderSpec.scala
@@ -19,13 +19,13 @@ package forms.notification
 import forms.behaviours.StringFieldBehaviours
 import play.api.data.FormError
 
-class OneSaoSubmitNotificationFullNameFormProviderSpec extends StringFieldBehaviours {
+class NotificationSingleSaoOfficerNameFormProviderSpec extends StringFieldBehaviours {
 
-  val requiredKey = "oneSaoSubmitNotificationFullName.error.required"
-  val lengthKey   = "oneSaoSubmitNotificationFullName.error.length"
+  val requiredKey = "notificationSingleSaoOfficerName.error.required"
+  val lengthKey   = "notificationSingleSaoOfficerName.error.length"
   val maxLength   = 254
 
-  val form = new OneSaoSubmitNotificationFullNameFormProvider()()
+  val form = new NotificationSingleSaoOfficerNameFormProvider()()
 
   ".value input field" - {
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -193,14 +193,14 @@ class NavigatorSpec extends SpecBase {
           NotificationMultiSaoLastOfficerNamePage,
           NormalMode,
           UserAnswers("id").set(NotificationMoreThanOneSaoPage, true).success.value
-        ) mustBe notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode)
+        ) mustBe notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode)
       }
 
-      "when on NotificationMoreSaoFirstStartDatePage, must go to who was the sao before page" in {
+      "when on NotificationMultiSaoLastOfficerStartDatePage, must go to who was the sao before page" in {
         navigator.nextPage(
-          NotificationMoreSaoFirstStartDatePage,
+          NotificationMultiSaoLastOfficerStartDatePage,
           NormalMode,
-          UserAnswers("id").set(NotificationMoreSaoFirstStartDatePage, LocalDate.of(2026, 5, 1)).success.value
+          UserAnswers("id").set(NotificationMultiSaoLastOfficerStartDatePage, LocalDate.of(2026, 5, 1)).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)
       }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -220,37 +220,37 @@ class NavigatorSpec extends SpecBase {
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode)
       }
 
-      "when on NotificationMultiSaoPreviousOfficerEndDatePage, must go to NotificationMoreSaoAreAllAdded page" in {
+      "when on NotificationMultiSaoPreviousOfficerEndDatePage, must go to NotificationMultiSaoAreAllAdded page" in {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerEndDatePage(0),
           NormalMode,
           UserAnswers("id")
-        ) mustBe notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode)
+        ) mustBe notificationRoutes.NotificationMultiSaoAreAllAddedController.onPageLoad(NormalMode)
       }
 
-      "when on NotificationMoreSaoAreAllAddedPage, and no response is in the database, must throw an exception" in {
+      "when on NotificationMultiSaoAreAllAddedPage, and no response is in the database, must throw an exception" in {
         intercept[NotImplementedError] {
           navigator.nextPage(
-            NotificationMoreSaoAreAllAddedPage(0),
+            NotificationMultiSaoAreAllAddedPage(0),
             NormalMode,
             UserAnswers("id")
           )
         }
       }
 
-      "when on NotificationMoreSaoAreAllAddedPage, and the user answers yes, must go to the notification task list" in {
+      "when on NotificationMultiSaoAreAllAddedPage, and the user answers yes, must go to the notification task list" in {
         navigator.nextPage(
-          NotificationMoreSaoAreAllAddedPage(0),
+          NotificationMultiSaoAreAllAddedPage(0),
           NormalMode,
-          UserAnswers("id").set(NotificationMoreSaoAreAllAddedPage(0), true).success.value
+          UserAnswers("id").set(NotificationMultiSaoAreAllAddedPage(0), true).success.value
         ) mustBe notificationRoutes.NotificationTaskListController.onPageLoad()
       }
 
-      "when on NotificationMoreSaoAreAllAddedPage, and the user answers no, must go to NotificationMultiSaoPreviousOfficerName page with an incremented saoIndex" in {
+      "when on NotificationMultiSaoAreAllAddedPage, and the user answers no, must go to NotificationMultiSaoPreviousOfficerName page with an incremented saoIndex" in {
         navigator.nextPage(
-          NotificationMoreSaoAreAllAddedPage(0),
+          NotificationMultiSaoAreAllAddedPage(0),
           NormalMode,
-          UserAnswers("id").set(NotificationMoreSaoAreAllAddedPage(0), false).success.value
+          UserAnswers("id").set(NotificationMultiSaoAreAllAddedPage(0), false).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode, 1)
       }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -204,17 +204,17 @@ class NavigatorSpec extends SpecBase {
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)
       }
 
-      "when on NotificationMultiSaoPreviousOfficerNamePage, must go to NotificationMoreSaoSecondStartDate" in {
+      "when on NotificationMultiSaoPreviousOfficerNamePage, must go to NotificationMultiSaoPreviousOfficerStartDate" in {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerNamePage(0),
           NormalMode,
           UserAnswers("id")
-        ) mustBe notificationRoutes.NotificationMoreSaoSecondStartDateController.onPageLoad(NormalMode, 0)
+        ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode, 0)
       }
 
-      "when on NotificationMoreSaoSecondStartDatePage, must go to NotificationMoreSaoSecondEndDate page" in {
+      "when on NotificationMultiSaoPreviousOfficerStartDatePage, must go to NotificationMoreSaoSecondEndDate page" in {
         navigator.nextPage(
-          NotificationMoreSaoSecondStartDatePage(0),
+          NotificationMultiSaoPreviousOfficerStartDatePage(0),
           NormalMode,
           UserAnswers("id")
         ) mustBe notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(NormalMode)

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -177,7 +177,7 @@ class NavigatorSpec extends SpecBase {
           NotificationMoreThanOneSaoPage,
           NormalMode,
           UserAnswers("id").set(NotificationMoreThanOneSaoPage, false).success.value
-        ) mustBe notificationRoutes.OneSaoSubmitNotificationFullNameController.onPageLoad(NormalMode)
+        ) mustBe notificationRoutes.NotificationSingleSaoOfficerNameController.onPageLoad(NormalMode)
       }
 
       "when on NotificationMoreThanOneSaoPage and the user selected Yes, must go to multiple sao name page" in {
@@ -254,11 +254,11 @@ class NavigatorSpec extends SpecBase {
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode, 1)
       }
 
-      "when on OneSaoSubmitNotificationFullNamePage, must go to the submit notification start page" in {
+      "when on NotificationSingleSaoOfficerNamePage, must go to the submit notification start page" in {
         navigator.nextPage(
-          OneSaoSubmitNotificationFullNamePage,
+          NotificationSingleSaoOfficerNamePage,
           NormalMode,
-          UserAnswers("id").set(OneSaoSubmitNotificationFullNamePage, "Firstname Lastname").success.value
+          UserAnswers("id").set(NotificationSingleSaoOfficerNamePage, "Firstname Lastname").success.value
         ) mustBe notificationRoutes.NotificationTaskListController.onPageLoad()
       }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -212,17 +212,17 @@ class NavigatorSpec extends SpecBase {
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode, 0)
       }
 
-      "when on NotificationMultiSaoPreviousOfficerStartDatePage, must go to NotificationMoreSaoSecondEndDate page" in {
+      "when on NotificationMultiSaoPreviousOfficerStartDatePage, must go to NotificationMultiSaoPreviousOfficerEndDate page" in {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerStartDatePage(0),
           NormalMode,
           UserAnswers("id")
-        ) mustBe notificationRoutes.NotificationMoreSaoSecondEndDateController.onPageLoad(NormalMode)
+        ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode)
       }
 
-      "when on NotificationMoreSaoSecondEndDatePage, must go to NotificationMoreSaoAreAllAdded page" in {
+      "when on NotificationMultiSaoPreviousOfficerEndDatePage, must go to NotificationMoreSaoAreAllAdded page" in {
         navigator.nextPage(
-          NotificationMoreSaoSecondEndDatePage(0),
+          NotificationMultiSaoPreviousOfficerEndDatePage(0),
           NormalMode,
           UserAnswers("id")
         ) mustBe notificationRoutes.NotificationMoreSaoAreAllAddedController.onPageLoad(NormalMode)

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -185,12 +185,12 @@ class NavigatorSpec extends SpecBase {
           NotificationMoreThanOneSaoPage,
           NormalMode,
           UserAnswers("id").set(NotificationMoreThanOneSaoPage, true).success.value
-        ) mustBe notificationRoutes.MoreSaoSubmitNotificationFullNameController.onPageLoad(NormalMode)
+        ) mustBe notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(NormalMode)
       }
 
-      "when on MoreSaoSubmitNotificationFullNameController, must go to more sao submit notification first date page" in {
+      "when on NotificationMultiSaoLastOfficerNameController, must go to more sao submit notification first date page" in {
         navigator.nextPage(
-          MoreSaoSubmitNotificationFullNamePage,
+          NotificationMultiSaoLastOfficerNamePage,
           NormalMode,
           UserAnswers("id").set(NotificationMoreThanOneSaoPage, true).success.value
         ) mustBe notificationRoutes.NotificationMoreSaoFirstStartDateController.onPageLoad(NormalMode)

--- a/test/services/UploadTemplatePlaybackServiceSpec.scala
+++ b/test/services/UploadTemplatePlaybackServiceSpec.scala
@@ -68,7 +68,7 @@ class UploadTemplatePlaybackServiceSpec extends SpecBase {
         .set(NotificationMoreThanOneSaoPage, false)
         .success
         .value
-        .set(OneSaoSubmitNotificationFullNamePage, "Jane Smith")
+        .set(NotificationSingleSaoOfficerNamePage, "Jane Smith")
         .success
         .value
 
@@ -83,7 +83,7 @@ class UploadTemplatePlaybackServiceSpec extends SpecBase {
         .set(NotificationMoreThanOneSaoPage, true)
         .success
         .value
-        .set(OneSaoSubmitNotificationFullNamePage, "Ignored Name")
+        .set(NotificationSingleSaoOfficerNamePage, "Ignored Name")
         .success
         .value
         .set(NotificationMultiSaoLastOfficerNamePage, "John Smith")
@@ -98,7 +98,7 @@ class UploadTemplatePlaybackServiceSpec extends SpecBase {
         .set(NotificationMoreThanOneSaoPage, false)
         .success
         .value
-        .set(OneSaoSubmitNotificationFullNamePage, "Jane Smith")
+        .set(NotificationSingleSaoOfficerNamePage, "Jane Smith")
         .success
         .value
 
@@ -134,7 +134,7 @@ class UploadTemplatePlaybackServiceSpec extends SpecBase {
         .set(UploadTemplateTablePage, tableData)
         .success
         .value
-        .set(OneSaoSubmitNotificationFullNamePage, "Jane Smith")
+        .set(NotificationSingleSaoOfficerNamePage, "Jane Smith")
         .success
         .value
 

--- a/test/services/UploadTemplatePlaybackServiceSpec.scala
+++ b/test/services/UploadTemplatePlaybackServiceSpec.scala
@@ -86,7 +86,7 @@ class UploadTemplatePlaybackServiceSpec extends SpecBase {
         .set(OneSaoSubmitNotificationFullNamePage, "Ignored Name")
         .success
         .value
-        .set(MoreSaoSubmitNotificationFullNamePage, "John Smith")
+        .set(NotificationMultiSaoLastOfficerNamePage, "John Smith")
         .success
         .value
 

--- a/test/viewmodels/checkAnswers/notification/NotificationMultiSaoAreAllAddedSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationMultiSaoAreAllAddedSummarySpec.scala
@@ -20,31 +20,31 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.NotificationMoreSaoAreAllAddedPage
+import pages.notification.NotificationMultiSaoAreAllAddedPage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
-class NotificationMoreSaoAreAllAddedSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationMultiSaoAreAllAddedSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "NotificationMoreSaoAreAllAddedSummary.row" - {
+  "NotificationMultiSaoAreAllAddedSummary.row" - {
 
-    "when there is no answer for NotificationMoreSaoAreAllAddedPage" - {
+    "when there is no answer for NotificationMultiSaoAreAllAddedPage" - {
       "must return None" in {
-        def SUT = NotificationMoreSaoAreAllAddedSummary.row(emptyUserAnswers, 0)
+        def SUT = NotificationMultiSaoAreAllAddedSummary.row(emptyUserAnswers, 0)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for NotificationMoreSaoAreAllAddedPage" - {
+    "when there is a user answer for NotificationMultiSaoAreAllAddedPage" - {
       def testUserAnswers(answer: Boolean) =
-        emptyUserAnswers.set(NotificationMoreSaoAreAllAddedPage(0), answer).get
+        emptyUserAnswers.set(NotificationMultiSaoAreAllAddedPage(0), answer).get
 
-      def SUT(answer: Boolean = true) = NotificationMoreSaoAreAllAddedSummary.row(testUserAnswers(answer), 0).get
+      def SUT(answer: Boolean = true) = NotificationMultiSaoAreAllAddedSummary.row(testUserAnswers(answer), 0).get
 
       "must have expected key" in {
-        SUT().key mustBe "notificationMoreSaoAreAllAdded".toKey
+        SUT().key mustBe "notificationMultiSaoAreAllAdded".toKey
       }
 
       "expected value" - {
@@ -76,13 +76,13 @@ class NotificationMoreSaoAreAllAddedSummarySpec extends SpecBase with GuiceOneAp
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.NotificationMoreSaoAreAllAddedController
+          action.href mustBe notificationRoutes.NotificationMultiSaoAreAllAddedController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "NotificationMoreSaoAreAllAdded"
+          action.visuallyHiddenText.get mustBe "NotificationMultiSaoAreAllAdded"
         }
       }
     }

--- a/test/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerNameSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerNameSummarySpec.scala
@@ -20,38 +20,38 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.MoreSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationMultiSaoLastOfficerNamePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
-class MoreSaoSubmitNotificationFullNameSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationMultiSaoLastOfficerNameSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "MoreSaoSubmitNotificationFullNameSummary.row" - {
+  "NotificationMultiSaoLastOfficerNameSummary.row" - {
 
-    "when there is no answer for MoreSaoSubmitNotificationFullNamePage" - {
+    "when there is no answer for NotificationMultiSaoLastOfficerNamePage" - {
       "must return None" in {
-        def SUT = MoreSaoSubmitNotificationFullNameSummary.row(emptyUserAnswers)
+        def SUT = NotificationMultiSaoLastOfficerNameSummary.row(emptyUserAnswers)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for MoreSaoSubmitNotificationFullNamePage" - {
+    "when there is a user answer for NotificationMultiSaoLastOfficerNamePage" - {
       def testUserAnswers(answer: String) =
-        emptyUserAnswers.set(MoreSaoSubmitNotificationFullNamePage, answer).get
+        emptyUserAnswers.set(NotificationMultiSaoLastOfficerNamePage, answer).get
 
-      def SUT(answer: String = "") = MoreSaoSubmitNotificationFullNameSummary.row(testUserAnswers(answer)).get
+      def SUT(answer: String = "") = NotificationMultiSaoLastOfficerNameSummary.row(testUserAnswers(answer)).get
 
       "must have expected key" in {
-        SUT().key mustBe "moreSaoSubmitNotificationFullName".toKey
+        SUT().key mustBe "notificationMultiSaoLastOfficerName".toKey
       }
 
       "expected value" - {
-        "must show 'testMoreSaoSubmitNotificationFullName' when user answers is 'testMoreSaoSubmitNotificationFullName'" in {
+        "must show 'testNotificationMultiSaoLastOfficerName' when user answers is 'testNotificationMultiSaoLastOfficerName'" in {
           SUT(answer =
-            "testMoreSaoSubmitNotificationFullName"
-          ).value.content mustBe "testMoreSaoSubmitNotificationFullName".toText
+            "testNotificationMultiSaoLastOfficerName"
+          ).value.content mustBe "testNotificationMultiSaoLastOfficerName".toText
         }
       }
 
@@ -74,13 +74,13 @@ class MoreSaoSubmitNotificationFullNameSummarySpec extends SpecBase with GuiceOn
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.MoreSaoSubmitNotificationFullNameController
+          action.href mustBe notificationRoutes.NotificationMultiSaoLastOfficerNameController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "MoreSaoSubmitNotificationFullName"
+          action.visuallyHiddenText.get mustBe "NotificationMultiSaoLastOfficerName"
         }
       }
     }

--- a/test/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerStartDateSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationMultiSaoLastOfficerStartDateSummarySpec.scala
@@ -20,34 +20,34 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.NotificationMoreSaoFirstStartDatePage
+import pages.notification.NotificationMultiSaoLastOfficerStartDatePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
 import java.time.LocalDate
 
-class NotificationMoreSaoFirstStartDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationMultiSaoLastOfficerStartDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "NotificationMoreSaoFirstStartDateSummary.row" - {
+  "NotificationMultiSaoLastOfficerStartDateSummary.row" - {
 
-    "when there is no answer for NotificationMoreSaoFirstStartDatePage" - {
+    "when there is no answer for NotificationMultiSaoLastOfficerStartDatePage" - {
       "must return None" in {
-        def SUT = NotificationMoreSaoFirstStartDateSummary.row(emptyUserAnswers)
+        def SUT = NotificationMultiSaoLastOfficerStartDateSummary.row(emptyUserAnswers)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for NotificationMoreSaoFirstStartDatePage" - {
+    "when there is a user answer for NotificationMultiSaoLastOfficerStartDatePage" - {
       def testUserAnswers(answer: LocalDate) =
-        emptyUserAnswers.set(NotificationMoreSaoFirstStartDatePage, answer).get
+        emptyUserAnswers.set(NotificationMultiSaoLastOfficerStartDatePage, answer).get
 
       def SUT(answer: LocalDate = LocalDate.now) =
-        NotificationMoreSaoFirstStartDateSummary.row(testUserAnswers(answer)).get
+        NotificationMultiSaoLastOfficerStartDateSummary.row(testUserAnswers(answer)).get
 
       "must have expected key" in {
-        SUT().key mustBe "NotificationMoreSaoFirstStartDate".toKey
+        SUT().key mustBe "NotificationMultiSaoLastOfficerStartDate".toKey
       }
 
       "expected value" - {
@@ -75,13 +75,13 @@ class NotificationMoreSaoFirstStartDateSummarySpec extends SpecBase with GuiceOn
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.NotificationMoreSaoFirstStartDateController
+          action.href mustBe notificationRoutes.NotificationMultiSaoLastOfficerStartDateController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "NotificationMoreSaoFirstStartDate"
+          action.visuallyHiddenText.get mustBe "NotificationMultiSaoLastOfficerStartDate"
         }
       }
     }

--- a/test/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerEndDateSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerEndDateSummarySpec.scala
@@ -20,34 +20,34 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.NotificationMoreSaoSecondEndDatePage
+import pages.notification.NotificationMultiSaoPreviousOfficerEndDatePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
 import java.time.LocalDate
 
-class NotificationMoreSaoSecondEndDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationMultiSaoPreviousOfficerEndDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "NotificationMoreSaoSecondEndDateSummary.row" - {
+  "NotificationMultiSaoPreviousOfficerEndDateSummary.row" - {
 
-    "when there is no answer for NotificationMoreSaoSecondEndDatePage" - {
+    "when there is no answer for NotificationMultiSaoPreviousOfficerEndDatePage" - {
       "must return None" in {
-        def SUT = NotificationMoreSaoSecondEndDateSummary.row(emptyUserAnswers, 0)
+        def SUT = NotificationMultiSaoPreviousOfficerEndDateSummary.row(emptyUserAnswers, 0)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for NotificationMoreSaoSecondEndDatePage" - {
+    "when there is a user answer for NotificationMultiSaoPreviousOfficerEndDatePage" - {
       def testUserAnswers(answer: LocalDate) =
-        emptyUserAnswers.set(NotificationMoreSaoSecondEndDatePage(0), answer).get
+        emptyUserAnswers.set(NotificationMultiSaoPreviousOfficerEndDatePage(0), answer).get
 
       def SUT(answer: LocalDate = LocalDate.now) =
-        NotificationMoreSaoSecondEndDateSummary.row(testUserAnswers(answer), 0).get
+        NotificationMultiSaoPreviousOfficerEndDateSummary.row(testUserAnswers(answer), 0).get
 
       "must have expected key" in {
-        SUT().key mustBe "NotificationMoreSaoSecondEndDate".toKey
+        SUT().key mustBe "NotificationMultiSaoPreviousOfficerEndDate".toKey
       }
 
       "expected value" - {
@@ -75,13 +75,13 @@ class NotificationMoreSaoSecondEndDateSummarySpec extends SpecBase with GuiceOne
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.NotificationMoreSaoSecondEndDateController
+          action.href mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "NotificationMoreSaoSecondEndDate"
+          action.visuallyHiddenText.get mustBe "NotificationMultiSaoPreviousOfficerEndDate"
         }
       }
     }

--- a/test/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerStartDateSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationMultiSaoPreviousOfficerStartDateSummarySpec.scala
@@ -20,34 +20,34 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.NotificationMoreSaoSecondStartDatePage
+import pages.notification.NotificationMultiSaoPreviousOfficerStartDatePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
 import java.time.LocalDate
 
-class NotificationMoreSaoSecondStartDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationMultiSaoPreviousOfficerStartDateSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "NotificationMoreSaoSecondStartDateSummary.row" - {
+  "NotificationMultiSaoPreviousOfficerStartDateSummary.row" - {
 
-    "when there is no answer for NotificationMoreSaoSecondStartDatePage" - {
+    "when there is no answer for NotificationMultiSaoPreviousOfficerStartDatePage" - {
       "must return None" in {
-        def SUT = NotificationMoreSaoSecondStartDateSummary.row(emptyUserAnswers, 0)
+        def SUT = NotificationMultiSaoPreviousOfficerStartDateSummary.row(emptyUserAnswers, 0)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for NotificationMoreSaoSecondStartDatePage" - {
+    "when there is a user answer for NotificationMultiSaoPreviousOfficerStartDatePage" - {
       def testUserAnswers(answer: LocalDate) =
-        emptyUserAnswers.set(NotificationMoreSaoSecondStartDatePage(0), answer).get
+        emptyUserAnswers.set(NotificationMultiSaoPreviousOfficerStartDatePage(0), answer).get
 
       def SUT(answer: LocalDate = LocalDate.now) =
-        NotificationMoreSaoSecondStartDateSummary.row(testUserAnswers(answer), 0).get
+        NotificationMultiSaoPreviousOfficerStartDateSummary.row(testUserAnswers(answer), 0).get
 
       "must have expected key" in {
-        SUT().key mustBe "NotificationMoreSaoSecondStartDate".toKey
+        SUT().key mustBe "NotificationMultiSaoPreviousOfficerStartDate".toKey
       }
 
       "expected value" - {
@@ -75,13 +75,13 @@ class NotificationMoreSaoSecondStartDateSummarySpec extends SpecBase with GuiceO
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.NotificationMoreSaoSecondStartDateController
+          action.href mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "NotificationMoreSaoSecondStartDate"
+          action.visuallyHiddenText.get mustBe "NotificationMultiSaoPreviousOfficerStartDate"
         }
       }
     }

--- a/test/viewmodels/checkAnswers/notification/NotificationSingleSaoOfficerNameSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/notification/NotificationSingleSaoOfficerNameSummarySpec.scala
@@ -20,38 +20,38 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.notification.OneSaoSubmitNotificationFullNamePage
+import pages.notification.NotificationSingleSaoOfficerNamePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 
-class OneSaoSubmitNotificationFullNameSummarySpec extends SpecBase with GuiceOneAppPerSuite {
+class NotificationSingleSaoOfficerNameSummarySpec extends SpecBase with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
-  "OneSaoSubmitNotificationFullNameSummary.row" - {
+  "NotificationSingleSaoOfficerNameSummary.row" - {
 
-    "when there is no answer for OneSaoSubmitNotificationFullNamePage" - {
+    "when there is no answer for NotificationSingleSaoOfficerNamePage" - {
       "must return None" in {
-        def SUT = OneSaoSubmitNotificationFullNameSummary.row(emptyUserAnswers)
+        def SUT = NotificationSingleSaoOfficerNameSummary.row(emptyUserAnswers)
 
         SUT mustBe None
       }
     }
 
-    "when there is a user answer for OneSaoSubmitNotificationFullNamePage" - {
+    "when there is a user answer for NotificationSingleSaoOfficerNamePage" - {
       def testUserAnswers(answer: String) =
-        emptyUserAnswers.set(OneSaoSubmitNotificationFullNamePage, answer).get
+        emptyUserAnswers.set(NotificationSingleSaoOfficerNamePage, answer).get
 
-      def SUT(answer: String = "") = OneSaoSubmitNotificationFullNameSummary.row(testUserAnswers(answer)).get
+      def SUT(answer: String = "") = NotificationSingleSaoOfficerNameSummary.row(testUserAnswers(answer)).get
 
       "must have expected key" in {
-        SUT().key mustBe "oneSaoSubmitNotificationFullName".toKey
+        SUT().key mustBe "notificationSingleSaoOfficerName".toKey
       }
 
       "expected value" - {
-        "must show 'testOneSaoSubmitNotificationFullName' when user answers is 'testOneSaoSubmitNotificationFullName'" in {
+        "must show 'testNotificationSingleSaoOfficerName' when user answers is 'testNotificationSingleSaoOfficerName'" in {
           SUT(answer =
-            "testOneSaoSubmitNotificationFullName"
-          ).value.content mustBe "testOneSaoSubmitNotificationFullName".toText
+            "testNotificationSingleSaoOfficerName"
+          ).value.content mustBe "testNotificationSingleSaoOfficerName".toText
         }
       }
 
@@ -74,13 +74,13 @@ class OneSaoSubmitNotificationFullNameSummarySpec extends SpecBase with GuiceOne
         }
 
         "must have expected url" in {
-          action.href mustBe notificationRoutes.OneSaoSubmitNotificationFullNameController
+          action.href mustBe notificationRoutes.NotificationSingleSaoOfficerNameController
             .onPageLoad(CheckMode)
             .url
         }
 
         "must have expected hidden text" in {
-          action.visuallyHiddenText.get mustBe "OneSaoSubmitNotificationFullName"
+          action.visuallyHiddenText.get mustBe "NotificationSingleSaoOfficerName"
         }
       }
     }

--- a/test/views/notification/NotificationMultiSaoAreAllAddedViewSpec.scala
+++ b/test/views/notification/NotificationMultiSaoAreAllAddedViewSpec.scala
@@ -18,18 +18,18 @@ package views.notification
 
 import base.ViewSpecBase
 import controllers.notification.routes as notificationRoutes
-import forms.notification.NotificationMoreSaoAreAllAddedFormProvider
+import forms.notification.NotificationMultiSaoAreAllAddedFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.NotificationMoreSaoAreAllAddedView
+import views.html.notification.NotificationMultiSaoAreAllAddedView
 
-import NotificationMoreSaoAreAllAddedViewSpec.*
+import NotificationMultiSaoAreAllAddedViewSpec.*
 
-class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMoreSaoAreAllAddedView] {
+class NotificationMultiSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMultiSaoAreAllAddedView] {
 
-  private val formProvider        = app.injector.instanceOf[NotificationMoreSaoAreAllAddedFormProvider]
+  private val formProvider        = app.injector.instanceOf[NotificationMultiSaoAreAllAddedFormProvider]
   private val form: Form[Boolean] = formProvider()
 
   private def generateView(form: Form[Boolean], mode: Mode): Document = {
@@ -46,7 +46,7 @@ class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMo
     }
   }
 
-  "NotificationMoreSaoAreAllAddedView" - {
+  "NotificationMultiSaoAreAllAddedView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -78,7 +78,7 @@ class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMo
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoAreAllAddedController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoAreAllAddedController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -113,7 +113,7 @@ class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMo
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoAreAllAddedController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoAreAllAddedController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -148,7 +148,7 @@ class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMo
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoAreAllAddedController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoAreAllAddedController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -163,7 +163,7 @@ class NotificationMoreSaoAreAllAddedViewSpec extends ViewSpecBase[NotificationMo
 
 }
 
-object NotificationMoreSaoAreAllAddedViewSpec {
+object NotificationMultiSaoAreAllAddedViewSpec {
   val pageHeading = "Have you added all the SAO for the financial year this notification relates to?"
   val pageCaption = "Submit a notification"
   val pageTitle   =

--- a/test/views/notification/NotificationMultiSaoLastOfficerNameViewSpec.scala
+++ b/test/views/notification/NotificationMultiSaoLastOfficerNameViewSpec.scala
@@ -18,18 +18,18 @@ package views.notification
 
 import base.ViewSpecBase
 import controllers.notification.routes as notificationRoutes
-import forms.notification.MoreSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerNameFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.MoreSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationMultiSaoLastOfficerNameView
 
-import MoreSaoSubmitNotificationFullNameViewSpec.*
+import NotificationMultiSaoLastOfficerNameViewSpec.*
 
-class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubmitNotificationFullNameView] {
+class NotificationMultiSaoLastOfficerNameViewSpec extends ViewSpecBase[NotificationMultiSaoLastOfficerNameView] {
 
-  private val formProvider       = app.injector.instanceOf[MoreSaoSubmitNotificationFullNameFormProvider]
+  private val formProvider       = app.injector.instanceOf[NotificationMultiSaoLastOfficerNameFormProvider]
   private val form: Form[String] = formProvider()
 
   private def generateView(form: Form[String], mode: Mode): Document = {
@@ -37,7 +37,7 @@ class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubm
     Jsoup.parse(view.toString)
   }
 
-  "MoreSaoSubmitNotificationFullNameView" - {
+  "NotificationMultiSaoLastOfficerNameView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -65,7 +65,7 @@ class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubm
           doc.createTestsForInputWidth()
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.MoreSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -98,7 +98,7 @@ class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubm
           doc.createTestsForInputWidth()
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.MoreSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -131,7 +131,7 @@ class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubm
           doc.createTestsForInputWidth()
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.MoreSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -144,7 +144,7 @@ class MoreSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[MoreSaoSubm
   }
 }
 
-object MoreSaoSubmitNotificationFullNameViewSpec {
+object NotificationMultiSaoLastOfficerNameViewSpec {
   val pageHeading              = "Senior Accounting Officer details"
   val pageTitle                = "Submit a notification - SAO full name"
   val pageCaption              = "Submit a notification"

--- a/test/views/notification/NotificationMultiSaoLastOfficerStartDateViewSpec.scala
+++ b/test/views/notification/NotificationMultiSaoLastOfficerStartDateViewSpec.scala
@@ -19,20 +19,21 @@ package views.notification
 import base.ViewSpecBase
 import base.ViewSpecBase.DateFieldValues
 import controllers.notification.routes as notificationRoutes
-import forms.notification.NotificationMoreSaoFirstStartDateFormProvider
+import forms.notification.NotificationMultiSaoLastOfficerStartDateFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.NotificationMoreSaoFirstStartDateView
+import views.html.notification.NotificationMultiSaoLastOfficerStartDateView
 
 import java.time.LocalDate
 
-import NotificationMoreSaoFirstStartDateViewSpec.*
+import NotificationMultiSaoLastOfficerStartDateViewSpec.*
 
-class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[NotificationMoreSaoFirstStartDateView] {
+class NotificationMultiSaoLastOfficerStartDateViewSpec
+    extends ViewSpecBase[NotificationMultiSaoLastOfficerStartDateView] {
 
-  private val formProvider          = app.injector.instanceOf[NotificationMoreSaoFirstStartDateFormProvider]
+  private val formProvider          = app.injector.instanceOf[NotificationMultiSaoLastOfficerStartDateFormProvider]
   private val form: Form[LocalDate] = formProvider()
 
   private def generateView(form: Form[LocalDate], mode: Mode): Document = {
@@ -40,7 +41,7 @@ class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[Notificatio
     Jsoup.parse(view.toString)
   }
 
-  "NotificationMoreSaoFirstStartDateView" - {
+  "NotificationMultiSaoLastOfficerStartDateView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -61,7 +62,7 @@ class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[Notificatio
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoFirstStartDateController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -89,7 +90,7 @@ class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[Notificatio
           doc.createTestMustShowHint(pageHint)
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoFirstStartDateController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -117,7 +118,7 @@ class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[Notificatio
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoFirstStartDateController.onSubmit(mode),
+            action = notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -128,7 +129,7 @@ class NotificationMoreSaoFirstStartDateViewSpec extends ViewSpecBase[Notificatio
   }
 }
 
-object NotificationMoreSaoFirstStartDateViewSpec {
+object NotificationMultiSaoLastOfficerStartDateViewSpec {
   val pageHeading = "What date did Firstname Lastname become the SAO?"
   val pageTitle   = "Submit a notification"
   val pageCaption = "Submit a notification"

--- a/test/views/notification/NotificationMultiSaoPreviousOfficerEndDateViewSpec.scala
+++ b/test/views/notification/NotificationMultiSaoPreviousOfficerEndDateViewSpec.scala
@@ -19,20 +19,21 @@ package views.notification
 import base.ViewSpecBase
 import base.ViewSpecBase.DateFieldValues
 import controllers.notification.routes as notificationRoutes
-import forms.notification.NotificationMoreSaoSecondEndDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerEndDateFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.NotificationMoreSaoSecondEndDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerEndDateView
 
 import java.time.LocalDate
 
-import NotificationMoreSaoSecondEndDateViewSpec.*
+import NotificationMultiSaoPreviousOfficerEndDateViewSpec.*
 
-class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[NotificationMoreSaoSecondEndDateView] {
+class NotificationMultiSaoPreviousOfficerEndDateViewSpec
+    extends ViewSpecBase[NotificationMultiSaoPreviousOfficerEndDateView] {
 
-  private val formProvider          = app.injector.instanceOf[NotificationMoreSaoSecondEndDateFormProvider]
+  private val formProvider          = app.injector.instanceOf[NotificationMultiSaoPreviousOfficerEndDateFormProvider]
   private val form: Form[LocalDate] = formProvider()
 
   private def generateView(form: Form[LocalDate], mode: Mode): Document = {
@@ -40,7 +41,7 @@ class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[Notification
     Jsoup.parse(view.toString)
   }
 
-  "NotificationMoreSaoSecondEndDateView" - {
+  "NotificationMultiSaoPreviousOfficerEndDateView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -61,7 +62,7 @@ class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[Notification
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondEndDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -89,7 +90,7 @@ class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[Notification
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondEndDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -117,7 +118,7 @@ class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[Notification
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondEndDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -132,7 +133,7 @@ class NotificationMoreSaoSecondEndDateViewSpec extends ViewSpecBase[Notification
   }
 }
 
-object NotificationMoreSaoSecondEndDateViewSpec {
+object NotificationMultiSaoPreviousOfficerEndDateViewSpec {
   val pageHeading = "When did Firstname Lastname stop being the SAO?"
   val pageTitle   = "Submit a notification"
   val saoIndex    = 3

--- a/test/views/notification/NotificationMultiSaoPreviousOfficerStartDateViewSpec.scala
+++ b/test/views/notification/NotificationMultiSaoPreviousOfficerStartDateViewSpec.scala
@@ -19,20 +19,21 @@ package views.notification
 import base.ViewSpecBase
 import base.ViewSpecBase.DateFieldValues
 import controllers.notification.routes as notificationRoutes
-import forms.notification.NotificationMoreSaoSecondStartDateFormProvider
+import forms.notification.NotificationMultiSaoPreviousOfficerStartDateFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.NotificationMoreSaoSecondStartDateView
+import views.html.notification.NotificationMultiSaoPreviousOfficerStartDateView
 
 import java.time.LocalDate
 
-import NotificationMoreSaoSecondStartDateViewSpec.*
+import NotificationMultiSaoPreviousOfficerStartDateViewSpec.*
 
-class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[NotificationMoreSaoSecondStartDateView] {
+class NotificationMultiSaoPreviousOfficerStartDateViewSpec
+    extends ViewSpecBase[NotificationMultiSaoPreviousOfficerStartDateView] {
 
-  private val formProvider          = app.injector.instanceOf[NotificationMoreSaoSecondStartDateFormProvider]
+  private val formProvider          = app.injector.instanceOf[NotificationMultiSaoPreviousOfficerStartDateFormProvider]
   private val form: Form[LocalDate] = formProvider()
 
   private def generateView(form: Form[LocalDate], mode: Mode): Document = {
@@ -40,7 +41,7 @@ class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[Notificati
     Jsoup.parse(view.toString)
   }
 
-  "NotificationMoreSaoSecondStartDateView" - {
+  "NotificationMultiSaoPreviousOfficerStartDateView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -61,7 +62,7 @@ class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[Notificati
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondStartDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -89,7 +90,7 @@ class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[Notificati
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondStartDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -117,7 +118,7 @@ class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[Notificati
           )
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.NotificationMoreSaoSecondStartDateController.onSubmit(mode, saoIndex),
+            action = notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onSubmit(mode, saoIndex),
             buttonText = "Continue"
           )
 
@@ -132,7 +133,7 @@ class NotificationMoreSaoSecondStartDateViewSpec extends ViewSpecBase[Notificati
   }
 }
 
-object NotificationMoreSaoSecondStartDateViewSpec {
+object NotificationMultiSaoPreviousOfficerStartDateViewSpec {
   val pageHeading = "When did Firstname Lastname’s responsibility as the SAO start?"
   val pageTitle   = "Submit a notification"
   val pageCaption = "Submit a notification"

--- a/test/views/notification/NotificationSingleSaoOfficerNameViewSpec.scala
+++ b/test/views/notification/NotificationSingleSaoOfficerNameViewSpec.scala
@@ -18,18 +18,18 @@ package views.notification
 
 import base.ViewSpecBase
 import controllers.notification.routes as notificationRoutes
-import forms.notification.OneSaoSubmitNotificationFullNameFormProvider
+import forms.notification.NotificationSingleSaoOfficerNameFormProvider
 import models.Mode
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import views.html.notification.OneSaoSubmitNotificationFullNameView
+import views.html.notification.NotificationSingleSaoOfficerNameView
 
-import OneSaoSubmitNotificationFullNameViewSpec.*
+import NotificationSingleSaoOfficerNameViewSpec.*
 
-class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmitNotificationFullNameView] {
+class NotificationSingleSaoOfficerNameViewSpec extends ViewSpecBase[NotificationSingleSaoOfficerNameView] {
 
-  private val formProvider       = app.injector.instanceOf[OneSaoSubmitNotificationFullNameFormProvider]
+  private val formProvider       = app.injector.instanceOf[NotificationSingleSaoOfficerNameFormProvider]
   private val form: Form[String] = formProvider()
 
   private def generateView(form: Form[String], mode: Mode): Document = {
@@ -37,7 +37,7 @@ class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmit
     Jsoup.parse(view.toString)
   }
 
-  "OneSaoSubmitNotificationFullNameView" - {
+  "NotificationSingleSaoOfficerNameView" - {
 
     Mode.values.foreach { mode =>
       s"when using $mode" - {
@@ -65,7 +65,7 @@ class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmit
           doc.createTestsWithLargeCaption(pageCaption)
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.OneSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationSingleSaoOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -98,7 +98,7 @@ class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmit
           doc.createTestsWithLargeCaption(pageCaption)
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.OneSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationSingleSaoOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -131,7 +131,7 @@ class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmit
           doc.createTestsWithLargeCaption(pageCaption)
 
           doc.createTestsWithSubmissionButton(
-            action = notificationRoutes.OneSaoSubmitNotificationFullNameController.onSubmit(mode),
+            action = notificationRoutes.NotificationSingleSaoOfficerNameController.onSubmit(mode),
             buttonText = "Continue"
           )
 
@@ -144,7 +144,7 @@ class OneSaoSubmitNotificationFullNameViewSpec extends ViewSpecBase[OneSaoSubmit
   }
 }
 
-object OneSaoSubmitNotificationFullNameViewSpec {
+object NotificationSingleSaoOfficerNameViewSpec {
   val pageHeading = "What is the name of the SAO?"
   val pageTitle   = "Submit a notification - SAO full name"
   val pageCaption = "Submit a notification"


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* refactored notification files as per dev discussions
   * MoreSaoSubmitNotificationFullName* -> NotificationMultiSaoLastOfficerName*
   * NotificationMoreSaoFirstStartDate* -> NotificationMultiSaoLastOfficerStartDate*
   * NotificationMoreSaoSecondStartDate* -> NotificationMultiSaoPreviousOfficerStartDate*
   * NotificationMoreSaoSecondEndDate* -> NotificationMultiSaoPreviousOfficerEndDate*
   * NotificationMoreSaoAreAllAdded*-> NotificationMultiSaoAreAllAdded*
   * OneSaoSubmitNotificationFullName* -> NotificationSingleSaoOfficerName*

## Jira ticket(s):
* No Jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [ ] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * will cause conflict with [PR 144](https://github.com/hmrc/senior-accounting-officer-submission-frontend/pull/144)
