### PR TITLE
No Jira: moved certificate pages into certificate package

### DIFF
--- a/app/controllers/certificate/CertificateAdditionalInformationController.scala
+++ b/app/controllers/certificate/CertificateAdditionalInformationController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import forms.certificate.CertificateAdditionalInformationFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.CertificateAdditionalInformationPage
+import pages.certificate.CertificateAdditionalInformationPage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}

--- a/app/controllers/certificate/CertificateConfirmationController.scala
+++ b/app/controllers/certificate/CertificateConfirmationController.scala
@@ -19,7 +19,7 @@ package controllers.certificate
 import controllers.actions.*
 import models.NormalMode
 import navigation.Navigator
-import pages.CertificateConfirmationPage
+import pages.certificate.CertificateConfirmationPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/controllers/certificate/CertificateDeclarationSaoController.scala
+++ b/app/controllers/certificate/CertificateDeclarationSaoController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import forms.certificate.CertificateDeclarationSaoFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.CertificateDeclarationSaoPage
+import pages.certificate.CertificateDeclarationSaoPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateDeclarationStandInController.scala
+++ b/app/controllers/certificate/CertificateDeclarationStandInController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import forms.certificate.CertificateDeclarationStandInFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.CertificateDeclarationStandInPage
+import pages.certificate.CertificateDeclarationStandInPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateReviewQualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewQualifiedController.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import models.NormalMode
 import models.upload.*
 import navigation.Navigator
