### PR TITLE
NoJira/refactored mongo path for notification & certificate pages

### DIFF
--- a/app/models/notification/NotificationStage.scala
+++ b/app/models/notification/NotificationStage.scala
@@ -19,6 +19,7 @@ package models.notification
 import models.TaskStatus.{CannotStartYet, Completed, NotStarted}
 import models.{TaskStatus, UserAnswers}
 import pages.*
+import pages.Page.NOTIFICATION_PATH
 import pages.notification.*
 import play.api.libs.json.*
 
@@ -76,7 +77,7 @@ object NotificationStage {
     }
 
   private def hasCompletedMoreSaoDetails(userAnswers: UserAnswers): Boolean =
-    (userAnswers.data \ NotificationMultiSaoAreAllAddedPage(0).key)
+    (userAnswers.data \ NOTIFICATION_PATH \ NotificationMultiSaoAreAllAddedPage(0).key)
       .asOpt[Seq[Boolean]]
       .exists(_.contains(true))
 

--- a/app/models/upload/ParsedSubmissionRow.scala
+++ b/app/models/upload/ParsedSubmissionRow.scala
@@ -16,8 +16,8 @@
 
 package models.upload
 
-import models.UnqualifiedCompany
 import models.QualifiedCompany
+import models.UnqualifiedCompany
 import play.api.libs.json.*
 
 import scala.util.Try

--- a/app/models/upscan/UploadJourney.scala
+++ b/app/models/upscan/UploadJourney.scala
@@ -17,15 +17,27 @@
 package models.upscan
 
 import pages.CertificateUploadStatePage
+import pages.Page.{CERTIFICATE_PATH, NOTIFICATION_PATH}
 import pages.notification.NotificationUploadStatePage
 import queries.{Gettable, Settable}
 
 enum UploadJourney(
     override val toString: String,
-    val page: Gettable[FileUploadState] with Settable[FileUploadState]
+    val page: Gettable[FileUploadState] with Settable[FileUploadState],
+    val uploadPath: String
 ) {
-  case Notification extends UploadJourney("notification", NotificationUploadStatePage)
-  case Certificate  extends UploadJourney("certificate", CertificateUploadStatePage)
+  case Notification
+      extends UploadJourney(
+        "notification",
+        NotificationUploadStatePage,
+        s"data.$NOTIFICATION_PATH.$NotificationUploadStatePage"
+      )
+  case Certificate
+      extends UploadJourney(
+        "certificate",
+        CertificateUploadStatePage,
+        s"data.$CERTIFICATE_PATH.$CertificateUploadStatePage"
+      )
 }
 
 object UploadJourney {

--- a/app/pages/CertificateAdditionalInformationPage.scala
+++ b/app/pages/CertificateAdditionalInformationPage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateAdditionalInformationPage extends QuestionPage[Option[String]] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateAdditionalInformation"
 }

--- a/app/pages/CertificateDeclarationSaoPage.scala
+++ b/app/pages/CertificateDeclarationSaoPage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateDeclarationSaoPage extends QuestionPage[String] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateDeclarationSao"
 }

--- a/app/pages/CertificateDeclarationStandInPage.scala
+++ b/app/pages/CertificateDeclarationStandInPage.scala
@@ -17,11 +17,12 @@
 package pages
 
 import models.CertificateDeclarationStandIn
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateDeclarationStandInPage extends QuestionPage[CertificateDeclarationStandIn] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateDeclarationStandIn"
 }

--- a/app/pages/CertificateReviewQualifiedPage.scala
+++ b/app/pages/CertificateReviewQualifiedPage.scala
@@ -16,10 +16,11 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateReviewQualifiedPage extends QuestionPage[Boolean] {
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateReviewQualifiedPage"
 }

--- a/app/pages/CertificateReviewUnqualifiedPage.scala
+++ b/app/pages/CertificateReviewUnqualifiedPage.scala
@@ -16,10 +16,11 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateReviewUnqualifiedPage extends QuestionPage[Boolean] {
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateUnreviewQualifiedPage"
+  override def toString: String = "certificateReviewUnqualifiedPage"
 }

--- a/app/pages/CertificateSaoEmailPage.scala
+++ b/app/pages/CertificateSaoEmailPage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateSaoEmailPage extends QuestionPage[String] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateSaoEmail"
 }

--- a/app/pages/CertificateSaoFullNamePage.scala
+++ b/app/pages/CertificateSaoFullNamePage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateSaoFullNamePage extends QuestionPage[String] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateSaoFullName"
 }

