### PR TITLE
Saod 771/certificate file upload

### DIFF
--- a/app/connectors/UpscanInitiateConnector.scala
+++ b/app/connectors/UpscanInitiateConnector.scala
@@ -52,7 +52,7 @@ class UpscanInitiateConnector @Inject() (
   private def successRedirect(journey: UploadJourney): Call =
     journey match {
       case UploadJourney.Notification => notificationRoutes.NotificationUploadSuccessController.onPageLoad(key = None)
-      case UploadJourney.Certificate  => certificateRoutes.CertificateUploadFormController.onPageLoad()
+      case UploadJourney.Certificate  => certificateRoutes.CertificateUploadSuccessController.onPageLoad(key = None)
     }
 
   private def errorRedirect(journey: UploadJourney): Call =

--- a/app/controllers/certificate/CertificateReviewQualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewQualifiedController.scala
@@ -34,8 +34,6 @@ import views.html.certificate.CertificateReviewQualifiedView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 class CertificateReviewQualifiedController @Inject() (
@@ -66,9 +64,6 @@ class CertificateReviewQualifiedController @Inject() (
           } yield Ok(
             view(
               saoName = saoName,
-              financialYearEnd = LocalDate
-                .of(2024, 12, 31) // TODO: get this from somewhere appropriate
-                .format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
               companyCount = totalCompanies,
               qualifiedCompanies = qualifiedCompanies
             )

--- a/app/controllers/certificate/CertificateReviewQualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewQualifiedController.scala
@@ -21,7 +21,11 @@ import controllers.routes
 import models.NormalMode
 import models.upload.*
 import navigation.Navigator
-import pages.certificate.{CertificateReviewQualifiedPage, CertificateSaoFullNamePage}
+import pages.certificate.{
+  CertificateReviewQualifiedPage,
+  CertificateSaoFullNamePage,
+  CertificateUploadTemplateTablePage
+}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
@@ -52,75 +56,23 @@ class CertificateReviewQualifiedController @Inject() (
     (identify andThen getData andThen requireData andThen requireUploadSubmissionTemplateStageUnlocked) {
       implicit request =>
         {
-          // TODO: get the submission data from somewhere more appropriate
-          val dummyData = Seq(
-            ParsedSubmissionRow(
-              notification = NotificationFields(
-                companyName = "example company name",
-                companyUtr = CompanyUtr("example company utr"),
-                companyCrn = Some(CompanyCrn("example company crn")),
-                companyType = CompanyType.LTD,
-                companyStatus = CompanyStatus.Dormant,
-                financialYearEndDate = LocalDate.now()
-              ),
-              certificate = CertificateFields(
-                corporationTax = false,
-                valueAddedTax = true,
-                paye = false,
-                insurancePremiumTax = true,
-                stampDutyLandTax = false,
-                stampDutyReserveTax = false,
-                petroleumRevenueTax = true,
-                customsDuties = false,
-                exciseDuties = false,
-                bankLevy = false,
-                certificateType = Some(CertificateType.Qualified),
-                additionalInformation = Some("example additional information")
-              )
-            ),
-            ParsedSubmissionRow(
-              notification = NotificationFields(
-                companyName = "example company name 2",
-                companyUtr = CompanyUtr("example company utr 2"),
-                companyCrn = Some(CompanyCrn("example company crn 2")),
-                companyType = CompanyType.LTD,
-                companyStatus = CompanyStatus.Dormant,
-                financialYearEndDate = LocalDate.now()
-              ),
-              certificate = CertificateFields(
-                corporationTax = false,
-                valueAddedTax = true,
-                paye = false,
-                insurancePremiumTax = true,
-                stampDutyLandTax = false,
-                stampDutyReserveTax = true,
-                petroleumRevenueTax = false,
-                customsDuties = false,
-                exciseDuties = true,
-                bankLevy = false,
-                certificateType = Some(CertificateType.Qualified),
-                additionalInformation = Some("example additional information 2")
-              )
+          val userAnswers = request.userAnswers
+
+          (for {
+            saoName        <- userAnswers.get(CertificateSaoFullNamePage)
+            parsedTemplate <- userAnswers.get(CertificateUploadTemplateTablePage)
+            totalCompanies     = parsedTemplate.rows.size
+            qualifiedCompanies = parsedTemplate.rows.flatMap(_.toQualifiedCompany)
+          } yield Ok(
+            view(
+              saoName = saoName,
+              financialYearEnd = LocalDate
+                .of(2024, 12, 31) // TODO: get this from somewhere appropriate
+                .format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
+              companyCount = totalCompanies,
+              qualifiedCompanies = qualifiedCompanies
             )
-          )
-
-          val qualifiedCompanies = dummyData.map(_.toQualifiedCompany)
-
-          request.userAnswers
-            .get(CertificateSaoFullNamePage) match {
-            case Some(saoName) =>
-              Ok(
-                view(
-                  saoName = saoName,
-                  financialYearEnd = LocalDate
-                    .of(2024, 12, 31) // TODO: get this from somewhere appropriate
-                    .format(DateTimeFormatter.ofPattern("d MMMM yyyy")),
-                  companyCount = 3,
-                  qualifiedCompanies = qualifiedCompanies
-                )
-              )
-            case None => Redirect(routes.JourneyRecoveryController.onPageLoad())
-          }
+          )).fold(Redirect(routes.JourneyRecoveryController.onPageLoad()))(identity)
         }
     }
 

--- a/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
@@ -53,9 +53,6 @@ class CertificateReviewUnqualifiedController @Inject() (
   def onPageLoad: Action[AnyContent] =
     (identify andThen getData andThen requireData andThen requireUploadSubmissionTemplateStageUnlocked) {
       implicit request =>
-        // TODO: remove in future
-        val dummyDate = "2020"
-        // TODO: pass financial year end date through for paragraph3
         val userAnswers = request.userAnswers
 
         (for {
@@ -68,8 +65,7 @@ class CertificateReviewUnqualifiedController @Inject() (
             view(
               saoName = saoName,
               unqualifiedCompanies = unqualifiedCompanies,
-              companyCount = totalCompanies,
-              dummyDate = dummyDate
+              companyCount = totalCompanies
             )
           )
         }).fold(Redirect(routes.JourneyRecoveryController.onPageLoad()))(identity)

--- a/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
+++ b/app/controllers/certificate/CertificateReviewUnqualifiedController.scala
@@ -21,7 +21,11 @@ import controllers.routes
 import models.NormalMode
 import models.upload.*
 import navigation.Navigator
-import pages.certificate.{CertificateReviewUnqualifiedPage, CertificateSaoFullNamePage}
+import pages.certificate.{
+  CertificateReviewUnqualifiedPage,
+  CertificateSaoFullNamePage,
+  CertificateUploadTemplateTablePage
+}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
@@ -30,7 +34,6 @@ import views.html.certificate.CertificateReviewUnqualifiedView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import java.time.LocalDate
 import javax.inject.Inject
 
 class CertificateReviewUnqualifiedController @Inject() (
@@ -51,98 +54,25 @@ class CertificateReviewUnqualifiedController @Inject() (
     (identify andThen getData andThen requireData andThen requireUploadSubmissionTemplateStageUnlocked) {
       implicit request =>
         // TODO: remove in future
-        val dummyDate            = "2020"
-        val unqualifiedDummyData = Seq(
-          ParsedSubmissionRow(
-            notification = NotificationFields(
-              companyName = "example company name",
-              companyUtr = CompanyUtr("example company utr"),
-              companyCrn = Some(CompanyCrn("example company crn")),
-              companyType = CompanyType.LTD,
-              companyStatus = CompanyStatus.Administration,
-              financialYearEndDate = LocalDate.now()
-            ),
-            certificate = CertificateFields(
-              corporationTax = false,
-              valueAddedTax = true,
-              paye = false,
-              insurancePremiumTax = true,
-              stampDutyLandTax = false,
-              stampDutyReserveTax = false,
-              petroleumRevenueTax = true,
-              customsDuties = false,
-              exciseDuties = false,
-              bankLevy = false,
-              certificateType = Some(CertificateType.Unqualified),
-              additionalInformation = Some("example additional information")
-            )
-          ),
-          ParsedSubmissionRow(
-            notification = NotificationFields(
-              companyName = "example company name 2",
-              companyUtr = CompanyUtr("example company utr 2"),
-              companyCrn = Some(CompanyCrn("example company crn 2")),
-              companyType = CompanyType.LTD,
-              companyStatus = CompanyStatus.Dormant,
-              financialYearEndDate = LocalDate.now()
-            ),
-            certificate = CertificateFields(
-              corporationTax = false,
-              valueAddedTax = false,
-              paye = false,
-              insurancePremiumTax = false,
-              stampDutyLandTax = false,
-              stampDutyReserveTax = false,
-              petroleumRevenueTax = false,
-              customsDuties = false,
-              exciseDuties = false,
-              bankLevy = false,
-              certificateType = Some(CertificateType.Unqualified),
-              additionalInformation = Some("example additional information ")
-            )
-          ),
-          ParsedSubmissionRow(
-            notification = NotificationFields(
-              companyName = "example company name 3",
-              companyUtr = CompanyUtr("example company utr 3"),
-              companyCrn = Some(CompanyCrn("example company crn 3")),
-              companyType = CompanyType.LTD,
-              companyStatus = CompanyStatus.Active,
-              financialYearEndDate = LocalDate.now()
-            ),
-            certificate = CertificateFields(
-              corporationTax = false,
-              valueAddedTax = false,
-              paye = false,
-              insurancePremiumTax = false,
-              stampDutyLandTax = false,
-              stampDutyReserveTax = false,
-              petroleumRevenueTax = false,
-              customsDuties = false,
-              exciseDuties = false,
-              bankLevy = false,
-              certificateType = Some(CertificateType.Unqualified),
-              additionalInformation = Some("example additional information 3")
-            )
-          )
-        )
+        val dummyDate = "2020"
+        // TODO: pass financial year end date through for paragraph3
+        val userAnswers = request.userAnswers
 
-        val unqualifiedCompanies = unqualifiedDummyData.map(_.toUnqualifiedCompany)
-//TODO: pass financial year end date through for paragraph3
-        request.userAnswers
-          .get(CertificateSaoFullNamePage)
-          .fold(
-            Redirect(routes.JourneyRecoveryController.onPageLoad())
-          )(saoName =>
-            Ok(
-              view(
-                saoName = saoName,
-                unqualifiedCompanies = unqualifiedCompanies,
-                companyCount = unqualifiedCompanies.size,
-                dummyDate = dummyDate
-              )
+        (for {
+          saoName        <- userAnswers.get(CertificateSaoFullNamePage)
+          parsedTemplate <- userAnswers.get(CertificateUploadTemplateTablePage)
+          totalCompanies       = parsedTemplate.rows.size
+          unqualifiedCompanies = parsedTemplate.rows.flatMap(_.toUnqualifiedCompany)
+        } yield {
+          Ok(
+            view(
+              saoName = saoName,
+              unqualifiedCompanies = unqualifiedCompanies,
+              companyCount = totalCompanies,
+              dummyDate = dummyDate
             )
           )
+        }).fold(Redirect(routes.JourneyRecoveryController.onPageLoad()))(identity)
     }
 
   def onSubmit(): Action[AnyContent] =

--- a/app/controllers/certificate/CertificateUploadFormController.scala
+++ b/app/controllers/certificate/CertificateUploadFormController.scala
@@ -16,11 +16,19 @@
 
 package controllers.certificate
 
+import connectors.UpscanInitiateConnector
 import controllers.actions.*
+import forms.UploadFormProvider
+import forms.UploadFormProvider.fileInputField
+import models.upscan.{FileUploadState, UploadJourney, UploadStatus}
+import pages.certificate.CertificateUploadStatePage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.certificate.CertificateUploadFormView
+
+import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
@@ -29,15 +37,47 @@ class CertificateUploadFormController @Inject() (
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    requireUploadSubmissionTemplateStageUnlocked: RequireCertificateUploadSubmissionTemplateUnlockedAction,
-    val controllerComponents: MessagesControllerComponents,
-    view: CertificateUploadFormView
-) extends FrontendBaseController
+    mcc: MessagesControllerComponents,
+    certificateUploadFormView: CertificateUploadFormView,
+    upscanInitiateConnector: UpscanInitiateConnector,
+    sessionRepository: SessionRepository,
+    formProvider: UploadFormProvider,
+    requireUploadSubmissionTemplateStageUnlocked: RequireCertificateUploadSubmissionTemplateUnlockedAction
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc)
     with I18nSupport {
 
   def onPageLoad: Action[AnyContent] =
-    (identify andThen getData andThen requireData andThen requireUploadSubmissionTemplateStageUnlocked) {
+    (identify andThen getData andThen requireData andThen requireUploadSubmissionTemplateStageUnlocked).async {
       implicit request =>
-        Ok(view())
+        val form = request.userAnswers.get(CertificateUploadStatePage).fold(formProvider()) {
+          case FileUploadState(_, UploadStatus.Quarantined) =>
+            formProvider().withError(
+              fileInputField,
+              "upload.error.quarantine"
+            )
+          case FileUploadState(_, UploadStatus.Rejected) =>
+            formProvider().withError(fileInputField, "upload.error.rejected")
+          case FileUploadState(_, UploadStatus.UnknownFailure) =>
+            formProvider().withError(fileInputField, "upload.error.unknown")
+          case _ => formProvider()
+        }
+
+        for {
+          upscanInitiateResponse <- upscanInitiateConnector.initiateV2(UploadJourney.Certificate)
+          updatedAnswers         <- Future.fromTry(
+            request.userAnswers.set(
+              CertificateUploadStatePage,
+              FileUploadState(
+                reference = upscanInitiateResponse.reference,
+                status = UploadStatus.InProgress
+              )
+            )
+          )
+          _ <- sessionRepository.set(updatedAnswers)
+        } yield {
+          if form.hasErrors then BadRequest(certificateUploadFormView(form, upscanInitiateResponse))
+          else Ok(certificateUploadFormView(form, upscanInitiateResponse))
+        }
     }
 }

--- a/app/controllers/certificate/CertificateUploadSuccessController.scala
+++ b/app/controllers/certificate/CertificateUploadSuccessController.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.certificate
+
+import controllers.actions.*
+import controllers.certificate.routes as certificateRoutes
+import controllers.routes
+import models.requests.DataRequest
+import models.upload.UploadTemplateTableData
+import models.upscan.UploadJourney
+import pages.certificate.CertificateUploadTemplateTablePage
+import play.api.Logging
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.*
+import repositories.SessionRepository
+import services.UpscanService
+import services.UpscanService.*
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.certificate.CertificateUploadSuccessView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class CertificateUploadSuccessController @Inject() (
+    override val messagesApi: MessagesApi,
+    identify: IdentifierAction,
+    getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
+    val controllerComponents: MessagesControllerComponents,
+    sessionRepository: SessionRepository,
+    upscanService: UpscanService,
+    view: CertificateUploadSuccessView
+)(using ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport
+    with Logging {
+
+  def onPageLoad(key: Option[String]): Action[AnyContent] =
+    (identify andThen getData andThen requireData).async { implicit request =>
+      upscanService.fileUploadState(UploadJourney.Certificate, request.userAnswers, key).flatMap {
+        case State.NoReference =>
+          Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
+        case State.WaitingForUpscan =>
+          Future.successful(Ok(view()))
+        case State.QuarantinedByUpscan =>
+          Future.successful(Redirect(certificateRoutes.CertificateUploadFormController.onPageLoad()))
+        case State.RejectedByUpscan =>
+          Future.successful(Redirect(certificateRoutes.CertificateUploadFormController.onPageLoad()))
+        case State.UnknownUpscanError =>
+          Future.successful(Redirect(certificateRoutes.CertificateUploadFormController.onPageLoad()))
+        case State.DownloadFromUpscanFailed(response) =>
+          logger.warn(s"Failed to download uploaded template from Upscan: ${response.status}")
+          Future.successful(Redirect(certificateRoutes.CertificateUploadFormController.onPageLoad()))
+        case State.ValidationFailed(errors) =>
+          logger.warn(s"Uploaded template failed validation with ${errors.size} error(s)")
+          saveTableDataAndRedirect(
+            UploadTemplateTableData(rows = Seq.empty, errors = errors),
+            certificateRoutes.CertificateUploadTemplateTableErrorController.onPageLoad()
+          )
+        case State.Result(reference, rows) =>
+          logger.info(s"Uploaded template parsed successfully, reference: $reference, rows: ${rows.size}")
+          saveTableDataAndRedirect(
+            UploadTemplateTableData(rows = rows, errors = Seq.empty),
+            certificateRoutes.CertificateReviewQualifiedController.onPageLoad()
+          )
+      }
+    }
+
+  private def saveTableDataAndRedirect(
+      tableData: UploadTemplateTableData,
+      redirectTo: Call
+  )(using request: DataRequest[AnyContent]): Future[Result] =
+    for {
+      updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateUploadTemplateTablePage, tableData))
+      _              <- sessionRepository.set(updatedAnswers)
+    } yield Redirect(redirectTo)
+}

--- a/app/controllers/certificate/CertificateUploadTemplateTableErrorController.scala
+++ b/app/controllers/certificate/CertificateUploadTemplateTableErrorController.scala
@@ -14,36 +14,35 @@
  * limitations under the License.
  */
 
-package controllers.notification
+package controllers.certificate
 
 import controllers.actions.*
 import controllers.routes
 import models.NormalMode
 import navigation.Navigator
-import pages.notification.{UploadTemplateTablePage, UploadTemplateTableErrorPage}
+import pages.certificate.{CertificateUploadTemplateTablePage, CertificateUploadTemplateTableErrorPage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import views.html.notification.UploadTemplateTableErrorView
+import views.html.certificate.CertificateUploadTemplateTableErrorView
 
 import javax.inject.Inject
 
-class UploadTemplateTableErrorController @Inject() (
+class CertificateUploadTemplateTableErrorController @Inject() (
     override val messagesApi: MessagesApi,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
-    requireNotificationUploadUnlocked: RequireNotificationUploadUnlockedAction,
     val controllerComponents: MessagesControllerComponents,
-    view: UploadTemplateTableErrorView,
+    view: CertificateUploadTemplateTableErrorView,
     navigator: Navigator
 ) extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad(): Action[AnyContent] =
-    (identify andThen getData andThen requireData andThen requireNotificationUploadUnlocked) { implicit request =>
+    (identify andThen getData andThen requireData) { implicit request =>
       request.userAnswers
-        .get(UploadTemplateTablePage)
+        .get(CertificateUploadTemplateTablePage)
         .fold(
           Redirect(routes.JourneyRecoveryController.onPageLoad())
         ) { tableData =>
@@ -52,7 +51,7 @@ class UploadTemplateTableErrorController @Inject() (
     }
 
   def onSubmit(): Action[AnyContent] =
-    (identify andThen getData andThen requireData andThen requireNotificationUploadUnlocked) { implicit request =>
-      Redirect(navigator.nextPage(UploadTemplateTableErrorPage, NormalMode, request.userAnswers))
+    (identify andThen getData andThen requireData) { implicit request =>
+      Redirect(navigator.nextPage(CertificateUploadTemplateTableErrorPage, NormalMode, request.userAnswers))
     }
 }

--- a/app/controllers/certificate/CertificateUploadTemplateTableErrorController.scala
+++ b/app/controllers/certificate/CertificateUploadTemplateTableErrorController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import controllers.routes
 import models.NormalMode
 import navigation.Navigator
-import pages.certificate.{CertificateUploadTemplateTablePage, CertificateUploadTemplateTableErrorPage}
+import pages.certificate.{CertificateUploadTemplateTableErrorPage, CertificateUploadTemplateTablePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/controllers/notification/NotificationUploadFormController.scala
+++ b/app/controllers/notification/NotificationUploadFormController.scala
@@ -18,7 +18,7 @@ package controllers.notification
 
 import connectors.UpscanInitiateConnector
 import controllers.actions.*
-import forms.notification.NotificationUploadFormProvider
+import forms.UploadFormProvider
 import models.*
 import models.upscan.{FileUploadState, UploadJourney, UploadStatus}
 import pages.notification.NotificationUploadStatePage
@@ -32,7 +32,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import javax.inject.Inject
 
-import NotificationUploadFormController.fileInputField
+import UploadFormProvider.fileInputField
 
 class NotificationUploadFormController @Inject() (
     identify: IdentifierAction,
@@ -43,7 +43,7 @@ class NotificationUploadFormController @Inject() (
     notificationUploadFormView: NotificationUploadFormView,
     upscanInitiateConnector: UpscanInitiateConnector,
     sessionRepository: SessionRepository,
-    formProvider: NotificationUploadFormProvider
+    formProvider: UploadFormProvider
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc)
     with I18nSupport {
@@ -54,12 +54,12 @@ class NotificationUploadFormController @Inject() (
         case FileUploadState(_, UploadStatus.Quarantined) =>
           formProvider().withError(
             fileInputField,
-            "notificationUploadForm.upload.error.quarantine"
+            "upload.error.quarantine"
           )
         case FileUploadState(_, UploadStatus.Rejected) =>
-          formProvider().withError(fileInputField, "notificationUploadForm.upload.error.rejected")
+          formProvider().withError(fileInputField, "upload.error.rejected")
         case FileUploadState(_, UploadStatus.UnknownFailure) =>
-          formProvider().withError(fileInputField, "notificationUploadForm.upload.error.unknown")
+          formProvider().withError(fileInputField, "upload.error.unknown")
         case _ => formProvider()
       }
 
@@ -80,8 +80,4 @@ class NotificationUploadFormController @Inject() (
         else Ok(notificationUploadFormView(form, upscanInitiateResponse))
       }
     }
-}
-
-object NotificationUploadFormController {
-  val fileInputField = "file"
 }

--- a/app/controllers/notification/UploadTemplateTableErrorController.scala
+++ b/app/controllers/notification/UploadTemplateTableErrorController.scala
@@ -20,7 +20,7 @@ import controllers.actions.*
 import controllers.routes
 import models.NormalMode
 import navigation.Navigator
-import pages.notification.{UploadTemplateTablePage, UploadTemplateTableErrorPage}
+import pages.notification.{UploadTemplateTableErrorPage, UploadTemplateTablePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/forms/UploadFormProvider.scala
+++ b/app/forms/UploadFormProvider.scala
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-package forms.notification
+package forms
 
 import forms.mappings.Mappings
 import play.api.data.Form
 
 import javax.inject.Inject
 
-class NotificationUploadFormProvider @Inject() extends Mappings {
-  def apply(): Form[String] = Form("file" -> text())
+class UploadFormProvider @Inject() extends Mappings {
+  def apply(): Form[String] = Form(UploadFormProvider.fileInputField -> text())
+}
+
+object UploadFormProvider {
+  val fileInputField = "file"
 }

--- a/app/models/QualifiedCompany.scala
+++ b/app/models/QualifiedCompany.scala
@@ -18,9 +18,15 @@ package models
 
 import play.api.i18n.Messages
 
+import java.time.LocalDate
+
 final case class QualifiedCompany(
     name: String,
     utr: String,
+    crn: Option[String],
+    companyType: String,
+    status: String,
+    financialYearEndDate: LocalDate,
     corporationTax: Boolean,
     valueAddedTax: Boolean,
     paye: Boolean,

--- a/app/models/UnqualifiedCompany.scala
+++ b/app/models/UnqualifiedCompany.scala
@@ -18,10 +18,13 @@ package models
 
 import models.upload.*
 
+import java.time.LocalDate
+
 final case class UnqualifiedCompany(
     name: String,
     utr: String,
-    crn: String,
+    crn: Option[String],
     companyType: CompanyType,
-    companyStatus: CompanyStatus
+    companyStatus: CompanyStatus,
+    financialYearEndDate: LocalDate
 )

--- a/app/models/upload/ParsedSubmissionRow.scala
+++ b/app/models/upload/ParsedSubmissionRow.scala
@@ -36,32 +36,39 @@ object ParsedSubmissionRow {
   given OFormat[ParsedSubmissionRow] = Json.format[ParsedSubmissionRow]
 
   extension (data: ParsedSubmissionRow) {
-    def toUnqualifiedCompany: UnqualifiedCompany = {
-      UnqualifiedCompany(
-        name = data.notification.companyName,
-        utr = data.notification.companyUtr.value,
-        crn = data.notification.companyCrn.fold("")(_.value),
-        companyType = data.notification.companyType,
-        companyStatus = data.notification.companyStatus
-      )
-    }
+    def toUnqualifiedCompany: Option[UnqualifiedCompany] =
+      if data.certificate.isQualified then None
+      else
+        Some(
+          UnqualifiedCompany(
+            name = data.notification.companyName,
+            utr = data.notification.companyUtr.value,
+            crn = data.notification.companyCrn.fold("")(_.value),
+            companyType = data.notification.companyType,
+            companyStatus = data.notification.companyStatus
+          )
+        )
 
-    def toQualifiedCompany: QualifiedCompany = {
-      QualifiedCompany(
-        name = data.notification.companyName,
-        utr = data.notification.companyUtr.value,
-        corporationTax = data.certificate.corporationTax,
-        valueAddedTax = data.certificate.valueAddedTax,
-        paye = data.certificate.paye,
-        insurancePremiumTax = data.certificate.insurancePremiumTax,
-        stampDutyLandTax = data.certificate.stampDutyLandTax,
-        stampDutyReserveTax = data.certificate.stampDutyReserveTax,
-        petroleumRevenueTax = data.certificate.petroleumRevenueTax,
-        customsDuties = data.certificate.customsDuties,
-        exciseDuties = data.certificate.exciseDuties,
-        bankLevy = data.certificate.bankLevy,
-        additionalInformation = data.certificate.additionalInformation.fold("")(s => s)
-      )
+    def toQualifiedCompany: Option[QualifiedCompany] = {
+      if data.certificate.isQualified then
+        Some(
+          QualifiedCompany(
+            name = data.notification.companyName,
+            utr = data.notification.companyUtr.value,
+            corporationTax = data.certificate.corporationTax,
+            valueAddedTax = data.certificate.valueAddedTax,
+            paye = data.certificate.paye,
+            insurancePremiumTax = data.certificate.insurancePremiumTax,
+            stampDutyLandTax = data.certificate.stampDutyLandTax,
+            stampDutyReserveTax = data.certificate.stampDutyReserveTax,
+            petroleumRevenueTax = data.certificate.petroleumRevenueTax,
+            customsDuties = data.certificate.customsDuties,
+            exciseDuties = data.certificate.exciseDuties,
+            bankLevy = data.certificate.bankLevy,
+            additionalInformation = data.certificate.additionalInformation.fold("")(s => s)
+          )
+        )
+      else None
     }
   }
 }
@@ -155,6 +162,19 @@ final case class CertificateFields(
 
 object CertificateFields {
   given OFormat[CertificateFields] = Json.format[CertificateFields]
+  extension (cert: CertificateFields) {
+    def isQualified: Boolean =
+      cert.corporationTax ||
+        cert.valueAddedTax ||
+        cert.paye ||
+        cert.insurancePremiumTax ||
+        cert.stampDutyLandTax ||
+        cert.stampDutyReserveTax ||
+        cert.petroleumRevenueTax ||
+        cert.customsDuties ||
+        cert.exciseDuties ||
+        cert.bankLevy && !cert.certificateType.contains(CertificateType.Unqualified)
+  }
 }
 
 enum CompanyType {

--- a/app/models/upload/ParsedSubmissionRow.scala
+++ b/app/models/upload/ParsedSubmissionRow.scala
@@ -43,9 +43,10 @@ object ParsedSubmissionRow {
           UnqualifiedCompany(
             name = data.notification.companyName,
             utr = data.notification.companyUtr.value,
-            crn = data.notification.companyCrn.fold("")(_.value),
+            crn = data.notification.companyCrn.map(_.value),
             companyType = data.notification.companyType,
-            companyStatus = data.notification.companyStatus
+            companyStatus = data.notification.companyStatus,
+            financialYearEndDate = data.notification.financialYearEndDate
           )
         )
 
@@ -55,6 +56,10 @@ object ParsedSubmissionRow {
           QualifiedCompany(
             name = data.notification.companyName,
             utr = data.notification.companyUtr.value,
+            crn = data.notification.companyCrn.map(_.value),
+            companyType = data.notification.companyType.toString,
+            status = data.notification.companyStatus.toString,
+            financialYearEndDate = data.notification.financialYearEndDate,
             corporationTax = data.certificate.corporationTax,
             valueAddedTax = data.certificate.valueAddedTax,
             paye = data.certificate.paye,

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -101,6 +101,13 @@ class Navigator @Inject() () {
               notificationRoutes.NotificationUploadFormController.onPageLoad()
             case _ => notificationRoutes.NotificationTaskListController.onPageLoad()
           }
+    case UploadTemplateTableErrorPage =>
+      userAnswers =>
+        userAnswers
+          .get(UploadTemplateTablePage)
+          .fold(routes.JourneyRecoveryController.onPageLoad()) { _ =>
+            notificationRoutes.NotificationUploadFormController.onPageLoad()
+          }
     case SubmissionTypePage =>
       userAnswers =>
         userAnswers.get(SubmissionTypePage) match {
@@ -117,6 +124,13 @@ class Navigator @Inject() () {
         certificateRoutes.CertificateTaskListController.onPageLoad(stage =
           CertificateTaskListStage.UploadSubmissionTemplateStage
         )
+    case CertificateUploadTemplateTableErrorPage =>
+      userAnswers =>
+        userAnswers
+          .get(CertificateUploadTemplateTablePage)
+          .fold(routes.JourneyRecoveryController.onPageLoad()) { _ =>
+            certificateRoutes.CertificateUploadFormController.onPageLoad()
+          }
     case CertificateReviewQualifiedPage =>
       _ => certificateRoutes.CertificateReviewUnqualifiedController.onPageLoad()
     case CertificateReviewUnqualifiedPage =>

--- a/app/pages/certificate/CertificateUploadTemplateTableErrorPage.scala
+++ b/app/pages/certificate/CertificateUploadTemplateTableErrorPage.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.certificate
+
+import pages.Page
+
+case object CertificateUploadTemplateTableErrorPage extends Page

--- a/app/pages/certificate/CertificateUploadTemplateTablePage.scala
+++ b/app/pages/certificate/CertificateUploadTemplateTablePage.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.certificate
+
+import models.upload.UploadTemplateTableData
+import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object CertificateUploadTemplateTablePage extends QuestionPage[UploadTemplateTableData] {
+
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
+
+  override def toString: String = "uploadTemplateTable"
+}

--- a/app/pages/notification/UploadTemplateTableErrorPage.scala
+++ b/app/pages/notification/UploadTemplateTableErrorPage.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.notification
+
+import pages.Page
+
+case object UploadTemplateTableErrorPage extends Page

--- a/app/viewmodels/checkAnswers/notification/NotificationAdditionalInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/notification/NotificationAdditionalInformationSummary.scala
@@ -32,7 +32,7 @@ object NotificationAdditionalInformationSummary {
     val additionalInformation =
       answers
         .getNullable(NotificationAdditionalInformationPage)
-        .getOrElse(messages("notificationAdditionalInformation.empty"))
+        .getOrElse(messages("site.notProvided"))
 
     SummaryListRowViewModel(
       key = messages("notificationAdditionalInformation.checkYourAnswersLabel").toKey,

--- a/app/views/certificate/CertificateReviewQualifiedView.scala.html
+++ b/app/views/certificate/CertificateReviewQualifiedView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import controllers.certificate.routes as certificateRoutes
+@import utils.DateTimeFormats.dateTimeFormat
 
 @this(
     layout: templates.Layout,
@@ -22,7 +23,7 @@
     formHelper: FormWithCSRF
 )
 
-@(saoName: String, financialYearEnd: String, companyCount: Int, qualifiedCompanies: Seq[QualifiedCompany])(using request: Request[?], messages: Messages)
+@(saoName: String, companyCount: Int, qualifiedCompanies: Seq[QualifiedCompany])(using request: Request[?], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("certificateReviewQualified.title"))) {
 
@@ -34,7 +35,7 @@
 
     <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph2WithLink", certificateRoutes.CertificateUploadFormController.onPageLoad()))</p>
 
-    <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph3", saoName, financialYearEnd, qualifiedCompanies.size))</p>
+    <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph3", saoName, qualifiedCompanies.size))</p>
 
     @for(qualifiedCompany <- qualifiedCompanies) {
         <dl class="govuk-summary-list">
@@ -45,6 +46,22 @@
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.utr")</dt>
                 <dd class="govuk-summary-list__value">@qualifiedCompany.utr</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.crn")</dt>
+                <dd class="govuk-summary-list__value">@qualifiedCompany.crn.fold(messages("site.notProvided"))(identity)</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.type")</dt>
+                <dd class="govuk-summary-list__value">@qualifiedCompany.companyType</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.status")</dt>
+                <dd class="govuk-summary-list__value">@qualifiedCompany.status</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.financialYearEndDate")</dt>
+                <dd class="govuk-summary-list__value">@qualifiedCompany.financialYearEndDate.format(dateTimeFormat()(using messages.lang))</dd>
             </div>
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">@messages("certificateReviewQualified.rows.taxRegimes")</dt>

--- a/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
+++ b/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
@@ -30,7 +30,7 @@
 
     <h1 class="govuk-heading-l">@messages("certificateReviewUnqualified.heading")</h1>
 
-    <p class="govuk-body">@messages("certificateReviewUnqualified.paragraph1", unqualifiedCompanies.size)</p>
+    <p class="govuk-body">@messages("certificateReviewUnqualified.paragraph1", companyCount)</p>
 
     <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph2WithLink", certificateRoutes.CertificateUploadFormController.onPageLoad()))</p>
 

--- a/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
+++ b/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import controllers.certificate.routes as certificateRoutes
+@import utils.DateTimeFormats.dateTimeFormat
 
 @this(
     layout: templates.Layout,
@@ -22,7 +23,7 @@
     formHelper: FormWithCSRF
 )
 
-@(saoName: String, unqualifiedCompanies: Seq[UnqualifiedCompany], companyCount: Int, dummyDate: String)(using request: Request[?], messages: Messages)
+@(saoName: String, unqualifiedCompanies: Seq[UnqualifiedCompany], companyCount: Int)(using request: Request[?], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("certificateReviewUnqualified.title"))) {
 
@@ -34,7 +35,7 @@
 
     <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph2WithLink", certificateRoutes.CertificateUploadFormController.onPageLoad()))</p>
 
-    <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph3", saoName, dummyDate, unqualifiedCompanies.size))</p>
+    <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph3", saoName, unqualifiedCompanies.size))</p>
 
     @for(unqualifiedCompany <- unqualifiedCompanies) {
         <dl class="govuk-summary-list">
@@ -48,7 +49,7 @@
             </div>
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">@messages("certificateReviewUnqualified.rows.crn")</dt>
-                <dd class="govuk-summary-list__value">@unqualifiedCompany.crn</dd>
+                <dd class="govuk-summary-list__value">@unqualifiedCompany.crn.fold(messages("site.notProvided"))(identity)</dd>
             </div>
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">@messages("certificateReviewUnqualified.rows.type")</dt>
@@ -57,6 +58,10 @@
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">@messages("certificateReviewUnqualified.rows.status")</dt>
                 <dd class="govuk-summary-list__value">@unqualifiedCompany.companyStatus</dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@messages("certificateReviewUnqualified.rows.financialYearEndDate")</dt>
+                <dd class="govuk-summary-list__value">@unqualifiedCompany.financialYearEndDate.format(dateTimeFormat()(using messages.lang))</dd>
             </div>
         </dl>
     }

--- a/app/views/certificate/CertificateUploadFormView.scala.html
+++ b/app/views/certificate/CertificateUploadFormView.scala.html
@@ -14,17 +14,71 @@
  * limitations under the License.
  *@
 
-@import controllers.certificate.routes as certificateRoutes
+@import models.upscan.UpscanInitiateResponse
 
 @this(
-        layout: templates.Layout,
-        govukButton: GovukButton
+    layout: templates.Layout,
+    govukButton: GovukButton,
+    govukFileUpload: GovukFileUpload,
+    govukErrorMessage: GovukErrorMessage,
+    govukErrorSummary: GovukErrorSummary
 )
 
-@()(using request: Request[?], messages: Messages)
+@(form: Form[?], upscanInitiateResponse: UpscanInitiateResponse)(using request: Request[?], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("certificateUploadForm.title"))) {
+@layout(pageTitle = title(form, messages("certificateUploadForm.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("certificateUploadForm.heading")</h1>
-    <a href=@certificateRoutes.CertificateReviewQualifiedController.onPageLoad()>Next page</a>
+    <form method="POST"
+          action=@upscanInitiateResponse.postTarget
+          enctype="multipart/form-data">
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        <span class="govuk-caption-l">@messages("certificateUploadForm.caption")</span>
+
+        <h1 class="govuk-heading-l">@messages("certificateUploadForm.heading")</h1>
+
+        <p class="govuk-body">@messages("certificateUploadForm.paragraph1")</p>
+
+        <p class="govuk-body">
+            <a target="_blank" id="template-guidance" class="govuk-link"
+               href=@routes.TemplateGuidanceController.onPageLoad()>
+                @messages("certificateUploadForm.paragraph2")
+            </a>
+        </p>
+
+        <div class="govuk-inset-text">
+            @messages("certificateUploadForm.inset.text")
+        </div>
+
+        @* ---- populating the form with hidden fields returned with the initiate response --- *@
+        @for(field <- upscanInitiateResponse.formFields) {
+            <input type="hidden" name="@field._1" value="@field._2"/>
+        }
+
+        @govukFileUpload(FileUpload(
+            name = "file",
+            id = "file-input",
+            label = Label(
+                isPageHeading = false,
+                classes = "govuk-label govuk-label--m",
+                content = Text(messages("upload.label"))
+            ),
+            javascript = Some(true),
+            errorMessage = form.error("file").collect{
+                formError => ErrorMessage(
+                    content = Text(
+                        messages(formError.messages.headOption.fold("")(identity))
+                    )
+                )
+            },
+            attributes = Map("accept" -> ".csv,.xlsx")
+        ))
+
+        <div class="section">
+            <button id="submit" class="govuk-button"> @messages("site.continue") </button>
+        </div>
+    </form>
 }

--- a/app/views/certificate/CertificateUploadSuccessView.scala.html
+++ b/app/views/certificate/CertificateUploadSuccessView.scala.html
@@ -33,7 +33,7 @@
 
 <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />
 
-@layout(pageTitle = titleNoForm(messages("upload.success.title")), additionalHeadBlock = Some(refreshScript)) {
+@layout(pageTitle = titleNoForm(messages("upload.success.title.certificate")), additionalHeadBlock = Some(refreshScript)) {
 
     <div class="loader"></div>
 

--- a/app/views/certificate/CertificateUploadSuccessView.scala.html
+++ b/app/views/certificate/CertificateUploadSuccessView.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.notification.{ routes => notificationRoutes }
+@import controllers.certificate.{ routes => certificateRoutes }
 
 @this(
     layout: templates.Layout,

--- a/app/views/certificate/CertificateUploadTemplateTableErrorView.scala.html
+++ b/app/views/certificate/CertificateUploadTemplateTableErrorView.scala.html
@@ -1,0 +1,97 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.certificate.{ routes => certificateRoutes }
+@this(
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukButton: GovukButton
+)
+
+@(tableData: models.upload.UploadTemplateTableData)(using request: Request[?], messages: Messages)
+
+@asDisplay(value: Option[String]) = {
+    @value.getOrElse("-")
+}
+
+@maximumLinesWithErrorsToDisplay = @{ 50 }
+
+@linesWithErrors = @{
+    tableData.errors
+        .groupBy(_.line)
+        .toSeq
+        .sortBy { case (line, _) => line }
+        .take(maximumLinesWithErrorsToDisplay)
+}
+
+@stylesheet = {
+    <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />
+}
+
+@layout(
+    showBackLink = false,
+    pageTitle = titleNoForm(messages("uploadTemplateTableError.title")),
+    additionalHeadBlock = Some(stylesheet)
+) {
+
+    <h1 class="govuk-heading-l">@messages("uploadTemplateTableError.heading")</h1>
+
+    <p class="govuk-body">
+        @Html(messages("uploadTemplateTableError.paragraph1WithLink", templateGuidanceLinkAttributes))
+    </p>
+
+    <h2 class="govuk-heading-m">@messages("uploadTemplateTableError.problems.heading")</h2>
+    <p class="govuk-body">@messages("uploadTemplateTableError.problems.summary", tableData.errors.size.toString)</p>
+
+    <table class="govuk-table govuk-!-font-size-16 upload-template-errors-table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">@messages("uploadTemplateTableError.errors.line")</th>
+                <th scope="col" class="govuk-table__header">@messages("uploadTemplateTableError.errors.column")</th>
+                <th scope="col" class="govuk-table__header">@messages("uploadTemplateTableError.errors.message")</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            @if(linesWithErrors.isEmpty) {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell" colspan="3">@messages("uploadTemplateTableError.errors.none")</td>
+                </tr>
+            } else {
+                @for(((line, errorsForLine), lineIndex) <- linesWithErrors.zipWithIndex) {
+                    @for((error, index) <- errorsForLine.zipWithIndex) {
+                        <tr class="govuk-table__row@if(index == 0 && lineIndex > 0) { upload-template-errors-table__line-start}">
+                            @if(index == 0) {
+                                <td class="govuk-table__cell" rowspan="@errorsForLine.size">@line</td>
+                            }
+                            <td class="govuk-table__cell">@asDisplay(error.column)</td>
+                            <td class="govuk-table__cell">@error.message</td>
+                        </tr>
+                    }
+                }
+            }
+        </tbody>
+    </table>
+
+    @formHelper(action = certificateRoutes.CertificateUploadTemplateTableErrorController.onSubmit()) {
+        @govukButton(
+            ButtonViewModel(messages("uploadTemplateTableError.continue").toText).withAttribute("id", "submit")
+        )
+    }
+}
+
+@templateGuidanceLinkAttributes = @{
+    s"""href="${routes.TemplateGuidanceController.onPageLoad()}" class="govuk-link" target="_blank""""
+}

--- a/app/views/notification/NotificationUploadFormView.scala.html
+++ b/app/views/notification/NotificationUploadFormView.scala.html
@@ -65,7 +65,7 @@
             label = Label(
                 isPageHeading = false,
                 classes = "govuk-label govuk-label--m",
-                content = Text(messages("notificationUploadForm.upload.label"))
+                content = Text(messages("upload.label"))
             ),
             javascript = Some(true),
             errorMessage = form.error("file").collect{

--- a/app/views/notification/NotificationUploadSuccessView.scala.html
+++ b/app/views/notification/NotificationUploadSuccessView.scala.html
@@ -33,7 +33,7 @@
 
 <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />
 
-@layout(pageTitle = titleNoForm(messages("upload.success.title")), additionalHeadBlock = Some(refreshScript)) {
+@layout(pageTitle = titleNoForm(messages("upload.success.title.notification")), additionalHeadBlock = Some(refreshScript)) {
 
     <div class="loader"></div>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -103,7 +103,10 @@ POST        /certificate-only/sao-email                                         
 GET         /certificate-only/change-sao-email                                        controllers.certificate.CertificateSaoEmailController.onPageLoad(mode: Mode = CheckMode)
 POST        /certificate-only/change-sao-email                                        controllers.certificate.CertificateSaoEmailController.onSubmit(mode: Mode = CheckMode)
 
-GET         /certificateUploadForm                                                    controllers.certificate.CertificateUploadFormController.onPageLoad()
+GET         /certificate/upload                                                       controllers.certificate.CertificateUploadFormController.onPageLoad()
+GET         /certificate/upload/success                                               controllers.certificate.CertificateUploadSuccessController.onPageLoad(key: Option[String])
+GET         /certificate/upload/table/error                                           controllers.certificate.CertificateUploadTemplateTableErrorController.onPageLoad()
+POST        /certificate/upload/table/error                                           controllers.certificate.CertificateUploadTemplateTableErrorController.onSubmit()
 
 GET         /certificateReviewQualified                                               controllers.certificate.CertificateReviewQualifiedController.onPageLoad()
 POST        /certificateReviewQualified                                               controllers.certificate.CertificateReviewQualifiedController.onSubmit()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -129,7 +129,6 @@ notificationAdditionalInformation.checkYourAnswersLabel = Additional information
 notificationAdditionalInformation.error.required = Enter information about your notification or skip
 notificationAdditionalInformation.error.length = Additional information must be 5000 characters or less
 notificationAdditionalInformation.change.hidden =  the additional information supplied for the notification (Financial year end {0})
-notificationAdditionalInformation.empty = Not provided
 
 notificationCheckYourAnswers.title = Check your answers
 notificationCheckYourAnswers.heading = Check your answers
@@ -367,13 +366,17 @@ confirmYourNotification.inset.text = If you realise the information you submitte
 certificateReviewQualified.title = Review the companies with a qualified certificate
 certificateReviewQualified.heading = Review the companies with a qualified certificate
 certificateReviewQualified.caption = Submit a certificate
-certificateReviewQualified.paragraph1 = This list is taken from the certificate details in the submission template you uploaded. There were {0} companies the SAO was responsible for during the financial year.
-certificateReviewQualified.paragraph2WithLink = If the information listed is not correct, <a class="govuk-link" href={0}>upload an updated submission template</a> before continuing.
-certificateReviewQualified.paragraph3 = In accordance with paragraph 2 of Schedule 46 to the Finance Act 2009, I {0}, the Senior Accounting Officer, hereby certify that throughout the company’s financial year ended {1}, <b>{2}</b> companies did not have appropriate tax accounting arrangements.
+certificateReviewQualified.paragraph1 = This list is from the certificate details in your submission template. There were {0} companies your SAO was responsible for in a previous financial year.
+certificateReviewQualified.paragraph2WithLink = If any companies listed are missing or incorrect, <a class="govuk-link" href={0}>upload an updated submission template</a> before continuing.
+certificateReviewQualified.paragraph3 = In accordance with paragraph 2, Schedule 46 of the Finance Act 2009, I {0}, the Senior Accounting Officer, hereby certify that <b>{1}</b> companies did not have appropriate tax accounting arrangements.
 certificateReviewQualified.rows.name = Company name
 certificateReviewQualified.rows.utr = UTR
+certificateReviewQualified.rows.crn = CRN
+certificateReviewQualified.rows.type = Type
+certificateReviewQualified.rows.status = Status
+certificateReviewQualified.rows.financialYearEndDate = Financial year end
 certificateReviewQualified.rows.taxRegimes = Tax Regimes
-certificateReviewQualified.rows.additionalInformation = Additional information
+certificateReviewQualified.rows.additionalInformation = Explain why the certificate is qualified
 certificateReviewQualified.taxRegimes.corporationTax = Corporation Tax
 certificateReviewQualified.taxRegimes.valueAddedTax = Value Added Tax
 certificateReviewQualified.taxRegimes.paye = PAYE (Pay As You Earn)
@@ -388,14 +391,15 @@ certificateReviewQualified.taxRegimes.bankLevy = Bank Levy
 certificateReviewUnqualified.title = Review the companies with an unqualified certificate
 certificateReviewUnqualified.heading = Review the companies with an unqualified certificate
 certificateReviewUnqualified.caption = Submit a certificate
-certificateReviewUnqualified.paragraph1 = This list is taken from the certificate details in the submission template you uploaded. There were {0} companies the SAO was responsible for during the financial year.
-certificateReviewUnqualified.paragraph2WithLink = If the information listed is not correct, <a class="govuk-link" href={0}>upload an updated submission template</a> before continuing.
-certificateReviewUnqualified.paragraph3 = In accordance with Paragraph 2 Schedule 46 Finance Act 2009, I {0} the Senior Accounting Officer hereby certify, in respect of the financial year ended 31 December {1} that <b>{2}</b> companies had appropriate tax accounting arrangements throughout the year.
+certificateReviewUnqualified.paragraph1 = This list is from the certificate details in your submission template. There were {0} companies your SAO was responsible for in a previous financial year.
+certificateReviewUnqualified.paragraph2WithLink = If any companies listed are missing or incorrect, <a class="govuk-link" href={0}>upload an updated submission template</a> before continuing.
+certificateReviewUnqualified.paragraph3 = In accordance with Paragraph 2, Schedule 46 of the Finance Act 2009, I {0}, the Senior Accounting Officer hereby certify that <b>{1}</b> companies had appropriate tax accounting arrangements throughout the year.
 certificateReviewUnqualified.rows.companyName = Company name
 certificateReviewUnqualified.rows.utr = UTR
 certificateReviewUnqualified.rows.crn = CRN
 certificateReviewUnqualified.rows.type = Type
 certificateReviewUnqualified.rows.status = Status
+certificateReviewUnqualified.rows.financialYearEndDate = Financial year end
 
 certificateAdditionalInformation.title = Additional information and explanation
 certificateAdditionalInformation.caption = Submit a certificate
@@ -533,6 +537,6 @@ certificateConfirmation.subheading = What happens next
 certificateUploadForm.title = Upload a submission template for your certificate
 certificateUploadForm.heading = Upload a submission template
 certificateUploadForm.caption = Submit a certificate
-certificateUploadForm.paragraph1 = The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.
+certificateUploadForm.paragraph1 = The template must be uploaded in CSV format. If your template is saved as .xls or .xlsx, save it again as a CSV (comma delimited) (.csv) file before uploading.
 certificateUploadForm.paragraph2 = Read guidance on how to complete the submission template (opens in new tab)
-certificateUploadForm.inset.text = If your group has more than one SAO, you must upload and submit separate templates, one for each SAO. After submitting one certificate, you can start another.
+certificateUploadForm.inset.text = If your group has more than one SAO, you must submit a separate certificate for each one. After you complete this submission, you can start another certificate.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -29,7 +29,8 @@ upload.error.quarantine = The selected file contains a virus
 upload.error.rejected = The selected file must be a CSV
 upload.error.unknown = The selected file could not be uploaded – try again
 
-upload.success.title = Upload a submission template for your notification
+upload.success.title.notification = Upload a submission template for your notification
+upload.success.title.certificate = Upload a submission template for your certificate
 upload.success.heading = Your submission template is uploading
 upload.success.paragraph1 = This may take a few minutes
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -24,6 +24,15 @@ error.title.prefix = Error:
 error.prefix = Error
 error.summary.title = There is a problem
 
+upload.label = Upload a file
+upload.error.quarantine = The selected file contains a virus
+upload.error.rejected = The selected file must be a CSV
+upload.error.unknown = The selected file could not be uploaded – try again
+
+upload.success.title = Upload a submission template for your notification
+upload.success.heading = Your submission template is uploading
+upload.success.paragraph1 = This may take a few minutes
+
 journeyRecovery.continue.title = Sorry, there is a problem with the service
 journeyRecovery.continue.heading = Sorry, there is a problem with the service
 journeyRecovery.continue.guidance = [Add content to explain how to proceed.]
@@ -97,10 +106,6 @@ notificationUploadForm.caption = Submit a notification
 notificationUploadForm.paragraph1 = The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.
 notificationUploadForm.paragraph2 = Read guidance on how to complete the submission template (opens in new tab)
 notificationUploadForm.inset.text = If your group has more than one SAO, you must submit a separate notification for each SAO. After you complete one submission, you can start another.
-notificationUploadForm.upload.label = Upload a file
-notificationUploadForm.upload.error.quarantine = The selected file contains a virus
-notificationUploadForm.upload.error.rejected = The selected file must be a CSV
-notificationUploadForm.upload.error.unknown = The selected file could not be uploaded – try again
 
 notificationGuidance.title = Submit a notification
 notificationGuidance.heading = Submit a notification
@@ -236,10 +241,6 @@ notificationUploadError.validation.headerMismatch = The upload template headers 
 notificationUploadError.validation.missingRequiredValue = A required value is missing in the uploaded template
 notificationUploadError.validation.invalidEnumValue = A value in the uploaded template is not valid
 notificationUploadError.validation.invalidCertificateType = Certificate type must be Qualified, Unqualified or blank
-
-notificationUploadSuccess.title = Upload a submission template for your notification
-notificationUploadSuccess.heading = Your submission template is uploading
-notificationUploadSuccess.paragraph1 = This may take a few minutes
 
 notificationMoreThanOneSao.title = Submit a notification - Was there more than one SAO during the financial year?
 notificationMoreThanOneSao.heading = Was there more than one SAO during the financial year?
@@ -528,3 +529,10 @@ certificateConfirmation.printPage = Print this page
 certificateConfirmation.list1.item1 = - save a copy of all the answers you submitted now. You may not be able to download a PDF if you leave this page
 certificateConfirmation.list1.item2 = - print a paper copy of this confirmation page
 certificateConfirmation.subheading = What happens next
+
+certificateUploadForm.title = Upload a submission template for your certificate
+certificateUploadForm.heading = Upload a submission template
+certificateUploadForm.caption = Submit a certificate
+certificateUploadForm.paragraph1 = The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.
+certificateUploadForm.paragraph2 = Read guidance on how to complete the submission template (opens in new tab)
+certificateUploadForm.inset.text = If your group has more than one SAO, you must upload and submit separate templates, one for each SAO. After submitting one certificate, you can start another.

--- a/it/test/connectors/UpscanInitiateConnectorISpec.scala
+++ b/it/test/connectors/UpscanInitiateConnectorISpec.scala
@@ -116,7 +116,7 @@ object UpscanInitiateConnectorISpec {
 
   val expectedCertificateRequest = UpscanInitiateRequestV2(
     callbackUrl = "http://localhost:10058/internal/upscan-callback?journey=certificate",
-    successRedirect = Some("http://localhost:10058/senior-accounting-officer/submission/certificateUploadForm"),
-    errorRedirect = Some("http://localhost:10058/senior-accounting-officer/submission/certificateUploadForm")
+    successRedirect = Some("http://localhost:10058/senior-accounting-officer/submission/certificate/upload/success"),
+    errorRedirect = Some("http://localhost:10058/senior-accounting-officer/submission/certificate/upload")
   )
 }

--- a/test/controllers/certificate/CertificateReviewQualifiedControllerSpec.scala
+++ b/test/controllers/certificate/CertificateReviewQualifiedControllerSpec.scala
@@ -20,56 +20,37 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import models.QualifiedCompany
 import models.certificate.CertificateTaskListStage
+import models.upload.*
 import navigation.{FakeNavigator, Navigator}
+import pages.certificate.CertificateUploadTemplateTablePage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.certificate.CertificateReviewQualifiedView
 
+import scala.util.Random
+
+import java.time.LocalDate
+
+import CertificateReviewQualifiedControllerSpec.*
+
 class CertificateReviewQualifiedControllerSpec extends SpecBase {
 
   def onwardRoute: Call = Call("GET", "/foo")
-
-  // TODO: remove when corresponding dummy data removed from controller
-  val dummyData: Seq[QualifiedCompany] = Seq(
-    QualifiedCompany(
-      name = "example company name",
-      utr = "example company utr",
-      corporationTax = false,
-      valueAddedTax = true,
-      paye = false,
-      insurancePremiumTax = true,
-      stampDutyLandTax = false,
-      stampDutyReserveTax = false,
-      petroleumRevenueTax = true,
-      customsDuties = false,
-      exciseDuties = false,
-      bankLevy = false,
-      additionalInformation = "example additional information"
-    ),
-    QualifiedCompany(
-      name = "example company name 2",
-      utr = "example company utr 2",
-      corporationTax = false,
-      valueAddedTax = true,
-      paye = false,
-      insurancePremiumTax = true,
-      stampDutyLandTax = false,
-      stampDutyReserveTax = true,
-      petroleumRevenueTax = false,
-      customsDuties = false,
-      exciseDuties = true,
-      bankLevy = false,
-      additionalInformation = "example additional information 2"
-    )
-  )
 
   "CertificateReviewQualified Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
-      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails)).build()
+      val application = applicationBuilder(userAnswers =
+        Some(
+          userAnswersWithCertificateSaoDetails
+            .set(CertificateUploadTemplateTablePage, testTemplateData)
+            .success
+            .value
+        )
+      ).build()
 
       running(application) {
         val request = FakeRequest(GET, certificateRoutes.CertificateReviewQualifiedController.onPageLoad().url)
@@ -79,7 +60,12 @@ class CertificateReviewQualifiedControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[CertificateReviewQualifiedView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view("Firstname Lastname", "31 December 2024", 3, dummyData)(using
+        contentAsString(result) mustEqual view(
+          "Firstname Lastname",
+          "31 December 2024",
+          testTemplateData.rows.size,
+          testQualifiedCompanies
+        )(using
           request,
           messages(application)
         ).toString
@@ -134,4 +120,123 @@ class CertificateReviewQualifiedControllerSpec extends SpecBase {
       }
     }
   }
+}
+
+object CertificateReviewQualifiedControllerSpec {
+
+  def utr(seed: Int): String = f"${Random(seed).nextLong(10000000000L)}%09d"
+
+  def crn(seed: Int): String = f"${Random(seed).nextLong(100000000L)}%08d"
+
+  val testTemplateData: UploadTemplateTableData = UploadTemplateTableData(
+    rows = Seq(
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name",
+          companyUtr = CompanyUtr(utr(1)),
+          companyCrn = Some(CompanyCrn(crn(1))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = true,
+          paye = false,
+          insurancePremiumTax = true,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = true,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Qualified),
+          additionalInformation = Some("example additional information")
+        )
+      ),
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name 2",
+          companyUtr = CompanyUtr(utr(2)),
+          companyCrn = Some(CompanyCrn(crn(2))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = true,
+          paye = false,
+          insurancePremiumTax = true,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = true,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = true,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Qualified),
+          additionalInformation = Some("example additional information 2")
+        )
+      ),
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name 3",
+          companyUtr = CompanyUtr(utr(3)),
+          companyCrn = Some(CompanyCrn(crn(3))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Unqualified),
+          additionalInformation = None
+        )
+      )
+    ),
+    errors = Seq.empty
+  )
+
+  val testQualifiedCompanies: Seq[QualifiedCompany] = Seq(
+    QualifiedCompany(
+      name = "example company name",
+      utr = utr(1),
+      corporationTax = false,
+      valueAddedTax = true,
+      paye = false,
+      insurancePremiumTax = true,
+      stampDutyLandTax = false,
+      stampDutyReserveTax = false,
+      petroleumRevenueTax = true,
+      customsDuties = false,
+      exciseDuties = false,
+      bankLevy = false,
+      additionalInformation = "example additional information"
+    ),
+    QualifiedCompany(
+      name = "example company name 2",
+      utr = utr(2),
+      corporationTax = false,
+      valueAddedTax = true,
+      paye = false,
+      insurancePremiumTax = true,
+      stampDutyLandTax = false,
+      stampDutyReserveTax = true,
+      petroleumRevenueTax = false,
+      customsDuties = false,
+      exciseDuties = true,
+      bankLevy = false,
+      additionalInformation = "example additional information 2"
+    )
+  )
+
 }

--- a/test/controllers/certificate/CertificateReviewQualifiedControllerSpec.scala
+++ b/test/controllers/certificate/CertificateReviewQualifiedControllerSpec.scala
@@ -61,10 +61,9 @@ class CertificateReviewQualifiedControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(
-          "Firstname Lastname",
-          "31 December 2024",
-          testTemplateData.rows.size,
-          testQualifiedCompanies
+          saoName = "Firstname Lastname",
+          companyCount = testTemplateData.rows.size,
+          qualifiedCompanies = testQualifiedCompanies
         )(using
           request,
           messages(application)
@@ -128,6 +127,9 @@ object CertificateReviewQualifiedControllerSpec {
 
   def crn(seed: Int): String = f"${Random(seed).nextLong(100000000L)}%08d"
 
+  private val testDate1 = LocalDate.now()
+  private val testDate2 = LocalDate.now().minusDays(1)
+
   val testTemplateData: UploadTemplateTableData = UploadTemplateTableData(
     rows = Seq(
       ParsedSubmissionRow(
@@ -136,8 +138,8 @@ object CertificateReviewQualifiedControllerSpec {
           companyUtr = CompanyUtr(utr(1)),
           companyCrn = Some(CompanyCrn(crn(1))),
           companyType = CompanyType.LTD,
-          companyStatus = CompanyStatus.Dormant,
-          financialYearEndDate = LocalDate.now()
+          companyStatus = CompanyStatus.Active,
+          financialYearEndDate = testDate1
         ),
         certificate = CertificateFields(
           corporationTax = false,
@@ -158,10 +160,10 @@ object CertificateReviewQualifiedControllerSpec {
         notification = NotificationFields(
           companyName = "example company name 2",
           companyUtr = CompanyUtr(utr(2)),
-          companyCrn = Some(CompanyCrn(crn(2))),
-          companyType = CompanyType.LTD,
+          companyCrn = None,
+          companyType = CompanyType.PLC,
           companyStatus = CompanyStatus.Dormant,
-          financialYearEndDate = LocalDate.now()
+          financialYearEndDate = testDate2
         ),
         certificate = CertificateFields(
           corporationTax = false,
@@ -210,6 +212,10 @@ object CertificateReviewQualifiedControllerSpec {
     QualifiedCompany(
       name = "example company name",
       utr = utr(1),
+      crn = Some(crn(1)),
+      companyType = "LTD",
+      status = "Active",
+      financialYearEndDate = testDate1,
       corporationTax = false,
       valueAddedTax = true,
       paye = false,
@@ -225,6 +231,10 @@ object CertificateReviewQualifiedControllerSpec {
     QualifiedCompany(
       name = "example company name 2",
       utr = utr(2),
+      crn = None,
+      companyType = "PLC",
+      status = "Dormant",
+      financialYearEndDate = testDate2,
       corporationTax = false,
       valueAddedTax = true,
       paye = false,

--- a/test/controllers/certificate/CertificateReviewUnqualifiedControllerSpec.scala
+++ b/test/controllers/certificate/CertificateReviewUnqualifiedControllerSpec.scala
@@ -20,48 +20,37 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import models.*
 import models.certificate.CertificateTaskListStage
-import models.upload.{CompanyStatus, CompanyType}
+import models.upload.*
 import navigation.{FakeNavigator, Navigator}
+import pages.certificate.CertificateUploadTemplateTablePage
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.certificate.CertificateReviewUnqualifiedView
 
+import scala.util.Random
+
+import java.time.LocalDate
+
+import CertificateReviewUnqualifiedControllerSpec.*
+
 class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
 
   def onwardRoute: Call = Call("GET", "/foo")
-
-  val dummyDate                                     = "2020"
-  val unqualifiedDummyData: Seq[UnqualifiedCompany] = Seq(
-    UnqualifiedCompany(
-      name = "example company name",
-      utr = "example company utr",
-      crn = "example company crn",
-      companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Administration
-    ),
-    UnqualifiedCompany(
-      name = "example company name 2",
-      utr = "example company utr 2",
-      crn = "example company crn 2",
-      companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Dormant
-    ),
-    UnqualifiedCompany(
-      name = "example company name 3",
-      utr = "example company utr 3",
-      crn = "example company crn 3",
-      companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Active
-    )
-  )
 
   "CertificateReviewUnqualified Controller" - {
 
     "must return OK and the correct view for a GET" in {
 
-      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails)).build()
+      val application = applicationBuilder(userAnswers =
+        Some(
+          userAnswersWithCertificateSaoDetails
+            .set(CertificateUploadTemplateTablePage, testTemplateData)
+            .success
+            .value
+        )
+      ).build()
 
       running(application) {
         val request = FakeRequest(GET, certificateRoutes.CertificateReviewUnqualifiedController.onPageLoad().url)
@@ -73,8 +62,8 @@ class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(
           "Firstname Lastname",
-          unqualifiedDummyData,
-          unqualifiedDummyData.size,
+          testUnqualifiedCompanies,
+          testTemplateData.rows.size,
           dummyDate
         )(using request, messages(application)).toString
       }
@@ -128,4 +117,107 @@ class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
       }
     }
   }
+}
+
+object CertificateReviewUnqualifiedControllerSpec {
+  val dummyDate = "2020"
+
+  def utr(seed: Int): String = f"${Random(seed).nextLong(10000000000L)}%09d"
+  def crn(seed: Int): String = f"${Random(seed).nextLong(100000000L)}%08d"
+
+  private val testTemplateData = UploadTemplateTableData(
+    rows = Seq(
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name",
+          companyUtr = CompanyUtr(utr(1)),
+          companyCrn = Some(CompanyCrn(crn(1))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Administration,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Unqualified),
+          additionalInformation = Some("example additional information")
+        )
+      ),
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name 2",
+          companyUtr = CompanyUtr(utr(2)),
+          companyCrn = Some(CompanyCrn(crn(2))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Unqualified),
+          additionalInformation = Some("example additional information ")
+        )
+      ),
+      ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name 3",
+          companyUtr = CompanyUtr(utr(3)),
+          companyCrn = Some(CompanyCrn(crn(3))),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Active,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = true,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Qualified),
+          additionalInformation = Some("example additional information 3")
+        )
+      )
+    ),
+    errors = Seq.empty
+  )
+
+  val testUnqualifiedCompanies: Seq[UnqualifiedCompany] = Seq(
+    UnqualifiedCompany(
+      name = "example company name",
+      utr = utr(1),
+      crn = crn(1),
+      companyType = CompanyType.LTD,
+      companyStatus = CompanyStatus.Administration
+    ),
+    UnqualifiedCompany(
+      name = "example company name 2",
+      utr = utr(2),
+      crn = crn(2),
+      companyType = CompanyType.LTD,
+      companyStatus = CompanyStatus.Dormant
+    )
+  )
+
 }

--- a/test/controllers/certificate/CertificateReviewUnqualifiedControllerSpec.scala
+++ b/test/controllers/certificate/CertificateReviewUnqualifiedControllerSpec.scala
@@ -61,10 +61,9 @@ class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(
-          "Firstname Lastname",
-          testUnqualifiedCompanies,
-          testTemplateData.rows.size,
-          dummyDate
+          saoName = "Firstname Lastname",
+          unqualifiedCompanies = testUnqualifiedCompanies,
+          companyCount = testTemplateData.rows.size
         )(using request, messages(application)).toString
       }
     }
@@ -120,7 +119,8 @@ class CertificateReviewUnqualifiedControllerSpec extends SpecBase {
 }
 
 object CertificateReviewUnqualifiedControllerSpec {
-  val dummyDate = "2020"
+  private val testDate1 = LocalDate.now()
+  private val testDate2 = LocalDate.now().minusDays(1)
 
   def utr(seed: Int): String = f"${Random(seed).nextLong(10000000000L)}%09d"
   def crn(seed: Int): String = f"${Random(seed).nextLong(100000000L)}%08d"
@@ -134,7 +134,7 @@ object CertificateReviewUnqualifiedControllerSpec {
           companyCrn = Some(CompanyCrn(crn(1))),
           companyType = CompanyType.LTD,
           companyStatus = CompanyStatus.Administration,
-          financialYearEndDate = LocalDate.now()
+          financialYearEndDate = testDate1
         ),
         certificate = CertificateFields(
           corporationTax = false,
@@ -158,7 +158,7 @@ object CertificateReviewUnqualifiedControllerSpec {
           companyCrn = Some(CompanyCrn(crn(2))),
           companyType = CompanyType.LTD,
           companyStatus = CompanyStatus.Dormant,
-          financialYearEndDate = LocalDate.now()
+          financialYearEndDate = testDate2
         ),
         certificate = CertificateFields(
           corporationTax = false,
@@ -207,16 +207,18 @@ object CertificateReviewUnqualifiedControllerSpec {
     UnqualifiedCompany(
       name = "example company name",
       utr = utr(1),
-      crn = crn(1),
+      crn = Some(crn(1)),
       companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Administration
+      companyStatus = CompanyStatus.Administration,
+      financialYearEndDate = testDate1
     ),
     UnqualifiedCompany(
       name = "example company name 2",
       utr = utr(2),
-      crn = crn(2),
+      crn = Some(crn(2)),
       companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Dormant
+      companyStatus = CompanyStatus.Dormant,
+      financialYearEndDate = testDate2
     )
   )
 

--- a/test/controllers/certificate/CertificateUploadFormControllerSpec.scala
+++ b/test/controllers/certificate/CertificateUploadFormControllerSpec.scala
@@ -17,34 +17,154 @@
 package controllers.certificate
 
 import base.SpecBase
+import connectors.UpscanInitiateConnector
 import controllers.certificate.routes as certificateRoutes
+import controllers.routes
 import models.certificate.CertificateTaskListStage
+import models.upscan.*
+import org.mockito.ArgumentMatchers.{any, argThat, eq as meq}
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatestplus.mockito.MockitoSugar
+import pages.certificate
+import pages.certificate.CertificateUploadStatePage
+import play.api.data.Form
+import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
+import play.twirl.api.Html
+import repositories.SessionRepository
+import uk.gov.hmrc.http.HeaderCarrier
 import views.html.certificate.CertificateUploadFormView
 
-class CertificateUploadFormControllerSpec extends SpecBase {
+import scala.concurrent.Future
 
-  "CertificateUploadForm Controller" - {
+class CertificateUploadFormControllerSpec extends SpecBase with MockitoSugar {
 
-    "must return OK and the correct view for a GET" in {
+  "CertificateUploadFormController must" - {
 
-      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails)).build()
+    "return OK and the correct view for a GET" in {
+      val mockUpscanInitiateConnector   = mock[UpscanInitiateConnector]
+      val mockSessionRepository         = mock[SessionRepository]
+      val mockCertificateUploadFormView = mock[CertificateUploadFormView]
+
+      val upscanInitiateResponse =
+        UpscanInitiateResponse(reference = "foo", postTarget = "bar", formFields = Map("foo2" -> "foo2Val"))
+
+      when(mockCertificateUploadFormView.apply(any(), any())(using any(), any())).thenReturn(Html(""))
+
+      when(
+        mockUpscanInitiateConnector.initiateV2(meq(UploadJourney.Certificate))(using
+          any[HeaderCarrier]()
+        )
+      ).thenReturn(Future.successful(upscanInitiateResponse))
+
+      when(mockSessionRepository.set(any()))
+        .thenReturn(Future.successful(true))
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails))
+        .overrides(
+          bind[UpscanInitiateConnector].toInstance(mockUpscanInitiateConnector),
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[CertificateUploadFormView].toInstance(mockCertificateUploadFormView)
+        )
+        .build()
 
       running(application) {
         val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[CertificateUploadFormView]
-
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(using request, messages(application)).toString
+
+        verify(mockCertificateUploadFormView, times(1)).apply(any(), any())(using any(), any())
       }
     }
 
-    "must redirect to task list on provide sao details stage when user answers is empty" in {
+    "return an error when upscan initiate connector fails" in {
+      val mockUpscanInitiateConnector   = mock[UpscanInitiateConnector]
+      val mockSessionRepository         = mock[SessionRepository]
+      val mockCertificateUploadFormView = mock[CertificateUploadFormView]
+
+      when(
+        mockUpscanInitiateConnector.initiateV2(meq(UploadJourney.Certificate))(using
+          any[HeaderCarrier]
+        )
+      ).thenReturn(Future.failed(new RuntimeException("Upscan service unavailable")))
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails))
+        .overrides(
+          bind[UpscanInitiateConnector].toInstance(mockUpscanInitiateConnector),
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[CertificateUploadFormView].toInstance(mockCertificateUploadFormView)
+        )
+        .build()
+
+      running(application) {
+
+        val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        result.failed.futureValue mustBe an[RuntimeException]
+
+      }
+
+    }
+
+    "return an error when upload progress tracker fails" in {
+      val mockUpscanInitiateConnector   = mock[UpscanInitiateConnector]
+      val mockSessionRepository         = mock[SessionRepository]
+      val mockCertificateUploadFormView = mock[CertificateUploadFormView]
+
+      val upscanInitiateResponse =
+        UpscanInitiateResponse(reference = "foo", postTarget = "bar", formFields = Map("foo2" -> "foo2Val"))
+
+      when(
+        mockUpscanInitiateConnector.initiateV2(meq(UploadJourney.Certificate))(using
+          any[HeaderCarrier]()
+        )
+      )
+        .thenReturn(Future.successful(upscanInitiateResponse))
+
+      when(mockSessionRepository.set(any()))
+        .thenReturn(Future.failed(new RuntimeException("Database connection failed")))
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails))
+        .overrides(
+          bind[UpscanInitiateConnector].toInstance(mockUpscanInitiateConnector),
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[CertificateUploadFormView].toInstance(mockCertificateUploadFormView)
+        )
+        .build()
+
+      running(application) {
+
+        val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        result.failed.futureValue mustBe an[RuntimeException]
+
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to the task list when SAO details have not been completed" in {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
       running(application) {
         val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
 
@@ -55,6 +175,128 @@ class CertificateUploadFormControllerSpec extends SpecBase {
           .onPageLoad(CertificateTaskListStage.ProvideSaoDetailsStage)
           .url
       }
+    }
+
+    "store the Upscan reference in user answers as soon as the upload is initiated" in {
+      val mockUpscanInitiateConnector   = mock[UpscanInitiateConnector]
+      val mockSessionRepository         = mock[SessionRepository]
+      val mockCertificateUploadFormView = mock[CertificateUploadFormView]
+
+      val upscanInitiateResponse =
+        UpscanInitiateResponse(reference = "foo", postTarget = "bar", formFields = Map("foo2" -> "foo2Val"))
+
+      when(mockCertificateUploadFormView.apply(any(), any())(using any(), any())).thenReturn(Html(""))
+      when(mockUpscanInitiateConnector.initiateV2(meq(UploadJourney.Certificate))(using any[HeaderCarrier]()))
+        .thenReturn(Future.successful(upscanInitiateResponse))
+      when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithCertificateSaoDetails))
+        .overrides(
+          bind[UpscanInitiateConnector].toInstance(mockUpscanInitiateConnector),
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[CertificateUploadFormView].toInstance(mockCertificateUploadFormView)
+        )
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+
+        verify(mockSessionRepository, times(1)).set(
+          argThat { (answers: models.UserAnswers) =>
+            answers.id == emptyUserAnswers.id &&
+            answers
+              .get(certificate.CertificateUploadStatePage)
+              .contains(
+                FileUploadState(reference = "foo", status = UploadStatus.InProgress)
+              )
+          }
+        )
+      }
+    }
+
+    def testErrorMessagePassed(
+        uploadStatus: UploadStatus,
+        expectedMessageKey: String
+    ): Unit = {
+      val mockUpscanInitiateConnector   = mock[UpscanInitiateConnector]
+      val mockSessionRepository         = mock[SessionRepository]
+      val mockCertificateUploadFormView = mock[CertificateUploadFormView]
+
+      val upscanInitiateResponse =
+        UpscanInitiateResponse(reference = "foo", postTarget = "bar", formFields = Map("foo2" -> "foo2Val"))
+
+      when(mockCertificateUploadFormView.apply(any(), any())(using any(), any())).thenReturn(Html(""))
+      when(mockUpscanInitiateConnector.initiateV2(meq(UploadJourney.Certificate))(using any[HeaderCarrier]()))
+        .thenReturn(Future.successful(upscanInitiateResponse))
+      when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+
+      val application = applicationBuilder(userAnswers =
+        Some(
+          userAnswersWithCertificateSaoDetails
+            .set(CertificateUploadStatePage, FileUploadState("foo", uploadStatus))
+            .get
+        )
+      )
+        .overrides(
+          bind[UpscanInitiateConnector].toInstance(mockUpscanInitiateConnector),
+          bind[SessionRepository].toInstance(mockSessionRepository),
+          bind[CertificateUploadFormView].toInstance(mockCertificateUploadFormView)
+        )
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, certificateRoutes.CertificateUploadFormController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+
+        verify(mockCertificateUploadFormView, times(1))(
+          argThat { (form: Form[String]) =>
+            {
+              form.errors("file").size == 1
+              form.errors("file").head.message == expectedMessageKey
+            }
+          },
+          any()
+        )(using any(), any())
+
+        verify(mockSessionRepository, times(1)).set(
+          argThat { (answers: models.UserAnswers) =>
+            answers.id == emptyUserAnswers.id &&
+            answers
+              .get(certificate.CertificateUploadStatePage)
+              .contains(
+                FileUploadState(reference = "foo", status = UploadStatus.InProgress)
+              )
+          }
+        )
+      }
+    }
+
+    "pass the view a form with a quarantine error message when the quarantine state is found in the database" in {
+      testErrorMessagePassed(
+        UploadStatus.Quarantined,
+        "upload.error.quarantine"
+      )
+    }
+
+    "pass the view a form with a rejected error message when the rejected state is found in the database" in {
+      testErrorMessagePassed(
+        UploadStatus.Rejected,
+        "upload.error.rejected"
+      )
+    }
+
+    "pass the view a form with a unknown error message when the unknown failure state is found in the database" in {
+      testErrorMessagePassed(
+        UploadStatus.UnknownFailure,
+        "upload.error.unknown"
+      )
     }
   }
 }

--- a/test/controllers/certificate/CertificateUploadSuccessControllerSpec.scala
+++ b/test/controllers/certificate/CertificateUploadSuccessControllerSpec.scala
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.certificate
+
+import base.SpecBase
+import controllers.certificate.CertificateUploadSuccessControllerSpec.*
+import controllers.certificate.routes as certificateRoutes
+import controllers.routes
+import models.*
+import models.upload.{ParsedSubmissionRow, TemplateParseError}
+import models.upscan.UploadJourney
+import org.mockito.ArgumentMatchers.{eq as meq, *}
+import org.mockito.Mockito.*
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{status, *}
+import repositories.SessionRepository
+import services.UpscanService
+import services.UpscanService.*
+import uk.gov.hmrc.http.HttpResponse
+import views.html.certificate.CertificateUploadSuccessView
+
+import scala.concurrent.Future
+import scala.util.Random
+
+class CertificateUploadSuccessControllerSpec extends SpecBase with BeforeAndAfterEach {
+  val mockUpscanService: UpscanService         = mock[UpscanService]
+  val mockSessionRepository: SessionRepository = mock[SessionRepository]
+
+  override def beforeEach(): Unit = {
+    reset(mockUpscanService)
+    reset(mockSessionRepository)
+    when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+  }
+
+  override def applicationBuilder(userAnswers: Option[UserAnswers] = None): GuiceApplicationBuilder = super
+    .applicationBuilder(userAnswers = userAnswers)
+    .overrides(
+      bind[UpscanService].toInstance(mockUpscanService),
+      bind[SessionRepository].toInstance(mockSessionRepository)
+    )
+
+  "CertificateUploadSuccess Controller" - {
+
+    "when UpscanService returns State.NoReference" - {
+      "must return Redirect to Journey recovery" in {
+        when(
+          mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], any[Option[String]])(using
+            any()
+          )
+        ).thenReturn(
+          Future.successful(State.NoReference)
+        )
+
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        running(application) {
+          val request =
+            FakeRequest(
+              GET,
+              certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+            )
+
+          val result = route(application, request).value
+
+          application.injector.instanceOf[CertificateUploadSuccessView]
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).get mustEqual routes.JourneyRecoveryController.onPageLoad().url
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(Some(testFileReference))
+          )(using any())
+        }
+      }
+
+    }
+
+    "when no key is provided" - {
+      "must return Redirect to Journey recovery" in {
+        when(
+          mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], meq(None))(using any())
+        ).thenReturn(
+          Future.successful(State.NoReference)
+        )
+
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        running(application) {
+          val request =
+            FakeRequest(GET, certificateRoutes.CertificateUploadSuccessController.onPageLoad(None).url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).get mustEqual routes.JourneyRecoveryController.onPageLoad().url
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(None)
+          )(using any())
+        }
+      }
+    }
+
+    "when UpscanService returns State.WaitingForUpscan" - {
+      "must return OK and the correct view for a GET" in {
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        when(
+          mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], any[Option[String]])(using
+            any()
+          )
+        ).thenReturn(
+          Future.successful(State.WaitingForUpscan)
+        )
+
+        running(application) {
+          val request =
+            FakeRequest(
+              GET,
+              certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+            )
+
+          val result = route(application, request).value
+
+          val view = application.injector.instanceOf[CertificateUploadSuccessView]
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view()(using request, messages(application)).toString
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(Some(testFileReference))
+          )(using any())
+        }
+      }
+    }
+
+    def testFileUploadStateCausesUploadFormRedirect(inState: State): Unit = {
+      val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+      when(
+        mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], any[Option[String]])(using
+          any()
+        )
+      ).thenReturn(
+        Future.successful(inState)
+      )
+
+      running(application) {
+        val request =
+          FakeRequest(
+            GET,
+            certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+          )
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).get mustEqual certificateRoutes.CertificateUploadFormController.onPageLoad().url
+
+        verify(mockUpscanService, times(1)).fileUploadState(
+          meq(UploadJourney.Certificate),
+          any[UserAnswers],
+          meq(Some(testFileReference))
+        )(using any())
+      }
+    }
+
+    "when UpscanService returns State.QuarantinedByUpscan" - {
+      "must redirect to CertificateUploadFormController" in {
+        testFileUploadStateCausesUploadFormRedirect(State.QuarantinedByUpscan)
+      }
+    }
+
+    "when UpscanService returns State.RejectedByUpscan" - {
+      "must redirect to CertificateUploadFormController" in {
+        testFileUploadStateCausesUploadFormRedirect(State.RejectedByUpscan)
+
+      }
+    }
+
+    "when UpscanService returns State.UnknownUpscanError" - {
+      "must redirect to CertificateUploadFormController" in {
+        testFileUploadStateCausesUploadFormRedirect(State.UnknownUpscanError)
+      }
+    }
+
+    "when UpscanService returns State.DownloadFromUpscanFailed" - {
+      "must redirect to certificate upload form page" in {
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        when(
+          mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], any[Option[String]])(using
+            any()
+          )
+        ).thenReturn(
+          Future.successful(State.DownloadFromUpscanFailed(HttpResponse(status = BAD_REQUEST, body = testFileContent)))
+        )
+
+        running(application) {
+          val request =
+            FakeRequest(
+              GET,
+              certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+            )
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustBe certificateRoutes.CertificateUploadFormController.onPageLoad().url
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(Some(testFileReference))
+          )(using any())
+        }
+      }
+    }
+
+    "when UpscanService returns State.ValidationFailed" - {
+      "must redirect to upload table error page" in {
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        when(
+          mockUpscanService.fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            any[Option[String]]
+          )(using any())
+        ).thenReturn(
+          Future.successful(
+            State.ValidationFailed(
+              Seq(
+                TemplateParseError(
+                  line = 8,
+                  column = Some("Company UTR"),
+                  code = "header_mismatch",
+                  message = "invalid header"
+                )
+              )
+            )
+          )
+        )
+
+        running(application) {
+          val request =
+            FakeRequest(
+              GET,
+              certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+            )
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustBe certificateRoutes.CertificateUploadTemplateTableErrorController
+            .onPageLoad()
+            .url
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(Some(testFileReference))
+          )(using any())
+          verify(mockSessionRepository, times(1)).set(any())
+        }
+      }
+    }
+
+    "when UpscanService returns State.Result" - {
+      "must redirect to upload table page" in {
+        val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+        when(
+          mockUpscanService.fileUploadState(meq(UploadJourney.Certificate), any[UserAnswers], any[Option[String]])(using
+            any()
+          )
+        ).thenReturn(
+          Future.successful(State.Result(testFileReference, parsedRows))
+        )
+
+        running(application) {
+          val request =
+            FakeRequest(
+              GET,
+              certificateRoutes.CertificateUploadSuccessController.onPageLoad(Some(testFileReference)).url
+            )
+
+          val result = route(application, request).value
+
+          application.injector.instanceOf[CertificateUploadSuccessView]
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).get mustBe certificateRoutes.CertificateReviewQualifiedController.onPageLoad().url
+
+          verify(mockUpscanService, times(1)).fileUploadState(
+            meq(UploadJourney.Certificate),
+            any[UserAnswers],
+            meq(Some(testFileReference))
+          )(using any())
+          verify(mockSessionRepository, times(1)).set(any())
+        }
+      }
+    }
+  }
+}
+
+object CertificateUploadSuccessControllerSpec {
+  val parsedRows: Seq[ParsedSubmissionRow] = Seq.empty
+  val testFileContent: String              = Random.nextString(10)
+  val testFileReference: String            = Random.nextString(10)
+}

--- a/test/controllers/certificate/CertificateUploadTemplateTableErrorControllerSpec.scala
+++ b/test/controllers/certificate/CertificateUploadTemplateTableErrorControllerSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.certificate
+
+import base.SpecBase
+import controllers.notification.routes as notificationRoutes
+import controllers.routes
+import models.upload.*
+import navigation.{FakeNavigator, Navigator}
+import pages.notification.UploadTemplateTablePage
+import play.api.http.HeaderNames
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import views.html.notification.UploadTemplateTableErrorView
+
+class CertificateUploadTemplateTableErrorControllerSpec extends SpecBase {
+
+  def onwardRoute: Call = Call("GET", "/foo")
+
+  private val tableData = UploadTemplateTableData(
+    rows = Seq.empty,
+    errors = Seq(TemplateParseError(9, Some("Company UTR"), "missing_required_value", "UTR is required"))
+  )
+
+  private val populatedAnswers = completedSaoDetailsAnswers.set(UploadTemplateTablePage, tableData).success.value
+
+  "UploadTemplateTableError Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+      val application = applicationBuilder(userAnswers = Some(populatedAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, notificationRoutes.UploadTemplateTableErrorController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UploadTemplateTableErrorView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(tableData)(using request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page for a POST" in {
+      val application = applicationBuilder(userAnswers = Some(populatedAnswers))
+        .overrides(bind[Navigator].toInstance(new FakeNavigator(onwardRoute)))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(POST, notificationRoutes.UploadTemplateTableErrorController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        header(HeaderNames.LOCATION, result) mustEqual Some(onwardRoute.url)
+      }
+    }
+
+    "must redirect to Journey Recovery for GET when table data is missing" in {
+      val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, notificationRoutes.UploadTemplateTableErrorController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for POST when table data is missing" in {
+      val application = applicationBuilder(userAnswers = Some(completedSaoDetailsAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(POST, notificationRoutes.UploadTemplateTableErrorController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/notification/NotificationUploadFormControllerSpec.scala
+++ b/test/controllers/notification/NotificationUploadFormControllerSpec.scala
@@ -278,21 +278,21 @@ class NotificationUploadFormControllerSpec extends SpecBase with MockitoSugar {
     "pass the view a form with a quarantine error message when the quarantine state is found in the database" in {
       testErrorMessagePassed(
         UploadStatus.Quarantined,
-        "notificationUploadForm.upload.error.quarantine"
+        "upload.error.quarantine"
       )
     }
 
     "pass the view a form with a rejected error message when the rejected state is found in the database" in {
       testErrorMessagePassed(
         UploadStatus.Rejected,
-        "notificationUploadForm.upload.error.rejected"
+        "upload.error.rejected"
       )
     }
 
     "pass the view a form with a unknown error message when the unknown failure state is found in the database" in {
       testErrorMessagePassed(
         UploadStatus.UnknownFailure,
-        "notificationUploadForm.upload.error.unknown"
+        "upload.error.unknown"
       )
     }
   }

--- a/test/models/QualifiedCompanySpec.scala
+++ b/test/models/QualifiedCompanySpec.scala
@@ -24,6 +24,8 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.Messages
 import play.api.i18n.MessagesApi
 
+import java.time.LocalDate
+
 class QualifiedCompanySpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite {
   given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
 
@@ -32,6 +34,10 @@ class QualifiedCompanySpec extends AnyFreeSpec with Matchers with GuiceOneAppPer
       val sut = QualifiedCompany(
         name = "",
         utr = "",
+        crn = None,
+        companyType = "LTD",
+        status = "Active",
+        financialYearEndDate = LocalDate.now(),
         corporationTax = false,
         valueAddedTax = false,
         paye = false,
@@ -52,6 +58,10 @@ class QualifiedCompanySpec extends AnyFreeSpec with Matchers with GuiceOneAppPer
       val sut = QualifiedCompany(
         name = "",
         utr = "",
+        crn = None,
+        companyType = "LTD",
+        status = "Active",
+        financialYearEndDate = LocalDate.now(),
         corporationTax = true,
         valueAddedTax = false,
         paye = false,
@@ -72,6 +82,10 @@ class QualifiedCompanySpec extends AnyFreeSpec with Matchers with GuiceOneAppPer
       val sut = QualifiedCompany(
         name = "",
         utr = "",
+        crn = None,
+        companyType = "LTD",
+        status = "Active",
+        financialYearEndDate = LocalDate.now(),
         corporationTax = true,
         valueAddedTax = true,
         paye = false,
@@ -92,6 +106,10 @@ class QualifiedCompanySpec extends AnyFreeSpec with Matchers with GuiceOneAppPer
       val sut = QualifiedCompany(
         name = "",
         utr = "",
+        crn = None,
+        companyType = "LTD",
+        status = "Active",
+        financialYearEndDate = LocalDate.now(),
         corporationTax = true,
         valueAddedTax = true,
         paye = true,

--- a/test/models/upload/ParsedSubmissionRowSpec.scala
+++ b/test/models/upload/ParsedSubmissionRowSpec.scala
@@ -94,14 +94,15 @@ class ParsedSubmissionRowSpec extends SpecBase {
 
   "toQualifiedCompany extension method must" - {
     "map a qualified company from ParsedSubmissionRow to Some(QualifiedCompany)" in {
-      val result = ParsedSubmissionRow(
+      val testDate = LocalDate.now()
+      val result   = ParsedSubmissionRow(
         notification = NotificationFields(
           companyName = testCompanyName,
           companyUtr = CompanyUtr(testCompanyUtr),
           companyCrn = Some(CompanyCrn(testCompanyCrn)),
           companyType = CompanyType.LTD,
           companyStatus = CompanyStatus.Dormant,
-          financialYearEndDate = LocalDate.now()
+          financialYearEndDate = testDate
         ),
         certificate = CertificateFields(
           corporationTax = true,
@@ -123,6 +124,10 @@ class ParsedSubmissionRowSpec extends SpecBase {
         QualifiedCompany(
           name = testCompanyName,
           utr = testCompanyUtr,
+          crn = Some(testCompanyCrn),
+          companyType = "LTD",
+          status = "Dormant",
+          financialYearEndDate = testDate,
           corporationTax = true,
           valueAddedTax = false,
           paye = true,
@@ -174,14 +179,15 @@ class ParsedSubmissionRowSpec extends SpecBase {
 
   "toUnqualifiedCompany extension method must" - {
     "map an unqualified company from ParsedSubmissionRow to Some(UnqualifiedCompany)" in {
-      val result = ParsedSubmissionRow(
+      val testDate = LocalDate.now()
+      val result   = ParsedSubmissionRow(
         notification = NotificationFields(
           companyName = "example company name",
           companyUtr = CompanyUtr("example company utr"),
           companyCrn = Some(CompanyCrn("example company crn")),
           companyType = CompanyType.LTD,
           companyStatus = CompanyStatus.Dormant,
-          financialYearEndDate = LocalDate.now()
+          financialYearEndDate = testDate
         ),
         certificate = CertificateFields(
           corporationTax = false,
@@ -203,9 +209,10 @@ class ParsedSubmissionRowSpec extends SpecBase {
         UnqualifiedCompany(
           name = "example company name",
           utr = "example company utr",
-          crn = "example company crn",
+          crn = Some("example company crn"),
           companyType = CompanyType.LTD,
-          companyStatus = CompanyStatus.Dormant
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = testDate
         )
       )
 

--- a/test/models/upload/ParsedSubmissionRowSpec.scala
+++ b/test/models/upload/ParsedSubmissionRowSpec.scala
@@ -92,8 +92,8 @@ class ParsedSubmissionRowSpec extends SpecBase {
     }
   }
 
-  "toQualifiedCompany extension method" - {
-    "maps from ParsedSubmissionRow to QualifiedCompany" in {
+  "toQualifiedCompany extension method must" - {
+    "map a qualified company from ParsedSubmissionRow to Some(QualifiedCompany)" in {
       val result = ParsedSubmissionRow(
         notification = NotificationFields(
           companyName = testCompanyName,
@@ -119,61 +119,127 @@ class ParsedSubmissionRowSpec extends SpecBase {
         )
       ).toQualifiedCompany
 
-      val expected = QualifiedCompany(
-        name = testCompanyName,
-        utr = testCompanyUtr,
-        corporationTax = true,
-        valueAddedTax = false,
-        paye = true,
-        insurancePremiumTax = false,
-        stampDutyLandTax = true,
-        stampDutyReserveTax = false,
-        petroleumRevenueTax = true,
-        customsDuties = false,
-        exciseDuties = true,
-        bankLevy = false,
-        additionalInformation = testAdditionalInformation
+      val expected = Some(
+        QualifiedCompany(
+          name = testCompanyName,
+          utr = testCompanyUtr,
+          corporationTax = true,
+          valueAddedTax = false,
+          paye = true,
+          insurancePremiumTax = false,
+          stampDutyLandTax = true,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = true,
+          customsDuties = false,
+          exciseDuties = true,
+          bankLevy = false,
+          additionalInformation = testAdditionalInformation
+        )
       )
 
       result mustBe expected
     }
+
+    "map an unqualified company from ParsedSubmissionRow to None" in {
+      val result = ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = testCompanyName,
+          companyUtr = CompanyUtr(testCompanyUtr),
+          companyCrn = Some(CompanyCrn(testCompanyCrn)),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Unqualified),
+          additionalInformation = Some(testAdditionalInformation)
+        )
+      ).toQualifiedCompany
+
+      result mustBe None
+
+    }
+
   }
 
-  "toUnqualifiedCompany extension method must map from ParsedSubmissionRow to UnqualifiedCompany" in {
-    val result = ParsedSubmissionRow(
-      notification = NotificationFields(
-        companyName = "example company name",
-        companyUtr = CompanyUtr("example company utr"),
-        companyCrn = Some(CompanyCrn("example company crn")),
-        companyType = CompanyType.LTD,
-        companyStatus = CompanyStatus.Dormant,
-        financialYearEndDate = LocalDate.now()
-      ),
-      certificate = CertificateFields(
-        corporationTax = true,
-        valueAddedTax = false,
-        paye = true,
-        insurancePremiumTax = false,
-        stampDutyLandTax = true,
-        stampDutyReserveTax = false,
-        petroleumRevenueTax = true,
-        customsDuties = false,
-        exciseDuties = true,
-        bankLevy = false,
-        certificateType = Some(CertificateType.Qualified),
-        additionalInformation = Some("example additional information")
+  "toUnqualifiedCompany extension method must" - {
+    "map an unqualified company from ParsedSubmissionRow to Some(UnqualifiedCompany)" in {
+      val result = ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name",
+          companyUtr = CompanyUtr("example company utr"),
+          companyCrn = Some(CompanyCrn("example company crn")),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = false,
+          valueAddedTax = false,
+          paye = false,
+          insurancePremiumTax = false,
+          stampDutyLandTax = false,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = false,
+          customsDuties = false,
+          exciseDuties = false,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Unqualified),
+          additionalInformation = Some("example additional information")
+        )
+      ).toUnqualifiedCompany
+
+      val expected = Some(
+        UnqualifiedCompany(
+          name = "example company name",
+          utr = "example company utr",
+          crn = "example company crn",
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant
+        )
       )
-    ).toUnqualifiedCompany
 
-    val expected = UnqualifiedCompany(
-      name = "example company name",
-      utr = "example company utr",
-      crn = "example company crn",
-      companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Dormant
-    )
+      result mustBe expected
+    }
 
-    result mustBe expected
+    "map a qualified company from ParsedSubmissionRow to None" in {
+      val result = ParsedSubmissionRow(
+        notification = NotificationFields(
+          companyName = "example company name",
+          companyUtr = CompanyUtr("example company utr"),
+          companyCrn = Some(CompanyCrn("example company crn")),
+          companyType = CompanyType.LTD,
+          companyStatus = CompanyStatus.Dormant,
+          financialYearEndDate = LocalDate.now()
+        ),
+        certificate = CertificateFields(
+          corporationTax = true,
+          valueAddedTax = false,
+          paye = true,
+          insurancePremiumTax = false,
+          stampDutyLandTax = true,
+          stampDutyReserveTax = false,
+          petroleumRevenueTax = true,
+          customsDuties = false,
+          exciseDuties = true,
+          bankLevy = false,
+          certificateType = Some(CertificateType.Qualified),
+          additionalInformation = Some("example additional information")
+        )
+      ).toUnqualifiedCompany
+
+      result mustBe None
+    }
   }
 }
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -299,6 +299,26 @@ class NavigatorSpec extends SpecBase {
         ) mustBe notificationRoutes.NotificationUploadFormController.onPageLoad()
       }
 
+      "when on UploadTemplateTableErrorPage  must go to upload form page" in {
+        val userAnswers =
+          UserAnswers("id")
+            .set(
+              UploadTemplateTablePage,
+              UploadTemplateTableData(
+                rows = Seq.empty,
+                errors = Seq(models.upload.TemplateParseError(9, Some("Company UTR"), "missing_required_value", "x"))
+              )
+            )
+            .success
+            .value
+
+        navigator.nextPage(
+          UploadTemplateTableErrorPage,
+          NormalMode,
+          userAnswers
+        ) mustBe notificationRoutes.NotificationUploadFormController.onPageLoad()
+      }
+
       "when on UploadTemplateTablePage with no upload data, must go to journey recovery page" in {
         navigator.nextPage(
           UploadTemplateTablePage,
@@ -356,6 +376,48 @@ class NavigatorSpec extends SpecBase {
         ) mustBe certificateRoutes.CertificateTaskListController.onPageLoad(
           CertificateTaskListStage.UploadSubmissionTemplateStage
         )
+      }
+
+      "when on CertificateUploadTemplateTableErrorPage with no parsing errors, must go to upload form page" in {
+        val userAnswers =
+          UserAnswers("id")
+            .set(CertificateUploadTemplateTablePage, UploadTemplateTableData(rows = Seq.empty, errors = Seq.empty))
+            .success
+            .value
+
+        navigator.nextPage(
+          CertificateUploadTemplateTableErrorPage,
+          NormalMode,
+          userAnswers
+        ) mustBe certificateRoutes.CertificateUploadFormController.onPageLoad()
+      }
+
+      "when on CertificateUploadTemplateTableErrorPage with parsing errors, must go to upload form page" in {
+        val userAnswers =
+          UserAnswers("id")
+            .set(
+              CertificateUploadTemplateTablePage,
+              UploadTemplateTableData(
+                rows = Seq.empty,
+                errors = Seq(models.upload.TemplateParseError(9, Some("Company UTR"), "missing_required_value", "x"))
+              )
+            )
+            .success
+            .value
+
+        navigator.nextPage(
+          CertificateUploadTemplateTableErrorPage,
+          NormalMode,
+          userAnswers
+        ) mustBe certificateRoutes.CertificateUploadFormController.onPageLoad()
+      }
+
+      "when on CertificateUploadTemplateTableErrorPage with no upload data, must go to journey recovery page" in {
+        navigator.nextPage(
+          CertificateUploadTemplateTableErrorPage,
+          NormalMode,
+          UserAnswers("id")
+        ) mustBe routes.JourneyRecoveryController.onPageLoad()
       }
 
       "when on CertificateReviewQualified, must go to CertificateReviewUnqualified page" in {

--- a/test/views/certificate/CertificateReviewQualifiedViewSpec.scala
+++ b/test/views/certificate/CertificateReviewQualifiedViewSpec.scala
@@ -23,21 +23,22 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import views.html.certificate.CertificateReviewQualifiedView
 
+import java.time.LocalDate
+
 import CertificateReviewQualifiedViewSpec.*
 
 class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQualifiedView] {
 
   private def generateView(
       saoName: String,
-      financialYearEnd: String,
       qualifiedCompanies: Seq[QualifiedCompany],
       companyCount: Int
   ): Document =
-    Jsoup.parse(SUT(saoName, financialYearEnd, companyCount, qualifiedCompanies).toString)
+    Jsoup.parse(SUT(saoName, companyCount, qualifiedCompanies).toString)
 
   "CertificateReviewQualifiedView" - {
     "When no rows are passed to the view must render empty table" - {
-      val doc: Document = generateView(firstSaoName, financialYearEnd, Seq(), 0)
+      val doc: Document = generateView(firstSaoName, Seq(), 0)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -71,7 +72,7 @@ class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQ
     }
 
     "When rows are passed to the view must render populated table" - {
-      val doc: Document = generateView(firstSaoName, financialYearEnd, qualifiedCompanies, 2)
+      val doc: Document = generateView(firstSaoName, qualifiedCompanies, 2)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -105,7 +106,7 @@ class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQ
     }
 
     "When rows are and a different sao name are passed to the view must render populated table with differnt sao name" - {
-      val doc: Document = generateView(secondSaoName, financialYearEnd, qualifiedCompanies, 2)
+      val doc: Document = generateView(secondSaoName, qualifiedCompanies, 2)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -151,25 +152,33 @@ class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQ
       "must be four description terms per qualified company with expected text" in {
         val descriptionTerms = doc.select("div.govuk-summary-list__row > dt.govuk-summary-list__key")
 
-        descriptionTerms.size() mustBe expectedCountOfDescriptionLists * 4
+        descriptionTerms.size() mustBe expectedCountOfDescriptionLists * 8
 
-        for i <- 0 to qualifiedCompanies.size - 1 do {
-          descriptionTerms.get(i * 4).text() mustBe companyNameDescriptionTermText
-          descriptionTerms.get(i * 4 + 1).text() mustBe utrDescriptionTermText
-          descriptionTerms.get(i * 4 + 2).text() mustBe taxRegimesDescriptionTermText
-          descriptionTerms.get(i * 4 + 3).text() mustBe additionalInformationDescriptionTermText
+        for i <- qualifiedCompanies.indices do {
+          descriptionTerms.get(i * 8).text() mustBe companyNameDescriptionTermText
+          descriptionTerms.get(i * 8 + 1).text() mustBe utrDescriptionTermText
+          descriptionTerms.get(i * 8 + 2).text() mustBe crnDescriptionTermText
+          descriptionTerms.get(i * 8 + 3).text() mustBe typeDescriptionTermText
+          descriptionTerms.get(i * 8 + 4).text() mustBe statusDescriptionTermText
+          descriptionTerms.get(i * 8 + 5).text() mustBe financialYearEndDescriptionTermText
+          descriptionTerms.get(i * 8 + 6).text() mustBe taxRegimesDescriptionTermText
+          descriptionTerms.get(i * 8 + 7).text() mustBe additionalInformationDescriptionTermText
         }
       }
 
       "must be four description details per qualified company with expected text" in {
         val descriptionDetails = doc.select("div.govuk-summary-list__row > dd.govuk-summary-list__value")
-        descriptionDetails.size() mustBe expectedCountOfDescriptionLists * 4
+        descriptionDetails.size() mustBe expectedCountOfDescriptionLists * 8
 
-        for i <- 0 to qualifiedCompanies.size - 1 do {
-          descriptionDetails.get(i * 4).text() mustBe qualifiedCompanies(i).name
-          descriptionDetails.get(i * 4 + 1).text() mustBe qualifiedCompanies(i).utr
-          descriptionDetails.get(i * 4 + 2).text() mustBe qualifiedCompanies(i).displayRegimes
-          descriptionDetails.get(i * 4 + 3).text() mustBe qualifiedCompanies(i).additionalInformation
+        for i <- qualifiedCompanies.indices do {
+          descriptionDetails.get(i * 8).text() mustBe qualifiedCompanies(i).name
+          descriptionDetails.get(i * 8 + 1).text() mustBe qualifiedCompanies(i).utr
+          descriptionDetails.get(i * 8 + 2).text() mustBe qualifiedCompanies(i).crn.fold("Not provided")(identity)
+          descriptionDetails.get(i * 8 + 3).text() mustBe qualifiedCompanies(i).companyType
+          descriptionDetails.get(i * 8 + 4).text() mustBe qualifiedCompanies(i).status
+          descriptionDetails.get(i * 8 + 5).text() mustBe testDateAsString(qualifiedCompanies(i).financialYearEndDate)
+          descriptionDetails.get(i * 8 + 6).text() mustBe qualifiedCompanies(i).displayRegimes
+          descriptionDetails.get(i * 8 + 7).text() mustBe qualifiedCompanies(i).additionalInformation
         }
       }
     }
@@ -180,29 +189,41 @@ object CertificateReviewQualifiedViewSpec {
   val pageHeading                 = "Review the companies with a qualified certificate"
   val pageTitle                   = "Review the companies with a qualified certificate"
   val firstParagraphZeroCompanies =
-    "This list is taken from the certificate details in the submission template you uploaded. There were 0 companies the SAO was responsible for during the financial year."
+    "This list is from the certificate details in your submission template. There were 0 companies your SAO was responsible for in a previous financial year."
   val firstParagraphTwoCompanies =
-    "This list is taken from the certificate details in the submission template you uploaded. There were 2 companies the SAO was responsible for during the financial year."
+    "This list is from the certificate details in your submission template. There were 2 companies your SAO was responsible for in a previous financial year."
   val secondParagraph =
-    "If the information listed is not correct, upload an updated submission template before continuing."
+    "If any companies listed are missing or incorrect, upload an updated submission template before continuing."
   val thirdParagraphZeroQualifiedCompanies =
-    "In accordance with paragraph 2 of Schedule 46 to the Finance Act 2009, I Firstname Lastname, the Senior Accounting Officer, hereby certify that throughout the company’s financial year ended 31 December 2024, 0 companies did not have appropriate tax accounting arrangements."
+    "In accordance with paragraph 2, Schedule 46 of the Finance Act 2009, I Firstname Lastname, the Senior Accounting Officer, hereby certify that 0 companies did not have appropriate tax accounting arrangements."
   val thirdParagraphTwoQualifiedCompanies =
-    "In accordance with paragraph 2 of Schedule 46 to the Finance Act 2009, I Firstname Lastname, the Senior Accounting Officer, hereby certify that throughout the company’s financial year ended 31 December 2024, 2 companies did not have appropriate tax accounting arrangements."
+    "In accordance with paragraph 2, Schedule 46 of the Finance Act 2009, I Firstname Lastname, the Senior Accounting Officer, hereby certify that 2 companies did not have appropriate tax accounting arrangements."
   val thirdParagraphTwoQualifiedCompaniesDifferentSao =
-    "In accordance with paragraph 2 of Schedule 46 to the Finance Act 2009, I Firstname Lastname II, the Senior Accounting Officer, hereby certify that throughout the company’s financial year ended 31 December 2024, 2 companies did not have appropriate tax accounting arrangements."
+    "In accordance with paragraph 2, Schedule 46 of the Finance Act 2009, I Firstname Lastname II, the Senior Accounting Officer, hereby certify that 2 companies did not have appropriate tax accounting arrangements."
   val firstSaoName                  = "Firstname Lastname"
   val secondSaoName                 = "Firstname Lastname II"
-  val financialYearEnd              = "31 December 2024"
   val zeroQualifiedCompanyCountText = "0"
   val twoQualifiedCompanyCountText  = "2"
   val secondParagraphLinkText       = "upload an updated submission template"
   val secondParagraphLinkSelector   = ".govuk-body:nth-of-type(2) .govuk-link"
 
+  val testDate1: LocalDate = LocalDate.of(2026, 1, 1)
+  val testDate2: LocalDate = LocalDate.of(2027, 2, 3)
+
+  def testDateAsString(localDate: LocalDate): String =
+    Map(
+      testDate1 -> "1 January 2026",
+      testDate2 -> "3 February 2027"
+    ).get(localDate).fold(throw RuntimeException("Unknown test date"))(identity)
+
   val qualifiedCompanies: Seq[QualifiedCompany] = Seq(
     QualifiedCompany(
       name = "example company name",
       utr = "example company utr",
+      crn = Some("example company crn"),
+      companyType = "LTD",
+      status = "Active",
+      financialYearEndDate = testDate1,
       corporationTax = false,
       valueAddedTax = true,
       paye = false,
@@ -218,6 +239,10 @@ object CertificateReviewQualifiedViewSpec {
     QualifiedCompany(
       name = "example company name 2",
       utr = "example company utr 2",
+      crn = None,
+      companyType = "PLC",
+      status = "Active",
+      financialYearEndDate = testDate2,
       corporationTax = false,
       valueAddedTax = true,
       paye = false,
@@ -234,6 +259,10 @@ object CertificateReviewQualifiedViewSpec {
 
   val companyNameDescriptionTermText           = "Company name"
   val utrDescriptionTermText                   = "UTR"
+  val crnDescriptionTermText                   = "CRN"
+  val typeDescriptionTermText                  = "Type"
+  val statusDescriptionTermText                = "Status"
+  val financialYearEndDescriptionTermText      = "Financial year end"
   val taxRegimesDescriptionTermText            = "Tax Regimes"
-  val additionalInformationDescriptionTermText = "Additional information"
+  val additionalInformationDescriptionTermText = "Explain why the certificate is qualified"
 }

--- a/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
+++ b/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
@@ -24,20 +24,20 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import views.html.certificate.CertificateReviewUnqualifiedView
 
-import CertificateReviewUnqualifiedViewSpec.*
+import java.time.LocalDate
 
+import CertificateReviewUnqualifiedViewSpec.*
 class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateReviewUnqualifiedView] {
   private def generateView(
       saoName: String,
       unqualifiedCompanies: Seq[UnqualifiedCompany],
-      companyCount: Int,
-      dummyDate: String
-  ): Document = Jsoup.parse(SUT(saoName, unqualifiedCompanies, companyCount, dummyDate).toString)
+      companyCount: Int
+  ): Document = Jsoup.parse(SUT(saoName, unqualifiedCompanies, companyCount).toString)
 
   "CertificateReviewUnqualifiedView" - {
     "will populate the table correctly when data is present" - {
 
-      val doc: Document = generateView(saoName, unqualifiedCompanies, 10, dummyDate)
+      val doc: Document = generateView(saoName, unqualifiedCompanies, 10)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -73,7 +73,7 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
 
     "will populate the table correctly when no data is present" - {
 
-      val doc: Document = generateView("", Seq.empty, 0, "")
+      val doc: Document = generateView("", Seq.empty, 0)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -119,32 +119,35 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
       "must be five description terms per unqualified company with expected text" in {
         val descriptionTerms = doc.select("div.govuk-summary-list__row > dt.govuk-summary-list__key")
 
-        descriptionTerms.size() mustBe expectedCountOfDescriptionLists * 5
+        descriptionTerms.size() mustBe expectedCountOfDescriptionLists * 6
 
         for i <- unqualifiedCompanies.indices do {
-          descriptionTerms.get(i * 5).text() mustBe companyNameDescriptionTermText
-          descriptionTerms.get(i * 5 + 1).text() mustBe utrDescriptionTermText
-          descriptionTerms.get(i * 5 + 2).text() mustBe crnDescriptionTermText
-          descriptionTerms.get(i * 5 + 3).text() mustBe typeDescriptionTermText
-          descriptionTerms.get(i * 5 + 4).text() mustBe statusDescriptionTermText
+          descriptionTerms.get(i * 6).text() mustBe companyNameDescriptionTermText
+          descriptionTerms.get(i * 6 + 1).text() mustBe utrDescriptionTermText
+          descriptionTerms.get(i * 6 + 2).text() mustBe crnDescriptionTermText
+          descriptionTerms.get(i * 6 + 3).text() mustBe typeDescriptionTermText
+          descriptionTerms.get(i * 6 + 4).text() mustBe statusDescriptionTermText
+          descriptionTerms.get(i * 6 + 5).text() mustBe financialYearEndDateDescriptionTermText
         }
       }
 
       "must be five description details per unqualified company with expected text" in {
         val descriptionDetails = doc.select("div.govuk-summary-list__row > dd.govuk-summary-list__value")
-        descriptionDetails.size() mustBe expectedCountOfDescriptionLists * 5
+        descriptionDetails.size() mustBe expectedCountOfDescriptionLists * 6
 
         for i <- unqualifiedCompanies.indices do {
-          descriptionDetails.get(i * 5).text() mustBe unqualifiedCompanies(i).name
-          descriptionDetails.get(i * 5 + 1).text() mustBe unqualifiedCompanies(i).utr
-          descriptionDetails.get(i * 5 + 2).text() mustBe unqualifiedCompanies(i).crn
-          descriptionDetails.get(i * 5 + 3).text() mustBe unqualifiedCompanies(i).companyType.toString
-          descriptionDetails.get(i * 5 + 4).text() mustBe unqualifiedCompanies(i).companyStatus.toString
+          descriptionDetails.get(i * 6).text() mustBe unqualifiedCompanies(i).name
+          descriptionDetails.get(i * 6 + 1).text() mustBe unqualifiedCompanies(i).utr
+          descriptionDetails.get(i * 6 + 2).text() mustBe unqualifiedCompanies(i).crn.fold("")(identity)
+          descriptionDetails.get(i * 6 + 3).text() mustBe unqualifiedCompanies(i).companyType.toString
+          descriptionDetails.get(i * 6 + 4).text() mustBe unqualifiedCompanies(i).companyStatus.toString
+          descriptionDetails.get(i * 6 + 5).text() mustBe testDateAsString(unqualifiedCompanies(i).financialYearEndDate)
         }
       }
     }
   }
 }
+
 object CertificateReviewUnqualifiedViewSpec {
   val pageHeading             = "Review the companies with an unqualified certificate"
   val pageTitle               = "Review the companies with an unqualified certificate"
@@ -152,41 +155,52 @@ object CertificateReviewUnqualifiedViewSpec {
   val linkLocator             = ".govuk-body:nth-of-type(2) .govuk-link"
   val linkText                = "upload an updated submission template"
   val paragraphs: Seq[String] = Seq(
-    "This list is taken from the certificate details in the submission template you uploaded. There were 10 companies the SAO was responsible for during the financial year.",
-    "If the information listed is not correct, upload an updated submission template before continuing.",
-    "In accordance with Paragraph 2 Schedule 46 Finance Act 2009, I example sao name the Senior Accounting Officer hereby certify, in respect of the financial year ended 31 December 1999 that 2 companies had appropriate tax accounting arrangements throughout the year."
+    "This list is from the certificate details in your submission template. There were 10 companies your SAO was responsible for in a previous financial year.",
+    "If any companies listed are missing or incorrect, upload an updated submission template before continuing.",
+    "In accordance with Paragraph 2, Schedule 46 of the Finance Act 2009, I example sao name, the Senior Accounting Officer hereby certify that 2 companies had appropriate tax accounting arrangements throughout the year."
   )
 
   val paragraphsWithNoData: Seq[String] = Seq(
-    "This list is taken from the certificate details in the submission template you uploaded. There were 0 companies the SAO was responsible for during the financial year.",
-    "If the information listed is not correct, upload an updated submission template before continuing.",
-    "In accordance with Paragraph 2 Schedule 46 Finance Act 2009, I the Senior Accounting Officer hereby certify, in respect of the financial year ended 31 December that 0 companies had appropriate tax accounting arrangements throughout the year."
+    "This list is from the certificate details in your submission template. There were 0 companies your SAO was responsible for in a previous financial year.",
+    "If any companies listed are missing or incorrect, upload an updated submission template before continuing.",
+    "In accordance with Paragraph 2, Schedule 46 of the Finance Act 2009, I , the Senior Accounting Officer hereby certify that 0 companies had appropriate tax accounting arrangements throughout the year."
   )
+
+  private val testDate1 = LocalDate.of(2026, 1, 1)
+  private val testDate2 = LocalDate.of(2027, 3, 4)
+
+  def testDateAsString(localDate: LocalDate): String =
+    Map(
+      testDate1 -> "1 January 2026",
+      testDate2 -> "4 March 2027"
+    ).get(localDate).fold(throw RuntimeException("Unknown test date"))(identity)
 
   val unqualifiedCompanies: Seq[UnqualifiedCompany] = Seq(
     UnqualifiedCompany(
       name = "example company name",
       utr = "example utr",
-      crn = "example crn",
+      crn = Some("example crn"),
       companyType = CompanyType.LTD,
-      companyStatus = CompanyStatus.Active
+      companyStatus = CompanyStatus.Active,
+      financialYearEndDate = testDate1
     ),
     UnqualifiedCompany(
       name = "example company name 2",
       utr = "example utr 2",
-      crn = "example crn 2",
+      crn = Some("example crn 2"),
       companyType = CompanyType.PLC,
-      companyStatus = CompanyStatus.Dormant
+      companyStatus = CompanyStatus.Dormant,
+      financialYearEndDate = testDate2
     )
   )
 
-  val companyNameDescriptionTermText = "Company name"
-  val utrDescriptionTermText         = "UTR"
-  val crnDescriptionTermText         = "CRN"
-  val typeDescriptionTermText        = "Type"
-  val statusDescriptionTermText      = "Status"
+  val companyNameDescriptionTermText          = "Company name"
+  val utrDescriptionTermText                  = "UTR"
+  val crnDescriptionTermText                  = "CRN"
+  val typeDescriptionTermText                 = "Type"
+  val statusDescriptionTermText               = "Status"
+  val financialYearEndDateDescriptionTermText = "Financial year end"
 
-  val saoName   = "example sao name"
-  val dummyDate = "1999"
+  val saoName = "example sao name"
 
 }

--- a/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
+++ b/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
@@ -37,7 +37,7 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
   "CertificateReviewUnqualifiedView" - {
     "will populate the table correctly when data is present" - {
 
-      val doc: Document = generateView(saoName, unqualifiedCompanies, unqualifiedCompanies.size, dummyDate)
+      val doc: Document = generateView(saoName, unqualifiedCompanies, 10, dummyDate)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -73,7 +73,7 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
 
     "will populate the table correctly when no data is present" - {
 
-      val doc: Document = generateView("", Seq(), 0, "")
+      val doc: Document = generateView("", Seq.empty, 0, "")
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -121,7 +121,7 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
 
         descriptionTerms.size() mustBe expectedCountOfDescriptionLists * 5
 
-        for i <- 0 to unqualifiedCompanies.size - 1 do {
+        for i <- unqualifiedCompanies.indices do {
           descriptionTerms.get(i * 5).text() mustBe companyNameDescriptionTermText
           descriptionTerms.get(i * 5 + 1).text() mustBe utrDescriptionTermText
           descriptionTerms.get(i * 5 + 2).text() mustBe crnDescriptionTermText
@@ -134,7 +134,7 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
         val descriptionDetails = doc.select("div.govuk-summary-list__row > dd.govuk-summary-list__value")
         descriptionDetails.size() mustBe expectedCountOfDescriptionLists * 5
 
-        for i <- 0 to unqualifiedCompanies.size - 1 do {
+        for i <- unqualifiedCompanies.indices do {
           descriptionDetails.get(i * 5).text() mustBe unqualifiedCompanies(i).name
           descriptionDetails.get(i * 5 + 1).text() mustBe unqualifiedCompanies(i).utr
           descriptionDetails.get(i * 5 + 2).text() mustBe unqualifiedCompanies(i).crn
@@ -152,7 +152,7 @@ object CertificateReviewUnqualifiedViewSpec {
   val linkLocator             = ".govuk-body:nth-of-type(2) .govuk-link"
   val linkText                = "upload an updated submission template"
   val paragraphs: Seq[String] = Seq(
-    "This list is taken from the certificate details in the submission template you uploaded. There were 2 companies the SAO was responsible for during the financial year.",
+    "This list is taken from the certificate details in the submission template you uploaded. There were 10 companies the SAO was responsible for during the financial year.",
     "If the information listed is not correct, upload an updated submission template before continuing.",
     "In accordance with Paragraph 2 Schedule 46 Finance Act 2009, I example sao name the Senior Accounting Officer hereby certify, in respect of the financial year ended 31 December 1999 that 2 companies had appropriate tax accounting arrangements throughout the year."
   )

--- a/test/views/certificate/CertificateUploadFormViewSpec.scala
+++ b/test/views/certificate/CertificateUploadFormViewSpec.scala
@@ -143,12 +143,12 @@ object CertificateUploadFormViewSpec {
   val captionText = "Submit a certificate"
 
   val paragraphs: List[String] = List(
-    "The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.",
+    "The template must be uploaded in CSV format. If your template is saved as .xls or .xlsx, save it again as a CSV (comma delimited) (.csv) file before uploading.",
     "Read guidance on how to complete the submission template (opens in new tab)"
   )
 
   val insetText =
-    "If your group has more than one SAO, you must upload and submit separate templates, one for each SAO. After submitting one certificate, you can start another."
+    "If your group has more than one SAO, you must submit a separate certificate for each one. After you complete this submission, you can start another certificate."
 
   val uploadFormLabel   = "Upload a file"
   val uploadFormInputId = "file-input"

--- a/test/views/certificate/CertificateUploadFormViewSpec.scala
+++ b/test/views/certificate/CertificateUploadFormViewSpec.scala
@@ -17,32 +17,150 @@
 package views.certificate
 
 import base.ViewSpecBase
+import controllers.routes
+import forms.UploadFormProvider
+import models.upscan.UpscanInitiateResponse
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import play.api.data.Form
 import views.html.certificate.CertificateUploadFormView
 
 import CertificateUploadFormViewSpec.*
 
 class CertificateUploadFormViewSpec extends ViewSpecBase[CertificateUploadFormView] {
 
-  private def generateView(): Document = Jsoup.parse(SUT().toString)
+  private val formProvider       = app.injector.instanceOf[UploadFormProvider]
+  private val form: Form[String] = formProvider()
+
+  private def generateView(form: Form[String]): Document = {
+    val view = SUT(form, upscanInitiateResponse)
+    Jsoup.parse(view.toString)
+  }
 
   "CertificateUploadFormView" - {
-    val doc: Document = generateView()
+    "Page with no error" - {
+      val doc: Document = generateView(form)
 
-    doc.createTestsWithStandardPageElements(
-      pageTitle = pageTitle,
-      pageHeading = pageHeading,
-      showBackLink = true,
-      showIsThisPageNotWorkingProperlyLink = true,
-      hasError = false
-    )
+      doc.createTestsWithStandardPageElements(
+        pageTitle = pageTitle,
+        pageHeading = pageHeading,
+        showBackLink = true,
+        showIsThisPageNotWorkingProperlyLink = true,
+        hasError = false
+      )
 
-    doc.createTestsWithOrWithoutError(hasError = false)
+      doc.createTestsWithOrWithoutError(hasError = false)
+
+      "must contain hidden fields" in {
+        val hiddenFields = doc.select("input[type=hidden]")
+        hiddenFields.size() mustBe 2
+        hiddenFields.get(0).attr("name") mustBe "test1"
+        hiddenFields.get(1).attr("name") mustBe "test2"
+        hiddenFields.get(0).attr("value") mustBe "testValue1"
+        hiddenFields.get(1).attr("value") mustBe "testValue2"
+      }
+
+      doc.createTestsWithLargeCaption(captionText)
+
+      doc.createTestsWithParagraphs(paragraphs)
+
+      doc
+        .getElementById("template-guidance")
+        .createTestWithLink(
+          "Read guidance on how to complete the submission template (opens in new tab)",
+          routes.TemplateGuidanceController.onPageLoad().url
+        )
+
+      doc.createTestForInsetText(insetText)
+
+      "must contain file upload input element" in {
+        doc.select(s"input#$uploadFormInputId.govuk-file-upload").size() mustBe 1
+      }
+
+      "must restrict the file picker to CSV and XLSX files" in {
+        val fileInput = doc.select(s"input#$uploadFormInputId")
+        fileInput.attr("accept") mustBe ".csv,.xlsx"
+      }
+
+      "must contain label for file upload input element" in {
+        val label = doc.select(s"""label.govuk-label[for="$uploadFormInputId"]""")
+        label.size() mustBe 1
+        label.text() mustBe uploadFormLabel
+      }
+
+    }
+
+    "Page with error" - {
+      val doc: Document = generateView(form.withError(uploadFormInputId, errorMessage))
+
+      doc.createTestsWithStandardPageElements(
+        pageTitle = pageTitle,
+        pageHeading = pageHeading,
+        showBackLink = true,
+        showIsThisPageNotWorkingProperlyLink = true,
+        hasError = true
+      )
+
+      doc.createTestsWithOrWithoutError(hasError = true)
+
+      "must contain hidden fields" in {
+        val hiddenFields = doc.select("input[type=hidden]")
+        hiddenFields.size() mustBe 2
+        hiddenFields.get(0).attr("name") mustBe "test1"
+        hiddenFields.get(1).attr("name") mustBe "test2"
+        hiddenFields.get(0).attr("value") mustBe "testValue1"
+        hiddenFields.get(1).attr("value") mustBe "testValue2"
+      }
+
+      doc.createTestsWithParagraphs(paragraphs)
+
+      doc
+        .getElementById("template-guidance")
+        .createTestWithLink(
+          "Read guidance on how to complete the submission template (opens in new tab)",
+          routes.TemplateGuidanceController.onPageLoad().url
+        )
+
+      doc.createTestForInsetText(insetText)
+
+      "must contain file upload input element" in {
+        doc.select(s"input#$uploadFormInputId.govuk-file-upload").size() mustBe 1
+      }
+
+      "must contain label for file upload input element" in {
+        val label = doc.select(s"""label.govuk-label[for="$uploadFormInputId"]""")
+        label.size() mustBe 1
+        label.text() mustBe uploadFormLabel
+      }
+    }
   }
 }
 
 object CertificateUploadFormViewSpec {
-  val pageHeading = "certificateUploadForm"
-  val pageTitle   = "certificateUploadForm"
+  val pageHeading = "Upload a submission template"
+  val pageTitle   = "Upload a submission template for your certificate"
+
+  val captionText = "Submit a certificate"
+
+  val paragraphs: List[String] = List(
+    "The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.",
+    "Read guidance on how to complete the submission template (opens in new tab)"
+  )
+
+  val insetText =
+    "If your group has more than one SAO, you must upload and submit separate templates, one for each SAO. After submitting one certificate, you can start another."
+
+  val uploadFormLabel   = "Upload a file"
+  val uploadFormInputId = "file-input"
+
+  val upscanInitiateResponse: UpscanInitiateResponse = UpscanInitiateResponse(
+    reference = "testReference",
+    postTarget = "formPostTarget",
+    formFields = Map(
+      "test1" -> "testValue1",
+      "test2" -> "testValue2"
+    )
+  )
+
+  val errorMessage = "Example error message"
 }

--- a/test/views/certificate/CertificateUploadSuccessViewSpec.scala
+++ b/test/views/certificate/CertificateUploadSuccessViewSpec.scala
@@ -54,7 +54,7 @@ class CertificateUploadSuccessViewSpec extends ViewSpecBase[CertificateUploadSuc
 
 object CertificateUploadSuccessViewSpec {
   val pageHeading = "Your submission template is uploading"
-  val pageTitle   = "Upload a submission template for your notification"
+  val pageTitle   = "Upload a submission template for your certificate"
 
   val paragraphs: List[String] = List("This may take a few minutes")
 }

--- a/test/views/certificate/CertificateUploadSuccessViewSpec.scala
+++ b/test/views/certificate/CertificateUploadSuccessViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.certificate
+
+import base.ViewSpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.certificate.CertificateUploadSuccessViewSpec.*
+import views.html.certificate.CertificateUploadSuccessView
+
+class CertificateUploadSuccessViewSpec extends ViewSpecBase[CertificateUploadSuccessView] {
+
+  private def generateView(): Document = Jsoup.parse(SUT().toString)
+
+  "CertificateUploadSuccessView" - {
+    val doc: Document = generateView()
+
+    doc.createTestsWithStandardPageElements(
+      pageTitle = pageTitle,
+      pageHeading = pageHeading,
+      showBackLink = true,
+      showIsThisPageNotWorkingProperlyLink = true,
+      hasError = false
+    )
+
+    doc.createTestsWithOrWithoutError(hasError = false)
+
+    doc.createTestsWithParagraphs(paragraphs)
+
+    "must have a spinner" in {
+      doc.select("div.loader").size() mustBe 1
+    }
+
+    "must refresh the page without adding a browser history entry" in {
+      doc.select("script").html() must include("window.location.replace(window.location.pathname)")
+      doc.select("script").html() must not include "window.location.href"
+    }
+  }
+}
+
+object CertificateUploadSuccessViewSpec {
+  val pageHeading = "Your submission template is uploading"
+  val pageTitle   = "Upload a submission template for your notification"
+
+  val paragraphs: List[String] = List("This may take a few minutes")
+}

--- a/test/views/certificate/CertificateUploadTemplateTableErrorViewSpec.scala
+++ b/test/views/certificate/CertificateUploadTemplateTableErrorViewSpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.certificate
+
+import base.ViewSpecBase
+import controllers.routes
+import models.upload.*
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import views.certificate.CertificateUploadTemplateTableErrorViewSpec.*
+import views.html.certificate.CertificateUploadTemplateTableErrorView
+
+import scala.jdk.CollectionConverters.*
+
+class CertificateUploadTemplateTableErrorViewSpec extends ViewSpecBase[CertificateUploadTemplateTableErrorView] {
+
+  private def generateView(): Document = Jsoup.parse(SUT(tableData).toString)
+
+  "CertificateUploadTemplateTableErrorView" - {
+    val doc: Document = generateView()
+
+    doc.createTestsWithStandardPageElements(
+      pageTitle = pageTitle,
+      pageHeading = pageHeading,
+      showBackLink = false,
+      showIsThisPageNotWorkingProperlyLink = true,
+      hasError = false
+    )
+
+    "must render error table columns and content" in {
+      val headings = doc.select("th.govuk-table__header").eachText()
+      headings must contain allOf ("Row", "Column", "Errors to Correct")
+      headings must not contain "Code"
+
+      val tableRows = doc.select("tbody.govuk-table__body tr")
+      tableRows.size() mustBe 2
+      tableRows.first().select("td").first().text() mustBe "9"
+      tableRows.first().select("td").first().attr("rowspan") mustBe "2"
+      doc.select("tbody.govuk-table__body").text() must include("Enter a valid Company UTR. It must be 10 digits long")
+      doc.select("tbody.govuk-table__body").text() must include(
+        "Enter a valid Company CRN. It must be 8 characters long"
+      )
+    }
+
+    "must render the problem summary and guidance link" in {
+      doc.text() must include("Your file has 2 errors.")
+      val link = doc.select("a.govuk-link").asScala.find(_.text().contains("Read guidance")).value
+      link.attr("href") mustBe routes.TemplateGuidanceController.onPageLoad().url
+      link.attr("target") mustBe "_blank"
+    }
+
+    "must render return to file upload button" in {
+      doc.select("#submit").size() mustBe 1
+      doc.select("#submit").text() mustBe "Return to file upload"
+    }
+
+    "must render the errors table with row separators removed" in {
+      doc.select("table.upload-template-errors-table").size() mustBe 1
+    }
+
+    "must render separators only between different row numbers" in {
+      doc.select("tbody.govuk-table__body tr").get(0).hasClass("upload-template-errors-table__line-start") mustBe false
+      doc.select("tbody.govuk-table__body tr").get(1).hasClass("upload-template-errors-table__line-start") mustBe false
+
+      val docWithMultipleRows = Jsoup.parse(SUT(tableDataWithMultipleRows).toString)
+      val rows                = docWithMultipleRows.select("tbody.govuk-table__body tr")
+
+      rows.get(0).hasClass("upload-template-errors-table__line-start") mustBe false
+      rows.get(1).hasClass("upload-template-errors-table__line-start") mustBe false
+      rows.get(2).hasClass("upload-template-errors-table__line-start") mustBe true
+      rows.get(3).hasClass("upload-template-errors-table__line-start") mustBe false
+    }
+
+    "must load the stylesheet containing the errors table border override" in {
+      doc.select("""link[href*="stylesheets/application.css"]""").size() mustBe 1
+    }
+  }
+}
+
+object CertificateUploadTemplateTableErrorViewSpec {
+  val pageHeading = "There is a problem with your submission template file"
+  val pageTitle   = "There is a problem with your submission template file"
+
+  val tableData: UploadTemplateTableData = UploadTemplateTableData(
+    rows = Seq.empty,
+    errors = Seq(
+      TemplateParseError(
+        line = 9,
+        column = Some("UTR"),
+        code = "invalid_company_utr",
+        message = "Enter a valid Company UTR. It must be 10 digits long"
+      ),
+      TemplateParseError(
+        line = 9,
+        column = Some("CRN"),
+        code = "invalid_company_crn",
+        message = "Enter a valid Company CRN. It must be 8 characters long"
+      )
+    )
+  )
+
+  val tableDataWithMultipleRows: UploadTemplateTableData = UploadTemplateTableData(
+    rows = Seq.empty,
+    errors = tableData.errors ++ Seq(
+      TemplateParseError(
+        line = 10,
+        column = Some("UTR"),
+        code = "invalid_company_utr",
+        message = "Enter a valid Company UTR. It must be 10 digits long"
+      ),
+      TemplateParseError(
+        line = 10,
+        column = Some("CRN"),
+        code = "invalid_company_crn",
+        message = "Enter a valid Company CRN. It must be 8 characters long"
+      )
+    )
+  )
+}

--- a/test/views/notification/NotificationUploadFormViewSpec.scala
+++ b/test/views/notification/NotificationUploadFormViewSpec.scala
@@ -18,7 +18,7 @@ package views.notification
 
 import base.ViewSpecBase
 import controllers.routes
-import forms.notification.NotificationUploadFormProvider
+import forms.UploadFormProvider
 import models.upscan.UpscanInitiateResponse
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -29,7 +29,7 @@ import NotificationUploadFormViewSpec.*
 
 class NotificationUploadFormViewSpec extends ViewSpecBase[NotificationUploadFormView] {
 
-  private val formProvider       = app.injector.instanceOf[NotificationUploadFormProvider]
+  private val formProvider       = app.injector.instanceOf[UploadFormProvider]
   private val form: Form[String] = formProvider()
 
   private def generateView(form: Form[String]): Document = {
@@ -110,6 +110,8 @@ class NotificationUploadFormViewSpec extends ViewSpecBase[NotificationUploadForm
         hiddenFields.get(1).attr("value") mustBe "testValue2"
       }
 
+      doc.createTestsWithLargeCaption(captionText)
+
       doc.createTestsWithParagraphs(paragraphs)
 
       doc
@@ -137,6 +139,8 @@ class NotificationUploadFormViewSpec extends ViewSpecBase[NotificationUploadForm
 object NotificationUploadFormViewSpec {
   val pageHeading = "Upload a submission template"
   val pageTitle   = "Upload a submission template for your notification"
+
+  val captionText = "Submit a notification"
 
   val paragraphs: List[String] = List(
     "The template must be uploaded in CSV format. If you already have the template saved in a different format (such as .xls or .xlsx), you must save it again as a CSV file.",


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Implemented file upload for the certificate journey
* Updated review qualified and review unqualified pages to make use of the file uploaded
* Updated the content for certificate file upload, review qualified and review unqualified pages so to 0.6a
* refactor: moved some shared message keys around file upload etc to a higher level
* bugfix: Updated notification flow's CTA destination for review template errors
  * Previously if the user lands on this page via the back browser navigation they the CTA will read upload file but send them to task list
* bugfix: on review unqualified companies linked fixed the bug around what is used to populate total company count

## Jira ticket(s):
* [SAOD-771](https://jira.tools.tax.service.gov.uk/browse/SAOD-771)

## Checklist
* [ ] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`? (of the SAOD-771/certificate-file-upload branch)
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