-import pages.{CertificateReviewQualifiedPage, CertificateSaoFullNamePage}
+import pages.certificate.{CertificateReviewQualifiedPage, CertificateSaoFullNamePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import models.NormalMode
 import models.upload.*
 import navigation.Navigator
-import pages.{CertificateReviewUnqualifiedPage, CertificateSaoFullNamePage}
+import pages.certificate.{CertificateReviewUnqualifiedPage, CertificateSaoFullNamePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateSaoEmailController.scala
+++ b/app/controllers/certificate/CertificateSaoEmailController.scala
@@ -21,7 +21,7 @@ import controllers.routes
 import forms.certificate.CertificateSaoEmailFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.{CertificateSaoEmailPage, CertificateSaoFullNamePage}
+import pages.certificate.{CertificateSaoEmailPage, CertificateSaoFullNamePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateSaoFullNameController.scala
+++ b/app/controllers/certificate/CertificateSaoFullNameController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import forms.certificate.CertificateSaoFullNameFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.CertificateSaoFullNamePage
+import pages.certificate.CertificateSaoFullNamePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/CertificateWhoIsSubmittingController.scala
+++ b/app/controllers/certificate/CertificateWhoIsSubmittingController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import forms.certificate.CertificateWhoIsSubmittingFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.CertificateWhoIsSubmittingPage
+import pages.certificate.CertificateWhoIsSubmittingPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository

--- a/app/controllers/certificate/QualifiedCompaniesController.scala
+++ b/app/controllers/certificate/QualifiedCompaniesController.scala
@@ -19,7 +19,7 @@ package controllers.certificate
 import controllers.actions.*
 import models.NormalMode
 import navigation.Navigator
-import pages.QualifiedCompaniesPage
+import pages.certificate.QualifiedCompaniesPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/controllers/certificate/UnqualifiedCompaniesController.scala
+++ b/app/controllers/certificate/UnqualifiedCompaniesController.scala
@@ -19,7 +19,7 @@ package controllers.certificate
 import controllers.actions.*
 import models.NormalMode
 import navigation.Navigator
-import pages.UnqualifiedCompaniesPage
+import pages.certificate.UnqualifiedCompaniesPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/models/upscan/UploadJourney.scala
+++ b/app/models/upscan/UploadJourney.scala
@@ -16,8 +16,8 @@
 
 package models.upscan
 
-import pages.CertificateUploadStatePage
 import pages.Page.{CERTIFICATE_PATH, NOTIFICATION_PATH}
+import pages.certificate.CertificateUploadStatePage
 import pages.notification.NotificationUploadStatePage
 import play.api.mvc.QueryStringBindable
 import queries.{Gettable, Settable}

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -24,6 +24,7 @@ import models.certificate.{CertificateTaskListStage, CertificateWhoIsSubmitting}
 import models.notification.NotificationIdReferenceNumber
 import models.upload.UploadTemplateTableData
 import pages.*
+import pages.certificate.*
 import pages.notification.*
 import play.api.mvc.Call
 

--- a/app/pages/certificate/CertificateAdditionalInformationPage.scala
+++ b/app/pages/certificate/CertificateAdditionalInformationPage.scala
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateReviewQualifiedPage extends QuestionPage[Boolean] {
+case object CertificateAdditionalInformationPage extends QuestionPage[Option[String]] {
+
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateReviewQualifiedPage"
+  override def toString: String = "certificateAdditionalInformation"
 }

--- a/app/pages/certificate/CertificateConfirmationPage.scala
+++ b/app/pages/certificate/CertificateConfirmationPage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
+import pages.Page
 
-import models.upscan.FileUploadState
-import pages.Page.CERTIFICATE_PATH
-import play.api.libs.json.JsPath
-
-case object CertificateUploadStatePage extends QuestionPage[FileUploadState] {
-
-  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
-
-  override def toString: String = "certificateUpload"
-}
+case object CertificateConfirmationPage extends Page

--- a/app/pages/certificate/CertificateDeclarationSaoPage.scala
+++ b/app/pages/certificate/CertificateDeclarationSaoPage.scala
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateSaoEmailPage extends QuestionPage[String] {
+case object CertificateDeclarationSaoPage extends QuestionPage[String] {
 
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateSaoEmail"
+  override def toString: String = "certificateDeclarationSao"
 }

--- a/app/pages/certificate/CertificateDeclarationStandInPage.scala
+++ b/app/pages/certificate/CertificateDeclarationStandInPage.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
-import models.certificate.CertificateWhoIsSubmitting
+import models.certificate.CertificateDeclarationStandIn
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateWhoIsSubmittingPage extends QuestionPage[CertificateWhoIsSubmitting] {
+case object CertificateDeclarationStandInPage extends QuestionPage[CertificateDeclarationStandIn] {
 
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateWhoIsSubmitting"
+  override def toString: String = "certificateDeclarationStandIn"
 }

--- a/app/pages/certificate/CertificateReviewQualifiedPage.scala
+++ b/app/pages/certificate/CertificateReviewQualifiedPage.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateAdditionalInformationPage extends QuestionPage[Option[String]] {
-
+case object CertificateReviewQualifiedPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateAdditionalInformation"
+  override def toString: String = "certificateReviewQualifiedPage"
 }

--- a/app/pages/certificate/CertificateReviewUnqualifiedPage.scala
+++ b/app/pages/certificate/CertificateReviewUnqualifiedPage.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateSaoFullNamePage extends QuestionPage[String] {
-
+case object CertificateReviewUnqualifiedPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateSaoFullName"
+  override def toString: String = "certificateReviewUnqualifiedPage"
 }

--- a/app/pages/certificate/CertificateSaoEmailPage.scala
+++ b/app/pages/certificate/CertificateSaoEmailPage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
-case object CertificateSubmittedPage extends Page
+import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object CertificateSaoEmailPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
+
+  override def toString: String = "certificateSaoEmail"
+}

--- a/app/pages/certificate/CertificateSaoFullNamePage.scala
+++ b/app/pages/certificate/CertificateSaoFullNamePage.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
-import models.certificate.CertificateDeclarationStandIn
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateDeclarationStandInPage extends QuestionPage[CertificateDeclarationStandIn] {
+case object CertificateSaoFullNamePage extends QuestionPage[String] {
 
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateDeclarationStandIn"
+  override def toString: String = "certificateSaoFullName"
 }

--- a/app/pages/certificate/CertificateSubmittedPage.scala
+++ b/app/pages/certificate/CertificateSubmittedPage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
+import pages.Page
 
-import pages.Page.CERTIFICATE_PATH
-import play.api.libs.json.JsPath
-
-case object CertificateReviewUnqualifiedPage extends QuestionPage[Boolean] {
-  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
-
-  override def toString: String = "certificateReviewUnqualifiedPage"
-}
+case object CertificateSubmittedPage extends Page

--- a/app/pages/certificate/CertificateUploadStatePage.scala
+++ b/app/pages/certificate/CertificateUploadStatePage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
-case object CertificateConfirmationPage extends Page
+import models.upscan.FileUploadState
+import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object CertificateUploadStatePage extends QuestionPage[FileUploadState] {
+
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
+
+  override def toString: String = "certificateUpload"
+}

--- a/app/pages/certificate/CertificateWhoIsSubmittingPage.scala
+++ b/app/pages/certificate/CertificateWhoIsSubmittingPage.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
 
+import models.certificate.CertificateWhoIsSubmitting
 import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
 import play.api.libs.json.JsPath
 
-case object CertificateDeclarationSaoPage extends QuestionPage[String] {
+case object CertificateWhoIsSubmittingPage extends QuestionPage[CertificateWhoIsSubmitting] {
 
   override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
 
-  override def toString: String = "certificateDeclarationSao"
+  override def toString: String = "certificateWhoIsSubmitting"
 }

--- a/app/pages/certificate/QualifiedCompaniesPage.scala
+++ b/app/pages/certificate/QualifiedCompaniesPage.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
+import pages.Page
 
-case object UnqualifiedCompaniesPage extends Page
+case object QualifiedCompaniesPage extends Page

--- a/app/pages/certificate/UnqualifiedCompaniesPage.scala
+++ b/app/pages/certificate/UnqualifiedCompaniesPage.scala
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-package pages
+package pages.certificate
+import pages.Page
 
-case object QualifiedCompaniesPage extends Page
+case object UnqualifiedCompaniesPage extends Page

--- a/app/utils/CertificateStageHelper.scala
+++ b/app/utils/CertificateStageHelper.scala
@@ -17,10 +17,7 @@
 package utils
 
 import models.UserAnswers
-import pages.CertificateReviewQualifiedPage
-import pages.CertificateReviewUnqualifiedPage
-import pages.CertificateSaoEmailPage
-import pages.CertificateSaoFullNamePage
+import pages.certificate.*
 
 object CertificateStageHelper {
   def isProvideSaoDetailsStageCompleted(userAnswers: UserAnswers): Boolean = {

--- a/app/viewmodels/checkAnswers/certificate/CertificateAdditionalInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateAdditionalInformationSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateAdditionalInformationPage
+import pages.certificate.CertificateAdditionalInformationPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*

--- a/app/viewmodels/checkAnswers/certificate/CertificateDeclarationSaoSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateDeclarationSaoSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateDeclarationSaoPage
+import pages.certificate.CertificateDeclarationSaoPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*

--- a/app/viewmodels/checkAnswers/certificate/CertificateDeclarationStandInSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateDeclarationStandInSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateDeclarationStandInPage
+import pages.certificate.CertificateDeclarationStandInPage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/app/viewmodels/checkAnswers/certificate/CertificateSaoEmailSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateSaoEmailSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateSaoEmailPage
+import pages.certificate.CertificateSaoEmailPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*

--- a/app/viewmodels/checkAnswers/certificate/CertificateSaoFullNameSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateSaoFullNameSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateSaoFullNamePage
+import pages.certificate.CertificateSaoFullNamePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.converters.*

--- a/app/viewmodels/checkAnswers/certificate/CertificateWhoIsSubmittingSummary.scala
+++ b/app/viewmodels/checkAnswers/certificate/CertificateWhoIsSubmittingSummary.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.{CheckMode, UserAnswers}
-import pages.CertificateWhoIsSubmittingPage
+import pages.certificate.CertificateWhoIsSubmittingPage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/it/test/repositories/SessionRepositoryISpec.scala
+++ b/it/test/repositories/SessionRepositoryISpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.slf4j.MDC
-import pages.CertificateUploadStatePage
+import pages.certificate.CertificateUploadStatePage
 import pages.notification.NotificationUploadStatePage
 import play.api.libs.json.Json
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -24,6 +24,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.{OptionValues, TryValues}
 import pages.*
+import pages.certificate.*
 import pages.notification.*
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/controllers/certificate/CertificateAdditionalInformationControllerSpec.scala
+++ b/test/controllers/certificate/CertificateAdditionalInformationControllerSpec.scala
@@ -26,7 +26,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CertificateAdditionalInformationPage
+import pages.certificate.CertificateAdditionalInformationPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call

--- a/test/controllers/certificate/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/certificate/CertificateDeclarationSaoControllerSpec.scala
@@ -25,7 +25,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CertificateDeclarationSaoPage
+import pages.certificate.CertificateDeclarationSaoPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call

--- a/test/controllers/certificate/CertificateDeclarationStandInControllerSpec.scala
+++ b/test/controllers/certificate/CertificateDeclarationStandInControllerSpec.scala
@@ -26,8 +26,8 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CertificateDeclarationStandInPage
 import pages.Page.CERTIFICATE_PATH
+import pages.certificate.CertificateDeclarationStandInPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.libs.json.Json

--- a/test/controllers/certificate/CertificateSaoEmailControllerSpec.scala
+++ b/test/controllers/certificate/CertificateSaoEmailControllerSpec.scala
@@ -25,7 +25,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{CertificateSaoEmailPage, CertificateSaoFullNamePage}
+import pages.certificate.{CertificateSaoEmailPage, CertificateSaoFullNamePage}
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call

--- a/test/controllers/certificate/CertificateSaoFullNameControllerSpec.scala
+++ b/test/controllers/certificate/CertificateSaoFullNameControllerSpec.scala
@@ -25,7 +25,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CertificateSaoFullNamePage
+import pages.certificate.CertificateSaoFullNamePage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call

--- a/test/controllers/certificate/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/certificate/CertificateWhoIsSubmittingControllerSpec.scala
@@ -26,7 +26,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.CertificateWhoIsSubmittingPage
+import pages.certificate.CertificateWhoIsSubmittingPage
 import play.api.data.Form
 import play.api.inject.bind
 import play.api.mvc.Call

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -24,6 +24,7 @@ import models.*
 import models.certificate.{CertificateTaskListStage, CertificateWhoIsSubmitting}
 import models.upload.UploadTemplateTableData
 import pages.*
+import pages.certificate.*
 import pages.notification.*
 
 import java.time.LocalDate

--- a/test/viewmodels/checkAnswers/certificate/CertificateAdditionalInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/certificate/CertificateAdditionalInformationSummarySpec.scala
@@ -18,7 +18,7 @@ package viewmodels.checkAnswers.certificate
 
 import controllers.certificate.routes as certificateRoutes
 import models.CheckMode
-import pages.CertificateAdditionalInformationPage
+import pages.certificate.CertificateAdditionalInformationPage
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 import viewmodels.checkAnswers.CheckYourAnswersSummaryRenderingSupport
 

--- a/test/viewmodels/checkAnswers/certificate/CertificateDeclarationSaoSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/certificate/CertificateDeclarationSaoSummarySpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.CertificateDeclarationSaoPage
+import pages.certificate.CertificateDeclarationSaoPage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 

--- a/test/viewmodels/checkAnswers/certificate/CertificateSaoEmailSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/certificate/CertificateSaoEmailSummarySpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.CertificateSaoEmailPage
+import pages.certificate.CertificateSaoEmailPage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 

--- a/test/viewmodels/checkAnswers/certificate/CertificateSaoFullNameSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/certificate/CertificateSaoFullNameSummarySpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import models.CheckMode
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.CertificateSaoFullNamePage
+import pages.certificate.CertificateSaoFullNamePage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 

--- a/test/viewmodels/checkAnswers/certificate/CertificateWhoIsSubmittingSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/certificate/CertificateWhoIsSubmittingSummarySpec.scala
@@ -21,7 +21,7 @@ import controllers.certificate.routes as certificateRoutes
 import models.CheckMode
 import models.certificate.CertificateWhoIsSubmitting
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import pages.CertificateWhoIsSubmittingPage
+import pages.certificate.CertificateWhoIsSubmittingPage
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.govukfrontend.views.Implicits.RichString
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Moved the certificate page object/classes into certificate package

## Jira ticket(s):
* no jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