--- a/app/pages/CertificateUploadStatePage.scala
+++ b/app/pages/CertificateUploadStatePage.scala
@@ -17,11 +17,12 @@
 package pages
 
 import models.upscan.FileUploadState
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateUploadStatePage extends QuestionPage[FileUploadState] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateUpload"
 }

--- a/app/pages/CertificateWhoIsSubmittingPage.scala
+++ b/app/pages/CertificateWhoIsSubmittingPage.scala
@@ -17,11 +17,12 @@
 package pages
 
 import models.CertificateWhoIsSubmitting
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object CertificateWhoIsSubmittingPage extends QuestionPage[CertificateWhoIsSubmitting] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "certificateWhoIsSubmitting"
 }

--- a/app/pages/IsThisTheSaoOnCertificatePage.scala
+++ b/app/pages/IsThisTheSaoOnCertificatePage.scala
@@ -16,11 +16,12 @@
 
 package pages
 
+import pages.Page.CERTIFICATE_PATH
 import play.api.libs.json.JsPath
 
 case object IsThisTheSaoOnCertificatePage extends QuestionPage[Boolean] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
   override def toString: String = "isThisTheSaoOnCertificate"
 }

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -21,4 +21,7 @@ trait Page
 object Page {
 
   given Conversion[Page, String] = (page: Page) => page.toString
+
+  val NOTIFICATION_PATH = "notification"
+  val CERTIFICATE_PATH  = "certificate"
 }

--- a/app/pages/notification/ConfirmYourNotificationPage.scala
+++ b/app/pages/notification/ConfirmYourNotificationPage.scala
@@ -17,4 +17,4 @@
 package pages.notification
 import pages.Page
 
-case object ConfirmYourNotificationPage extends Page {}
+case object ConfirmYourNotificationPage extends Page

--- a/app/pages/notification/NotificationAdditionalInformationPage.scala
+++ b/app/pages/notification/NotificationAdditionalInformationPage.scala
@@ -16,12 +16,13 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object NotificationAdditionalInformationPage extends QuestionPage[Option[String]] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationAdditionalInformation"
 }

--- a/app/pages/notification/NotificationMoreThanOneSaoPage.scala
+++ b/app/pages/notification/NotificationMoreThanOneSaoPage.scala
@@ -16,12 +16,13 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object NotificationMoreThanOneSaoPage extends QuestionPage[Boolean] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationMoreThanOneSao"
 }

--- a/app/pages/notification/NotificationMultiSaoAreAllAddedPage.scala
+++ b/app/pages/notification/NotificationMultiSaoAreAllAddedPage.scala
@@ -16,6 +16,7 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -23,7 +24,7 @@ final case class NotificationMultiSaoAreAllAddedPage(saoIndex: Int) extends Ques
 
   val key = "notificationMultiSaoAreAllAdded"
 
-  override def path: JsPath = JsPath \ key \ saoIndex
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ key \ saoIndex
 
   override def toString: String = s"$key[$saoIndex]"
 }

--- a/app/pages/notification/NotificationMultiSaoLastOfficerNamePage.scala
+++ b/app/pages/notification/NotificationMultiSaoLastOfficerNamePage.scala
@@ -16,12 +16,13 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object NotificationMultiSaoLastOfficerNamePage extends QuestionPage[String] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationMultiSaoLastOfficerName"
 }

--- a/app/pages/notification/NotificationMultiSaoLastOfficerStartDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoLastOfficerStartDatePage.scala
@@ -16,6 +16,7 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -23,7 +24,7 @@ import java.time.LocalDate
 
 case object NotificationMultiSaoLastOfficerStartDatePage extends QuestionPage[LocalDate] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationMultiSaoLastOfficerStartDate"
 }

--- a/app/pages/notification/NotificationMultiSaoPreviousOfficerEndDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoPreviousOfficerEndDatePage.scala
@@ -16,6 +16,7 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -25,7 +26,7 @@ final case class NotificationMultiSaoPreviousOfficerEndDatePage(saoIndex: Int) e
 
   val key = "notificationMultiSaoPreviousOfficerEndDate"
 
-  override def path: JsPath = JsPath \ key \ saoIndex
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ key \ saoIndex
 
   override def toString: String = s"$key[$saoIndex]"
 }

--- a/app/pages/notification/NotificationMultiSaoPreviousOfficerNamePage.scala
+++ b/app/pages/notification/NotificationMultiSaoPreviousOfficerNamePage.scala
@@ -16,6 +16,7 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -23,7 +24,7 @@ final case class NotificationMultiSaoPreviousOfficerNamePage(saoIndex: Int) exte
 
   val key = "notificationMultiSaoPreviousOfficerName"
 
-  override def path: JsPath = JsPath \ key \ saoIndex
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ key \ saoIndex
 
   override def toString: String = s"$key[$saoIndex]"
 }

--- a/app/pages/notification/NotificationMultiSaoPreviousOfficerStartDatePage.scala
+++ b/app/pages/notification/NotificationMultiSaoPreviousOfficerStartDatePage.scala
@@ -16,6 +16,7 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -25,7 +26,7 @@ final case class NotificationMultiSaoPreviousOfficerStartDatePage(saoIndex: Int)
 
   val key = "notificationMultiSaoPreviousOfficerStartDate"
 
-  override def path: JsPath = JsPath \ key \ saoIndex
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ key \ saoIndex
 
   override def toString: String = s"$key[$saoIndex]"
 }

--- a/app/pages/notification/NotificationSingleSaoOfficerNamePage.scala
+++ b/app/pages/notification/NotificationSingleSaoOfficerNamePage.scala
@@ -16,12 +16,13 @@
 
 package pages.notification
 
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object NotificationSingleSaoOfficerNamePage extends QuestionPage[String] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationSingleSaoOfficerName"
 }

--- a/app/pages/notification/NotificationUploadStatePage.scala
+++ b/app/pages/notification/NotificationUploadStatePage.scala
@@ -17,12 +17,13 @@
 package pages.notification
 
 import models.upscan.FileUploadState
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object NotificationUploadStatePage extends QuestionPage[FileUploadState] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "notificationUpload"
 }

--- a/app/pages/notification/UploadTemplateTablePage.scala
+++ b/app/pages/notification/UploadTemplateTablePage.scala
@@ -17,12 +17,13 @@
 package pages.notification
 
 import models.upload.UploadTemplateTableData
+import pages.Page.NOTIFICATION_PATH
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
 case object UploadTemplateTablePage extends QuestionPage[UploadTemplateTableData] {
 
-  override def path: JsPath = JsPath \ toString
+  override def path: JsPath = JsPath \ NOTIFICATION_PATH \ toString
 
   override def toString: String = "uploadTemplateTable"
 }

--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -45,11 +45,11 @@ class SessionRepository @Inject() (
       mongoComponent = mongoComponent,
       domainFormat = UserAnswers.format,
       indexes = UploadJourney.values.toSeq.map { journey =>
-        val uploadKey = journey.page.toString
+        val uploadKey = journey.uploadPath
 
         IndexModel(
-          Indexes.ascending(s"data.$uploadKey.reference"),
-          IndexOptions().name(s"${uploadKey}ReferenceIdx").unique(true).sparse(true)
+          Indexes.ascending(s"$uploadKey.reference"),
+          IndexOptions().name(s"${journey}ReferenceIdx").unique(true).sparse(true)
         )
       } ++ Seq(
         IndexModel(
@@ -106,7 +106,7 @@ class SessionRepository @Inject() (
 
   def updateUploadStatus(journey: UploadJourney, reference: String, newStatus: UploadStatus): Future[Boolean] =
     Mdc.preservingMdc {
-      val uploadPath = s"data.${journey.page.toString}"
+      val uploadPath = journey.uploadPath
 
       collection
         .updateOne(

--- a/test/controllers/CertificateDeclarationStandInControllerSpec.scala
+++ b/test/controllers/CertificateDeclarationStandInControllerSpec.scala
@@ -24,6 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import pages.CertificateDeclarationStandInPage
+import pages.Page.CERTIFICATE_PATH
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.libs.json.Json
@@ -48,9 +49,11 @@ class CertificateDeclarationStandInControllerSpec extends SpecBase with MockitoS
   val userAnswers: UserAnswers = UserAnswers(
     userAnswersId,
     Json.obj(
-      CertificateDeclarationStandInPage.toString -> Json.obj(
-        "StandInName" -> "value 1",
-        "SaoName"     -> "value 2"
+      CERTIFICATE_PATH -> Json.obj(
+        CertificateDeclarationStandInPage.toString -> Json.obj(
+          "StandInName" -> "value 1",
+          "SaoName"     -> "value 2"
+        )
       )
     )
   )

--- a/test/models/upload/ParsedSubmissionRowSpec.scala
+++ b/test/models/upload/ParsedSubmissionRowSpec.scala
@@ -17,8 +17,8 @@
 package models.upload
 
 import base.SpecBase
-import models.UnqualifiedCompany
 import models.QualifiedCompany
+import models.UnqualifiedCompany
 import models.upload.ParsedSubmissionRowSpec.*
 import play.api.libs.json.{JsError, JsString, Json}
 


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Refactored the mongo path so that notification and certificate data are filed under their distinct top level objects

## Jira ticket(s):
* no jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
