### PR TITLE
Saod 897/final cta

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -51,6 +51,8 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
 
   lazy val upscanInitiateV2Url: String = servicesConfig.baseUrl("upscan-initiate") + "/upscan/v2/initiate"
 
+  lazy val protectedServiceBaseUrl: String = servicesConfig.baseUrl("senior-accounting-officer")
+
   lazy val internalAuthTestOnlyTokenUrl: String = servicesConfig.baseUrl("internal-auth") + "/test-only/token"
 
   val internalAuthToken: String = config.get[String]("internal-auth.token")

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -45,13 +45,11 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
   val hubSignOutUrl: String      = hubBaseUrl + "/account/sign-out-survey"
   val hubUnauthorisedUrl: String = hubBaseUrl + "/unauthorised"
 
-  def protectedServiceUrl: String = servicesConfig.baseUrl("senior-accounting-officer")
+  lazy val protectedServiceUrl: String = servicesConfig.baseUrl("senior-accounting-officer")
 
   val loginContinueUrl: String = hubBaseUrl
 
   lazy val upscanInitiateV2Url: String = servicesConfig.baseUrl("upscan-initiate") + "/upscan/v2/initiate"
-
-  lazy val protectedServiceBaseUrl: String = servicesConfig.baseUrl("senior-accounting-officer")
 
   lazy val internalAuthTestOnlyTokenUrl: String = servicesConfig.baseUrl("internal-auth") + "/test-only/token"
 

--- a/app/connectors/CertificateSubmissionConnector.scala
+++ b/app/connectors/CertificateSubmissionConnector.scala
@@ -36,7 +36,7 @@ class CertificateSubmissionConnector @Inject() (
 
   def submit(request: CertificateSubmissionRequest)(using HeaderCarrier): Future[CertificateSubmissionResponse] =
     httpClient
-      .post(url"${appConfig.protectedServiceBaseUrl}/senior-accounting-officer/certificate")
+      .post(url"${appConfig.protectedServiceUrl}/senior-accounting-officer/certificate")
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
       .map {

--- a/app/connectors/CertificateSubmissionConnector.scala
+++ b/app/connectors/CertificateSubmissionConnector.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import models.certificate.{CertificateSubmissionRequest, CertificateSubmissionResponse}
+import play.api.http.Status.CREATED
+import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.ws.writeableOf_JsValue
+import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
+import uk.gov.hmrc.http.client.HttpClientV2
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class CertificateSubmissionConnector @Inject() (
+    httpClient: HttpClientV2,
+    appConfig: AppConfig
+)(using ExecutionContext) {
+
+  def submit(request: CertificateSubmissionRequest)(using HeaderCarrier): Future[CertificateSubmissionResponse] =
+    httpClient
+      .post(url"${appConfig.protectedServiceBaseUrl}/senior-accounting-officer/certificate")
+      .withBody(Json.toJson(request))
+      .execute[HttpResponse]
+      .map {
+        case response if response.status == CREATED =>
+          response.json.validate[CertificateSubmissionResponse] match {
+            case JsSuccess(value, _) => value
+            case _                   =>
+              throw UpstreamErrorResponse(
+                "Certificate submission response did not contain a valid certificateRef",
+                CREATED
+              )
+          }
+        case response =>
+          throw UpstreamErrorResponse(response.body, response.status)
+      }
+}

--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -33,7 +33,7 @@ class DataRequiredActionImpl @Inject() (implicit val executionContext: Execution
       case None =>
         Future.successful(Left(Redirect(routes.JourneyRecoveryController.onPageLoad())))
       case Some(data) =>
-        Future.successful(Right(DataRequest(request.request, request.userId, data)))
+        Future.successful(Right(DataRequest(request.request, request.userId, request.saoSubscriptionId, data)))
     }
   }
 }

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -32,7 +32,7 @@ class DataRetrievalActionImpl @Inject() (
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
 
     sessionRepository.get(request.userId).map {
-      OptionalDataRequest(request.request, request.userId, _)
+      OptionalDataRequest(request.request, request.userId, request.saoSubscriptionId, _)
     }
   }
 }

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -23,6 +23,7 @@ import play.api.mvc.*
 import play.api.mvc.Results.*
 import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
@@ -44,10 +45,20 @@ class AuthenticatedIdentifierAction @Inject() (
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    authorised().retrieve(Retrievals.internalId) {
-      _.map { internalId =>
-        block(IdentifierRequest(request, internalId))
-      }.getOrElse(throw new UnauthorizedException("Unable to retrieve internal Id"))
+    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments) { case internalId ~ enrolments =>
+      val saoSubscriptionId = enrolments.enrolments
+        .find(_.key == AuthenticatedIdentifierAction.DsaoServiceName)
+        .flatMap(
+          _.identifiers
+            .find(_.key == AuthenticatedIdentifierAction.EtmpSubscriptionIdIdentifier)
+            .map(_.value)
+        )
+
+      (internalId, saoSubscriptionId) match {
+        case (Some(id), Some(subscriptionId)) => block(IdentifierRequest(request, id, subscriptionId))
+        case (None, _)                        => throw new UnauthorizedException("Unable to retrieve internal Id")
+        case (_, None)                        => Future.successful(Redirect(config.hubUnauthorisedUrl))
+      }
     } recover {
       case _: NoActiveSession =>
         Redirect(config.loginContinueUrl)
@@ -55,4 +66,9 @@ class AuthenticatedIdentifierAction @Inject() (
         Redirect(config.hubUnauthorisedUrl)
     }
   }
+}
+
+object AuthenticatedIdentifierAction {
+  private val DsaoServiceName              = "HMRC-DSAO-ORG"
+  private val EtmpSubscriptionIdIdentifier = "EtmpSubscriptionId"
 }

--- a/app/controllers/certificate/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/certificate/CertificateCheckYourAnswersController.scala
@@ -16,7 +16,6 @@
 
 package controllers.certificate
 
-import config.ErrorHandler
 import controllers.actions.*
 import controllers.certificate.routes as certificateRoutes
 import pages.certificate.CertificateSubmissionTokenPage
@@ -45,7 +44,6 @@ class CertificateCheckYourAnswersController @Inject() (
     sessionRepository: SessionRepository,
     certificateCheckYourAnswersService: CertificateCheckYourAnswersService,
     certificateSubmissionService: CertificateSubmissionService,
-    errorHandler: ErrorHandler,
     view: CertificateCheckYourAnswersView
 )(using ExecutionContext)
     extends FrontendBaseController
@@ -80,26 +78,19 @@ class CertificateCheckYourAnswersController @Inject() (
             case CertificateSubmissionResult.MissingData =>
               Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
             case CertificateSubmissionResult.Failed =>
-              internalServerError
+              Future.failed(CertificateCheckYourAnswersController.SubmissionFailedException)
           }
     }
   }
 
-  private def internalServerError(using RequestHeader): Future[Result] =
-    errorHandler
-      .standardErrorTemplate(
-        "Sorry, there is a problem with the service",
-        "Sorry, there is a problem with the service",
-        "Try again later."
-      )
-      .map(InternalServerError(_))
-
   private def submissionToken(form: Map[String, Seq[String]]): Option[String] =
-    form.collectFirst {
-      case (CertificateCheckYourAnswersController.TokenField, token +: _) => token
+    form.collectFirst { case (CertificateCheckYourAnswersController.TokenField, token +: _) =>
+      token
     }
 }
 
 object CertificateCheckYourAnswersController {
   val TokenField: String = "certificateSubmissionToken"
+
+  object SubmissionFailedException extends RuntimeException("Certificate submission failed")
 }

--- a/app/controllers/certificate/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/certificate/CertificateCheckYourAnswersController.scala
@@ -16,15 +16,24 @@
 
 package controllers.certificate
 
+import config.ErrorHandler
 import controllers.actions.*
-import controllers.certificate.CertificateCheckYourAnswersController.certificateId
 import controllers.certificate.routes as certificateRoutes
+import pages.certificate.CertificateSubmissionTokenPage
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.*
+import repositories.SessionRepository
 import services.CertificateCheckYourAnswersService
+import services.CertificateSubmissionService
+import services.CertificateSubmissionService.CertificateSubmissionResult
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import views.html.certificate.CertificateCheckYourAnswersView
 
+import scala.concurrent.{ExecutionContext, Future}
+
+import java.util.UUID
 import javax.inject.Inject
 
 class CertificateCheckYourAnswersController @Inject() (
@@ -33,22 +42,61 @@ class CertificateCheckYourAnswersController @Inject() (
     getData: DataRetrievalAction,
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
-    view: CertificateCheckYourAnswersView,
-    certificateCheckYourAnswersService: CertificateCheckYourAnswersService
-) extends FrontendBaseController
+    sessionRepository: SessionRepository,
+    certificateCheckYourAnswersService: CertificateCheckYourAnswersService,
+    certificateSubmissionService: CertificateSubmissionService,
+    errorHandler: ErrorHandler,
+    view: CertificateCheckYourAnswersView
+)(using ExecutionContext)
+    extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
     val summaryList = certificateCheckYourAnswersService.getSummaryList(request.userAnswers)
+    val token       = UUID.randomUUID().toString
 
-    Ok(view(summaryList))
+    for {
+      updatedAnswers <- Future.fromTry(request.userAnswers.set(CertificateSubmissionTokenPage, token))
+      _              <- sessionRepository.set(updatedAnswers)
+    } yield Ok(view(summaryList, token))
   }
 
-  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
-    Redirect(certificateRoutes.CertificateConfirmationController.onPageLoad(certificateId))
+  def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
+    given HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    request.body.asFormUrlEncoded.flatMap(
+      _.get(CertificateCheckYourAnswersController.TokenField).flatMap(_.headOption)
+    ) match {
+      case None =>
+        Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+      case Some(token) =>
+        certificateSubmissionService
+          .submit(request.userId, request.saoSubscriptionId, request.userAnswers, token)
+          .flatMap {
+            case CertificateSubmissionResult.Submitted(certificateRef) =>
+              Future.successful(
+                Redirect(certificateRoutes.CertificateConfirmationController.onPageLoad(certificateRef))
+              )
+            case CertificateSubmissionResult.Duplicate =>
+              Future.successful(Redirect(certificateRoutes.CertificateCheckYourAnswersController.onPageLoad()))
+            case CertificateSubmissionResult.MissingData =>
+              Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
+            case CertificateSubmissionResult.Failed =>
+              internalServerError
+          }
+    }
   }
+
+  private def internalServerError(using RequestHeader): Future[Result] =
+    errorHandler
+      .standardErrorTemplate(
+        "Sorry, there is a problem with the service",
+        "Sorry, there is a problem with the service",
+        "Try again later."
+      )
+      .map(InternalServerError(_))
 }
 
 object CertificateCheckYourAnswersController {
-  val certificateId: String = "SAOCRT0123456789"
+  val TokenField: String = "certificateSubmissionToken"
 }

--- a/app/controllers/certificate/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/certificate/CertificateCheckYourAnswersController.scala
@@ -64,9 +64,7 @@ class CertificateCheckYourAnswersController @Inject() (
   def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
     given HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    request.body.asFormUrlEncoded.flatMap(
-      _.get(CertificateCheckYourAnswersController.TokenField).flatMap(_.headOption)
-    ) match {
+    request.body.asFormUrlEncoded.flatMap(submissionToken) match {
       case None =>
         Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
       case Some(token) =>
@@ -95,6 +93,11 @@ class CertificateCheckYourAnswersController @Inject() (
         "Try again later."
       )
       .map(InternalServerError(_))
+
+  private def submissionToken(form: Map[String, Seq[String]]): Option[String] =
+    form.collectFirst {
+      case (CertificateCheckYourAnswersController.TokenField, token +: _) => token
+    }
 }
 
 object CertificateCheckYourAnswersController {

--- a/app/models/certificate/CertificateSubmissionRequest.scala
+++ b/app/models/certificate/CertificateSubmissionRequest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.certificate
+
+import play.api.libs.json.{Json, OFormat}
+
+final case class CertificateSubmissionRequest(
+    subscriptionId: String,
+    submitterName: Option[String],
+    SAOName: String,
+    SAOEmail: String,
+    companies: Seq[CertificateSubmissionCompany],
+    remarks: Option[String]
+)
+
+object CertificateSubmissionRequest {
+  given OFormat[CertificateSubmissionRequest] = Json.format[CertificateSubmissionRequest]
+}
+
+final case class CertificateSubmissionCompany(
+    crn: Option[String],
+    utr: String,
+    name: String,
+    accPeriodEnd: String,
+    status: String,
+    `type`: String,
+    isCorporationTaxQualified: Boolean,
+    isVatQualified: Boolean,
+    isPayeQualified: Boolean,
+    isInsurancePremiumTaxQualified: Boolean,
+    isStampDutyLandTaxQualified: Boolean,
+    isStampDutyReserveTaxQualified: Boolean,
+    isPetroleumRevenueTaxQualified: Boolean,
+    isCustomsDutiesQualified: Boolean,
+    isExciseDutiesQualified: Boolean,
+    isBankLevyQualified: Boolean
+)
+
+object CertificateSubmissionCompany {
+  given OFormat[CertificateSubmissionCompany] = Json.format[CertificateSubmissionCompany]
+}
+
+final case class CertificateSubmissionResponse(certificateRef: String)
+
+object CertificateSubmissionResponse {
+  given OFormat[CertificateSubmissionResponse] = Json.format[CertificateSubmissionResponse]
+}

--- a/app/models/certificate/CertificateSubmissionRequest.scala
+++ b/app/models/certificate/CertificateSubmissionRequest.scala
@@ -21,8 +21,8 @@ import play.api.libs.json.{Json, OFormat}
 final case class CertificateSubmissionRequest(
     subscriptionId: String,
     submitterName: Option[String],
-    SAOName: String,
-    SAOEmail: String,
+    saoName: String,
+    saoEmail: String,
     companies: Seq[CertificateSubmissionCompany],
     remarks: Option[String]
 )

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,8 +19,12 @@ package models.requests
 import models.UserAnswers
 import play.api.mvc.{Request, WrappedRequest}
 
-case class OptionalDataRequest[A](request: Request[A], userId: String, userAnswers: Option[UserAnswers])
-    extends WrappedRequest[A](request)
+case class OptionalDataRequest[A](
+    request: Request[A],
+    userId: String,
+    saoSubscriptionId: String,
+    userAnswers: Option[UserAnswers]
+) extends WrappedRequest[A](request)
 
-case class DataRequest[A](request: Request[A], userId: String, userAnswers: UserAnswers)
+case class DataRequest[A](request: Request[A], userId: String, saoSubscriptionId: String, userAnswers: UserAnswers)
     extends WrappedRequest[A](request)

--- a/app/pages/certificate/CertificateSubmissionTokenPage.scala
+++ b/app/pages/certificate/CertificateSubmissionTokenPage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-package models.requests
+package pages.certificate
 
-import play.api.mvc.{Request, WrappedRequest}
+import pages.Page.CERTIFICATE_PATH
+import pages.QuestionPage
+import play.api.libs.json.JsPath
 
-final case class IdentifierRequest[A](request: Request[A], userId: String, saoSubscriptionId: String)
-    extends WrappedRequest[A](request)
+case object CertificateSubmissionTokenPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ CERTIFICATE_PATH \ toString
+
+  override def toString: String = "certificateSubmissionToken"
+}

--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -63,7 +63,9 @@ class SessionRepository @Inject() (
 
   given instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
 
-  private def byId(id: String): Bson = Filters.equal("_id", id)
+  private def byId(id: String): Bson                          = Filters.equal("_id", id)
+  private def certificateSubmissionToken(token: String): Bson =
+    Filters.equal("data.certificate.certificateSubmissionToken", Codecs.toBson(token))
 
   def keepAlive(id: String): Future[Boolean] = Mdc.preservingMdc {
     collection
@@ -102,6 +104,19 @@ class SessionRepository @Inject() (
       .deleteOne(byId(id))
       .toFuture()
       .map(_ => true)
+  }
+
+  def claimCertificateSubmissionToken(id: String, token: String): Future[Boolean] = Mdc.preservingMdc {
+    collection
+      .updateOne(
+        filter = Filters.and(byId(id), certificateSubmissionToken(token)),
+        update = Updates.combine(
+          Updates.unset("data.certificate.certificateSubmissionToken"),
+          Updates.set("lastUpdated", Instant.now(clock))
+        )
+      )
+      .toFuture()
+      .map(_.getMatchedCount > 0)
   }
 
   def updateUploadStatus(journey: UploadJourney, reference: String, newStatus: UploadStatus): Future[Boolean] =

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.CertificateSubmissionConnector
+import models.UserAnswers
+import models.certificate.*
+import models.upload.{CompanyStatus, ParsedSubmissionRow}
+import pages.certificate.*
+import play.api.Logging
+import repositories.SessionRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class CertificateSubmissionService @Inject() (
+    connector: CertificateSubmissionConnector,
+    sessionRepository: SessionRepository
+)(using ExecutionContext)
+    extends Logging {
+
+  import CertificateSubmissionService.*
+
+  def submit(
+      userId: String,
+      saoSubscriptionId: String,
+      userAnswers: UserAnswers,
+      token: String
+  )(using HeaderCarrier): Future[CertificateSubmissionResult] =
+    buildRequest(saoSubscriptionId, userAnswers) match {
+      case Left(error) =>
+        logger.warn(s"Certificate submission could not be built: $error")
+        Future.successful(CertificateSubmissionResult.MissingData)
+      case Right(request) =>
+        sessionRepository.claimCertificateSubmissionToken(userId, token).flatMap {
+          case false =>
+            logger.warn("Certificate submission token was missing or already used")
+            Future.successful(CertificateSubmissionResult.Duplicate)
+          case true =>
+            connector
+              .submit(request)
+              .flatMap(response =>
+                sessionRepository.clear(userId).map(_ => CertificateSubmissionResult.Submitted(response.certificateRef))
+              )
+              .recover { case e =>
+                logger.error("Certificate submission failed", e)
+                CertificateSubmissionResult.Failed
+              }
+        }
+    }
+
+  private def buildRequest(
+      saoSubscriptionId: String,
+      userAnswers: UserAnswers
+  ): Either[String, CertificateSubmissionRequest] =
+    for {
+      saoName   <- userAnswers.get(CertificateSaoFullNamePage).toRight("missing SAO name")
+      saoEmail  <- userAnswers.get(CertificateSaoEmailPage).toRight("missing SAO email")
+      tableData <- userAnswers.get(CertificateUploadTemplateTablePage).toRight("missing uploaded certificate data")
+      companies = tableData.rows.map(toCompany)
+      _ <- Either.cond(companies.nonEmpty, (), "missing companies")
+    } yield CertificateSubmissionRequest(
+      subscriptionId = saoSubscriptionId,
+      submitterName = submitterName(userAnswers),
+      SAOName = saoName,
+      SAOEmail = saoEmail,
+      companies = companies,
+      remarks = userAnswers.getNullable(CertificateAdditionalInformationPage)
+    )
+
+  private def submitterName(userAnswers: UserAnswers): Option[String] =
+    userAnswers
+      .get(CertificateWhoIsSubmittingPage)
+      .collect { case CertificateWhoIsSubmitting.StandIn =>
+        userAnswers.get(CertificateDeclarationStandInPage).map(_.StandInName)
+      }
+      .flatten
+
+  private def toCompany(row: ParsedSubmissionRow): CertificateSubmissionCompany =
+    CertificateSubmissionCompany(
+      crn = row.notification.companyCrn.map(_.value),
+      utr = row.notification.companyUtr.value,
+      name = row.notification.companyName,
+      accPeriodEnd = row.notification.financialYearEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
+      status = status(row.notification.companyStatus),
+      `type` = row.notification.companyType.toString,
+      isCorporationTaxQualified = row.certificate.corporationTax,
+      isVatQualified = row.certificate.valueAddedTax,
+      isPayeQualified = row.certificate.paye,
+      isInsurancePremiumTaxQualified = row.certificate.insurancePremiumTax,
+      isStampDutyLandTaxQualified = row.certificate.stampDutyLandTax,
+      isStampDutyReserveTaxQualified = row.certificate.stampDutyReserveTax,
+      isPetroleumRevenueTaxQualified = row.certificate.petroleumRevenueTax,
+      isCustomsDutiesQualified = row.certificate.customsDuties,
+      isExciseDutiesQualified = row.certificate.exciseDuties,
+      isBankLevyQualified = row.certificate.bankLevy
+    )
+
+  private def status(companyStatus: CompanyStatus): String =
+    companyStatus match {
+      case CompanyStatus.Active         => "COMPLIANT"
+      case CompanyStatus.Dormant        => "DORMANT"
+      case CompanyStatus.Administration => "ADMINISTRATION"
+      case CompanyStatus.Liquidation    => "LIQUIDATION"
+    }
+}
+
+object CertificateSubmissionService {
+  enum CertificateSubmissionResult {
+    case Submitted(certificateRef: String)
+    case MissingData
+    case Duplicate
+    case Failed
+  }
+}

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -22,6 +22,7 @@ import models.certificate.*
 import models.upload.{CompanyStatus, ParsedSubmissionRow}
 import pages.certificate.*
 import play.api.Logging
+import play.api.libs.json.Json
 import repositories.SessionRepository
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -57,7 +58,9 @@ class CertificateSubmissionService @Inject() (
             connector
               .submit(request)
               .flatMap(response =>
-                sessionRepository.clear(userId).map(_ => CertificateSubmissionResult.Submitted(response.certificateRef))
+                sessionRepository
+                  .set(userAnswers.copy(data = Json.obj()))
+                  .map(_ => CertificateSubmissionResult.Submitted(response.certificateRef))
               )
               .recover { case e =>
                 logger.error("Certificate submission failed", e)

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -57,11 +57,15 @@ class CertificateSubmissionService @Inject() (
           case true =>
             connector
               .submit(request)
-              .flatMap(response =>
+              .flatMap { response =>
                 sessionRepository
                   .set(userAnswers.copy(data = Json.obj()))
+                  .recover { case e =>
+                    logger.warn(s"Certificate ${response.certificateRef} submitted but wiping journey data failed", e)
+                    true
+                  }
                   .map(_ => CertificateSubmissionResult.Submitted(response.certificateRef))
-              )
+              }
               .recover { case e =>
                 logger.error("Certificate submission failed", e)
                 CertificateSubmissionResult.Failed

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -79,8 +79,8 @@ class CertificateSubmissionService @Inject() (
     } yield CertificateSubmissionRequest(
       subscriptionId = saoSubscriptionId,
       submitterName = submitterName(userAnswers),
-      SAOName = saoName,
-      SAOEmail = saoEmail,
+      saoName = saoName,
+      saoEmail = saoEmail,
       companies = companies,
       remarks = userAnswers.getNullable(CertificateAdditionalInformationPage)
     )

--- a/app/views/certificate/CertificateCheckYourAnswersView.scala.html
+++ b/app/views/certificate/CertificateCheckYourAnswersView.scala.html
@@ -23,7 +23,7 @@
     govukSummaryList: GovukSummaryList
 )
 
-@(summaryList: SummaryList)(using request: Request[?], messages: Messages)
+@(summaryList: SummaryList, certificateSubmissionToken: String)(using request: Request[?], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("certificateCheckYourAnswers.title"))) {
 
@@ -33,8 +33,11 @@
     <div class="govuk-summary-list__row">@govukSummaryList(summaryList)</div>
 
     @formHelper(action = certificateRoutes.CertificateCheckYourAnswersController.onSubmit()) {
+        <input type="hidden" name="certificateSubmissionToken" value="@certificateSubmissionToken">
         @govukButton(
-            ButtonViewModel(messages("site.confirmAndSubmit").toText).withAttribute("id", "submit")
+            ButtonViewModel(messages("site.confirmAndSubmit").toText)
+                .withAttribute("id", "submit")
+                .withAttribute("data-prevent-double-click", "true")
         )
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,12 +39,6 @@ microservice {
       port     = 10058
     }
 
-    senior-accounting-officer {
-      protocol = http
-      host     = localhost
-      port     = 10059
-    }
-
     auth {
       protocol = http
       host     = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,6 +39,12 @@ microservice {
       port     = 10058
     }
 
+    senior-accounting-officer {
+      protocol = http
+      host     = localhost
+      port     = 10059
+    }
+
     auth {
       protocol = http
       host     = localhost

--- a/it/test/support/MockAuthHelper.scala
+++ b/it/test/support/MockAuthHelper.scala
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping
 object MockAuthHelper {
 
   val authSession: Map[String, String] = Map("authToken" -> "mock-bearer-token")
-  
+
   val authoriseUri: String = "/auth/authorise"
 
   def mockAuthOk(): StubMapping =
@@ -33,7 +33,19 @@ object MockAuthHelper {
             .withHeader("content-type", "application/json")
             .withBody(
               """{
-                | "internalId": "testId"
+                | "internalId": "testId",
+                | "allEnrolments": [
+                |   {
+                |     "key": "HMRC-DSAO-ORG",
+                |     "identifiers": [
+                |       {
+                |         "key": "EtmpSubscriptionId",
+                |         "value": "SAOSUB123456789"
+                |       }
+                |     ],
+                |     "state": "Activated"
+                |   }
+                | ]
                 |}""".stripMargin)
             .withStatus(200)
         )

--- a/it/test/support/MockAuthHelper.scala
+++ b/it/test/support/MockAuthHelper.scala
@@ -18,6 +18,7 @@ package support
 
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import utils.TestDataGenerator.testSaoSubscriptionId
 
 object MockAuthHelper {
 
@@ -32,7 +33,7 @@ object MockAuthHelper {
           aResponse()
             .withHeader("content-type", "application/json")
             .withBody(
-              """{
+              s"""{
                 | "internalId": "testId",
                 | "allEnrolments": [
                 |   {
@@ -40,7 +41,7 @@ object MockAuthHelper {
                 |     "identifiers": [
                 |       {
                 |         "key": "EtmpSubscriptionId",
-                |         "value": "SAOSUB123456789"
+                |         "value": "$testSaoSubscriptionId"
                 |       }
                 |     ],
                 |     "state": "Activated"

--- a/resources/templates/testonly/CSV scenarios/fail/incorrect template.csv
+++ b/resources/templates/testonly/CSV scenarios/fail/incorrect template.csv
@@ -1,0 +1,14 @@
+"Senior Accounting Officer  Submission template. List all the companies in your group. Complete one row per company. You can add as many rows as needed.
+",,,,,,,,,,,,,,,,,
+How to complete this  ,,,,,,,,,,,,,,,,,
+"1. Notification columns (A to F): Enter company details in the correct format. For company type and status, use the drop down to select one",,,,,,,,,,,,,,,,,
+"2. Certificate columns (G to R): Mark tax regimes with an x where the company did not have appropriate tax accounting arrangements and leave all others blank. The certificate type will show as Qualified automatically if any regime is marked. If none are marked, enter Unqualified in the certificate type column.",,,,,,,,,,,,,,,,,
+3. Additional information (column R): You must add an explanation if the certificate is qualified and a tax regime is marked x. There is no character limit. You can write as much information as you would normally provide in an email to HMRC.,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,Notification,,,,Certificate,,,,,,,,,,,,
+Company name,Company UTR,Company CRN,Company type,Company status,Financial year end date,Corporation tax,Value added tax,PAYE,Insurance premium tax,Stamp duty land tax,Stamp duty reserve tax,Petroleum revenue tax,Customs Duties,Excise Duties,Bank Levy,Certificate type,Additional information 
+Z Moderately Complex A,111111111,11111111,PLC,Active,31/12/2025,,,,,,,,,,,Unqualified,
+Z Moderately Complex E,2222222222,22222222,PLC,Active,31/12/2025,,,,,,,,,,,Unqualified,
+Z Moderately Complex F,3333333333,33333333,PLC,Active,31/12/2025,,,,,,,,,,,Unqualified,
+Z Moderately Complex G,4444444444,4444444,PLC,Active,31/12/2025,,,,,X,,,,,,Unqualified,
+Z Moderately Complex D,7777777777,77777777,PLC,Active,31/12/2025,,,,,,,,,,,Unqualified,

--- a/test-utils/utils/TestDataGenerator.scala
+++ b/test-utils/utils/TestDataGenerator.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import uk.gov.hmrc.domain.SaUtrGenerator
+
+import scala.util.Random
+
+object TestDataGenerator {
+
+  val testSaoSubscriptionId: String = "SAOSUB123456789"
+
+  def generateCrn: String = {
+    val num = Random.nextInt(1000000)
+    f"$num%08d"
+  }
+
+  def generateUtr: String = {
+    val seed = Random.nextInt(1000000)
+    SaUtrGenerator(seed).nextSaUtr.toString
+  }
+}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -31,6 +31,7 @@ import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
+import utils.TestDataGenerator
 
 import java.time.LocalDate
 
@@ -42,19 +43,20 @@ trait SpecBase
     with ScalaFutures
     with IntegrationPatience {
 
-  val userAnswersId: String = "id"
-  val etmpSafeId            = "etmpSafeId"
-  val companyCrn            = "companyCrn"
-  val companyName           = "companyName"
-  val companyUtr            = "companyUtr"
-  val contact1Name          = "Contact 1 Name"
-  val contact1Email         = "1@test.com"
-  val contact1Language      = "en"
-  val contact1Status        = "valid"
-  val contact2Name          = "Contact 2 Name"
-  val contact2Email         = "2@test.com"
-  val contact2Language      = "cy"
-  val contact2Status        = "unreachable"
+  val userAnswersId: String         = "id"
+  val testSaoSubscriptionId: String = TestDataGenerator.testSaoSubscriptionId
+  val etmpSafeId                    = "etmpSafeId"
+  val companyCrn                    = "companyCrn"
+  val companyName                   = "companyName"
+  val companyUtr                    = "companyUtr"
+  val contact1Name                  = "Contact 1 Name"
+  val contact1Email                 = "1@test.com"
+  val contact1Language              = "en"
+  val contact1Status                = "valid"
+  val contact2Name                  = "Contact 2 Name"
+  val contact2Email                 = "2@test.com"
+  val contact2Language              = "cy"
+  val contact2Status                = "unreachable"
 
   def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId)
 

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -42,9 +42,10 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar {
         when(sessionRepository.get("id")) thenReturn Future(None)
         val action = new Harness(sessionRepository)
 
-        val result = action.callTransform(IdentifierRequest(FakeRequest(), "id")).futureValue
+        val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", "SAOSUB123456789")).futureValue
 
         result.userAnswers must not be defined
+        result.saoSubscriptionId mustBe "SAOSUB123456789"
       }
     }
 
@@ -56,9 +57,10 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar {
         when(sessionRepository.get("id")) thenReturn Future(Some(emptyUserAnswers))
         val action = new Harness(sessionRepository)
 
-        val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id")).futureValue
+        val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id", "SAOSUB123456789")).futureValue
 
         result.userAnswers mustBe defined
+        result.saoSubscriptionId mustBe "SAOSUB123456789"
       }
     }
   }

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -42,10 +42,10 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar {
         when(sessionRepository.get("id")) thenReturn Future(None)
         val action = new Harness(sessionRepository)
 
-        val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", "SAOSUB123456789")).futureValue
+        val result = action.callTransform(IdentifierRequest(FakeRequest(), "id", testSaoSubscriptionId)).futureValue
 
         result.userAnswers must not be defined
-        result.saoSubscriptionId mustBe "SAOSUB123456789"
+        result.saoSubscriptionId mustBe testSaoSubscriptionId
       }
     }
 
@@ -57,10 +57,10 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar {
         when(sessionRepository.get("id")) thenReturn Future(Some(emptyUserAnswers))
         val action = new Harness(sessionRepository)
 
-        val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id", "SAOSUB123456789")).futureValue
+        val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id", testSaoSubscriptionId)).futureValue
 
         result.userAnswers mustBe defined
-        result.saoSubscriptionId mustBe "SAOSUB123456789"
+        result.saoSubscriptionId mustBe testSaoSubscriptionId
       }
     }
   }

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
-    Future(OptionalDataRequest(request.request, request.userId, dataToReturn))
+    Future(OptionalDataRequest(request.request, request.userId, request.saoSubscriptionId, dataToReturn))
 
   override protected implicit val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -26,7 +26,7 @@ import javax.inject.Inject
 class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
 
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
-    block(IdentifierRequest(request, "id"))
+    block(IdentifierRequest(request, "id", "SAOSUB123456789"))
 
   override def parser: BodyParser[AnyContent] =
     bodyParsers.default

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -18,6 +18,7 @@ package controllers.actions
 
 import models.requests.IdentifierRequest
 import play.api.mvc.*
+import utils.TestDataGenerator
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -26,7 +27,7 @@ import javax.inject.Inject
 class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
 
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
-    block(IdentifierRequest(request, "id", "SAOSUB123456789"))
+    block(IdentifierRequest(request, "id", TestDataGenerator.testSaoSubscriptionId))
 
   override def parser: BodyParser[AnyContent] =
     bodyParsers.default

--- a/test/controllers/actions/NotificationTaskAvailabilityActionSpec.scala
+++ b/test/controllers/actions/NotificationTaskAvailabilityActionSpec.scala
@@ -31,12 +31,12 @@ class NotificationTaskAvailabilityActionSpec extends SpecBase {
 
   class UploadHarness extends RequireNotificationUploadUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, testSaoSubscriptionId, userAnswers))
   }
 
   class SubmitHarness extends RequireSubmitNotificationUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, testSaoSubscriptionId, userAnswers))
   }
 
   "RequireNotificationUploadUnlockedAction" - {

--- a/test/controllers/actions/NotificationTaskAvailabilityActionSpec.scala
+++ b/test/controllers/actions/NotificationTaskAvailabilityActionSpec.scala
@@ -31,12 +31,12 @@ class NotificationTaskAvailabilityActionSpec extends SpecBase {
 
   class UploadHarness extends RequireNotificationUploadUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
   }
 
   class SubmitHarness extends RequireSubmitNotificationUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
   }
 
   "RequireNotificationUploadUnlockedAction" - {

--- a/test/controllers/actions/RequireCertificateSubmitCertificateStageUnlockedActionSpec.scala
+++ b/test/controllers/actions/RequireCertificateSubmitCertificateStageUnlockedActionSpec.scala
@@ -32,7 +32,7 @@ class RequireCertificateSubmitCertificateStageUnlockedActionSpec extends SpecBas
 
   class Harness extends RequireCertificateSubmitCertificateStageUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, testSaoSubscriptionId, userAnswers))
   }
 
   "RequireCertificateSubmitCertificateStageUnlockedAction" - {

--- a/test/controllers/actions/RequireCertificateSubmitCertificateStageUnlockedActionSpec.scala
+++ b/test/controllers/actions/RequireCertificateSubmitCertificateStageUnlockedActionSpec.scala
@@ -32,7 +32,7 @@ class RequireCertificateSubmitCertificateStageUnlockedActionSpec extends SpecBas
 
   class Harness extends RequireCertificateSubmitCertificateStageUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
   }
 
   "RequireCertificateSubmitCertificateStageUnlockedAction" - {

--- a/test/controllers/actions/RequireCertificateUploadSubmissionTemplateUnlockedActionSpec.scala
+++ b/test/controllers/actions/RequireCertificateUploadSubmissionTemplateUnlockedActionSpec.scala
@@ -32,7 +32,7 @@ class RequireCertificateUploadSubmissionTemplateUnlockedActionSpec extends SpecB
 
   class Harness extends RequireCertificateUploadSubmissionTemplateUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, testSaoSubscriptionId, userAnswers))
   }
 
   "RequireCertificateUploadSubmissionTemplateUnlockedAction" - {

--- a/test/controllers/actions/RequireCertificateUploadSubmissionTemplateUnlockedActionSpec.scala
+++ b/test/controllers/actions/RequireCertificateUploadSubmissionTemplateUnlockedActionSpec.scala
@@ -32,7 +32,7 @@ class RequireCertificateUploadSubmissionTemplateUnlockedActionSpec extends SpecB
 
   class Harness extends RequireCertificateUploadSubmissionTemplateUnlockedAction {
     def callFilter(userAnswers: UserAnswers): Future[Option[play.api.mvc.Result]] =
-      filter(DataRequest(FakeRequest(), userAnswers.id, userAnswers))
+      filter(DataRequest(FakeRequest(), userAnswers.id, "SAOSUB123456789", userAnswers))
   }
 
   "RequireCertificateUploadSubmissionTemplateUnlockedAction" - {

--- a/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
@@ -82,9 +82,10 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
 
     "must submit the certificate and redirect to confirmation for a POST" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
+      val certificateRef        = "CRT0123456789"
 
       when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
-        .thenReturn(Future.successful(CertificateSubmissionResult.Submitted("CRT0123456789")))
+        .thenReturn(Future.successful(CertificateSubmissionResult.Submitted(certificateRef)))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
@@ -100,7 +101,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual certificateRoutes.CertificateConfirmationController
-          .onPageLoad("CRT0123456789")
+          .onPageLoad(certificateRef)
           .url
       }
     }

--- a/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
@@ -19,9 +19,9 @@ package controllers.certificate
 import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import controllers.routes
+import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.{any, eq as meq}
 import org.mockito.Mockito.*
-import org.jsoup.Jsoup
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.test.FakeRequest
@@ -54,9 +54,9 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[CertificateCheckYourAnswersView]
+        val view     = application.injector.instanceOf[CertificateCheckYourAnswersView]
         val document = Jsoup.parse(contentAsString(result))
-        val token = document.select("input[name=certificateSubmissionToken]").attr("value")
+        val token    = document.select("input[name=certificateSubmissionToken]").attr("value")
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(SummaryList(), token)(using request, messages(application)).toString
@@ -105,7 +105,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
       }
     }
 
-    "must return internal server error when submission fails" in {
+    "must fail when submission fails so the error handler can render the 500 page" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
       when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
@@ -123,7 +123,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
 
         val result = route(application, request).value
 
-        status(result) mustEqual INTERNAL_SERVER_ERROR
+        result.failed.futureValue mustBe CertificateCheckYourAnswersController.SubmissionFailedException
       }
     }
 
@@ -169,7 +169,9 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual certificateRoutes.CertificateCheckYourAnswersController.onPageLoad().url
+        redirectLocation(result).value mustEqual certificateRoutes.CertificateCheckYourAnswersController
+          .onPageLoad()
+          .url
       }
     }
 

--- a/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
@@ -83,7 +83,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must submit the certificate and redirect to confirmation for a POST" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Submitted("CRT0123456789")))
 
       val application =
@@ -108,7 +108,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must fail when submission fails so the error handler can render the 500 page" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Failed))
 
       val application =
@@ -130,7 +130,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must redirect to Journey Recovery when required submission data is missing" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.MissingData))
 
       val application =
@@ -153,7 +153,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must redirect back to check your answers when the submission token has already been used" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Duplicate))
 
       val application =

--- a/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
@@ -17,18 +17,22 @@
 package controllers.certificate
 
 import base.SpecBase
-import controllers.certificate.CertificateCheckYourAnswersController.certificateId
 import controllers.certificate.routes as certificateRoutes
 import controllers.routes
 import org.mockito.ArgumentMatchers.{any, eq as meq}
 import org.mockito.Mockito.*
+import org.jsoup.Jsoup
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import services.CertificateCheckYourAnswersService
+import services.CertificateSubmissionService
+import services.CertificateSubmissionService.CertificateSubmissionResult
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import views.html.certificate.CertificateCheckYourAnswersView
+
+import scala.concurrent.Future
 
 class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
 
@@ -51,9 +55,11 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
         val result = route(application, request).value
 
         val view = application.injector.instanceOf[CertificateCheckYourAnswersView]
+        val document = Jsoup.parse(contentAsString(result))
+        val token = document.select("input[name=certificateSubmissionToken]").attr("value")
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(SummaryList())(using request, messages(application)).toString
+        contentAsString(result) mustEqual view(SummaryList(), token)(using request, messages(application)).toString
         verify(mockService).getSummaryList(meq(testAnswers))(using any())
       }
     }
@@ -70,9 +76,100 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must submit the certificate and redirect to confirmation for a POST" in {
+      val mockSubmissionService = mock[CertificateSubmissionService]
+
+      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResult.Submitted("CRT0123456789")))
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[CertificateSubmissionService].toInstance(mockSubmissionService))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateRoutes.CertificateCheckYourAnswersController.onSubmit().url)
+            .withFormUrlEncodedBody("certificateSubmissionToken" -> "token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual certificateRoutes.CertificateConfirmationController
-          .onPageLoad(certificateId)
+          .onPageLoad("CRT0123456789")
           .url
+      }
+    }
+
+    "must return internal server error when submission fails" in {
+      val mockSubmissionService = mock[CertificateSubmissionService]
+
+      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResult.Failed))
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[CertificateSubmissionService].toInstance(mockSubmissionService))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateRoutes.CertificateCheckYourAnswersController.onSubmit().url)
+            .withFormUrlEncodedBody("certificateSubmissionToken" -> "token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "must redirect to Journey Recovery when required submission data is missing" in {
+      val mockSubmissionService = mock[CertificateSubmissionService]
+
+      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResult.MissingData))
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[CertificateSubmissionService].toInstance(mockSubmissionService))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateRoutes.CertificateCheckYourAnswersController.onSubmit().url)
+            .withFormUrlEncodedBody("certificateSubmissionToken" -> "token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect back to check your answers when the submission token has already been used" in {
+      val mockSubmissionService = mock[CertificateSubmissionService]
+
+      when(mockSubmissionService.submit(meq("id"), meq("SAOSUB123456789"), any(), meq("token"))(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResult.Duplicate))
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(bind[CertificateSubmissionService].toInstance(mockSubmissionService))
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, certificateRoutes.CertificateCheckYourAnswersController.onSubmit().url)
+            .withFormUrlEncodedBody("certificateSubmissionToken" -> "token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual certificateRoutes.CertificateCheckYourAnswersController.onPageLoad().url
       }
     }
 

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.certificate
+
+import base.SpecBase
+import play.api.libs.json.{JsError, JsObject, JsSuccess, JsValue, Json}
+
+class CertificateSubmissionRequestFormatSpec extends SpecBase {
+
+  "CertificateSubmissionRequest" - {
+
+    "must write to and read from JSON" in {
+      Json.toJson(request) mustBe requestJson
+      requestJson.validate[CertificateSubmissionRequest] mustBe JsSuccess(request)
+    }
+
+    "must write and read empty optional fields" in {
+      val requestWithoutOptionalValues = request.copy(
+        submitterName = None,
+        companies = Seq(company.copy(crn = None)),
+        remarks = None
+      )
+
+      val json = Json.toJson(requestWithoutOptionalValues)
+
+      (json \ "submitterName").asOpt[String] mustBe None
+      (json \ "companies" \ 0 \ "crn").asOpt[String] mustBe None
+      (json \ "remarks").asOpt[String] mustBe None
+      json.validate[CertificateSubmissionRequest] mustBe JsSuccess(requestWithoutOptionalValues)
+    }
+
+    "must fail to read when a required field is missing" in {
+      val result = requestJson.as[JsObject].-("subscriptionId").validate[CertificateSubmissionRequest]
+
+      result mustBe a[JsError]
+    }
+  }
+
+  "CertificateSubmissionCompany" - {
+
+    "must write to and read from JSON" in {
+      Json.toJson(company) mustBe companyJson
+      companyJson.validate[CertificateSubmissionCompany] mustBe JsSuccess(company)
+    }
+
+    "must fail to read when a tax regime flag is missing" in {
+      val result = companyJson.as[JsObject].-("isVatQualified").validate[CertificateSubmissionCompany]
+
+      result mustBe a[JsError]
+    }
+  }
+
+  "CertificateSubmissionResponse" - {
+
+    "must write to and read from JSON" in {
+      val response = CertificateSubmissionResponse("CRT0123456789")
+      val json     = Json.obj("certificateRef" -> "CRT0123456789")
+
+      Json.toJson(response) mustBe json
+      json.validate[CertificateSubmissionResponse] mustBe JsSuccess(response)
+    }
+
+    "must fail to read when certificateRef is missing" in {
+      Json.obj().validate[CertificateSubmissionResponse] mustBe a[JsError]
+    }
+  }
+
+  private val company: CertificateSubmissionCompany =
+    CertificateSubmissionCompany(
+      crn = Some("AB123456"),
+      utr = "1234567890",
+      name = "Example Ltd",
+      accPeriodEnd = "2026-03-31",
+      status = "COMPLIANT",
+      `type` = "LTD",
+      isCorporationTaxQualified = true,
+      isVatQualified = false,
+      isPayeQualified = false,
+      isInsurancePremiumTaxQualified = false,
+      isStampDutyLandTaxQualified = false,
+      isStampDutyReserveTaxQualified = false,
+      isPetroleumRevenueTaxQualified = false,
+      isCustomsDutiesQualified = false,
+      isExciseDutiesQualified = false,
+      isBankLevyQualified = false
+    )
+
+  private val companyJson: JsValue = Json.parse(
+    """{
+      |  "crn": "AB123456",
+      |  "utr": "1234567890",
+      |  "name": "Example Ltd",
+      |  "accPeriodEnd": "2026-03-31",
+      |  "status": "COMPLIANT",
+      |  "type": "LTD",
+      |  "isCorporationTaxQualified": true,
+      |  "isVatQualified": false,
+      |  "isPayeQualified": false,
+      |  "isInsurancePremiumTaxQualified": false,
+      |  "isStampDutyLandTaxQualified": false,
+      |  "isStampDutyReserveTaxQualified": false,
+      |  "isPetroleumRevenueTaxQualified": false,
+      |  "isCustomsDutiesQualified": false,
+      |  "isExciseDutiesQualified": false,
+      |  "isBankLevyQualified": false
+      |}""".stripMargin
+  )
+
+  private val request: CertificateSubmissionRequest =
+    CertificateSubmissionRequest(
+      subscriptionId = "SAOSUB123456789",
+      submitterName = Some("Proxy Person"),
+      SAOName = "Senior Officer",
+      SAOEmail = "sao@example.com",
+      companies = Seq(company),
+      remarks = Some("Certificate remarks")
+    )
+
+  private val requestJson: JsValue = Json.parse(
+    """{
+      |  "subscriptionId": "SAOSUB123456789",
+      |  "submitterName": "Proxy Person",
+      |  "SAOName": "Senior Officer",
+      |  "SAOEmail": "sao@example.com",
+      |  "companies": [
+      |    {
+      |      "crn": "AB123456",
+      |      "utr": "1234567890",
+      |      "name": "Example Ltd",
+      |      "accPeriodEnd": "2026-03-31",
+      |      "status": "COMPLIANT",
+      |      "type": "LTD",
+      |      "isCorporationTaxQualified": true,
+      |      "isVatQualified": false,
+      |      "isPayeQualified": false,
+      |      "isInsurancePremiumTaxQualified": false,
+      |      "isStampDutyLandTaxQualified": false,
+      |      "isStampDutyReserveTaxQualified": false,
+      |      "isPetroleumRevenueTaxQualified": false,
+      |      "isCustomsDutiesQualified": false,
+      |      "isExciseDutiesQualified": false,
+      |      "isBankLevyQualified": false
+      |    }
+      |  ],
+      |  "remarks": "Certificate remarks"
+      |}""".stripMargin
+  )
+}

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -19,7 +19,12 @@ package models.certificate
 import base.SpecBase
 import play.api.libs.json.*
 
+import CertificateSubmissionRequestFormatSpec.*
+
 class CertificateSubmissionRequestFormatSpec extends SpecBase {
+
+  private val request     = certificateSubmissionRequest(testSaoSubscriptionId)
+  private val requestJson = certificateSubmissionRequestJson(testSaoSubscriptionId)
 
   "CertificateSubmissionRequest" - {
 
@@ -79,7 +84,11 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
     }
   }
 
-  private val company: CertificateSubmissionCompany =
+}
+
+object CertificateSubmissionRequestFormatSpec {
+
+  val company: CertificateSubmissionCompany =
     CertificateSubmissionCompany(
       crn = Some("AB123456"),
       utr = "1234567890",
@@ -99,7 +108,7 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
       isBankLevyQualified = false
     )
 
-  private val companyJson: JsValue = Json.parse(
+  val companyJson: JsValue = Json.parse(
     """{
       |  "crn": "AB123456",
       |  "utr": "1234567890",
@@ -120,7 +129,7 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
       |}""".stripMargin
   )
 
-  private val request: CertificateSubmissionRequest =
+  def certificateSubmissionRequest(testSaoSubscriptionId: String): CertificateSubmissionRequest =
     CertificateSubmissionRequest(
       subscriptionId = testSaoSubscriptionId,
       submitterName = Some("Proxy Person"),
@@ -130,7 +139,7 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
       remarks = Some("Certificate remarks")
     )
 
-  private val requestJson: JsValue = Json.parse(
+  def certificateSubmissionRequestJson(testSaoSubscriptionId: String): JsValue = Json.parse(
     s"""{
       |  "subscriptionId": "$testSaoSubscriptionId",
       |  "submitterName": "Proxy Person",

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -122,7 +122,7 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
 
   private val request: CertificateSubmissionRequest =
     CertificateSubmissionRequest(
-      subscriptionId = "SAOSUB123456789",
+      subscriptionId = testSaoSubscriptionId,
       submitterName = Some("Proxy Person"),
       saoName = "Senior Officer",
       saoEmail = "sao@example.com",
@@ -131,8 +131,8 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
     )
 
   private val requestJson: JsValue = Json.parse(
-    """{
-      |  "subscriptionId": "SAOSUB123456789",
+    s"""{
+      |  "subscriptionId": "$testSaoSubscriptionId",
       |  "submitterName": "Proxy Person",
       |  "saoName": "Senior Officer",
       |  "saoEmail": "sao@example.com",

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -17,7 +17,7 @@
 package models.certificate
 
 import base.SpecBase
-import play.api.libs.json.{JsError, JsObject, JsSuccess, JsValue, Json}
+import play.api.libs.json.*
 
 class CertificateSubmissionRequestFormatSpec extends SpecBase {
 

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -124,8 +124,8 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
     CertificateSubmissionRequest(
       subscriptionId = "SAOSUB123456789",
       submitterName = Some("Proxy Person"),
-      SAOName = "Senior Officer",
-      SAOEmail = "sao@example.com",
+      saoName = "Senior Officer",
+      saoEmail = "sao@example.com",
       companies = Seq(company),
       remarks = Some("Certificate remarks")
     )
@@ -134,8 +134,8 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
     """{
       |  "subscriptionId": "SAOSUB123456789",
       |  "submitterName": "Proxy Person",
-      |  "SAOName": "Senior Officer",
-      |  "SAOEmail": "sao@example.com",
+      |  "saoName": "Senior Officer",
+      |  "saoEmail": "sao@example.com",
       |  "companies": [
       |    {
       |      "crn": "AB123456",

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -131,6 +131,26 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       verify(sessionRepository, never()).set(any())
     }
 
+    "must still succeed when the certificate is submitted but wiping the session data fails" in {
+      val connector         = mock[CertificateSubmissionConnector]
+      val sessionRepository = mock[SessionRepository]
+
+      when(sessionRepository.claimCertificateSubmissionToken(eqTo(userAnswersId), eqTo("token")))
+        .thenReturn(Future.successful(true))
+      when(connector.submit(any())(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResponse("CRT0123456789")))
+      when(sessionRepository.set(any())).thenReturn(Future.failed(new RuntimeException("mongo down")))
+
+      val service = new CertificateSubmissionService(connector, sessionRepository)
+
+      val result = service
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
+        .futureValue
+
+      result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
+      verify(sessionRepository).set(any())
+    }
+
     "must return MissingData when required answers are absent" in {
       val connector         = mock[CertificateSubmissionConnector]
       val sessionRepository = mock[SessionRepository]

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import connectors.CertificateSubmissionConnector
+import models.UserAnswers
+import models.certificate.*
+import models.upload.*
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.Mockito.{never, verify, when}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import pages.certificate.*
+import repositories.SessionRepository
+import services.CertificateSubmissionService.CertificateSubmissionResult
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import java.time.LocalDate
+
+class CertificateSubmissionServiceSpec extends SpecBase {
+
+  given HeaderCarrier    = HeaderCarrier()
+  given ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  "CertificateSubmissionService" - {
+
+    "must build the certificate payload, call the connector, clear Mongo, and return the certificate ref" in {
+      val connector         = mock[CertificateSubmissionConnector]
+      val sessionRepository = mock[SessionRepository]
+      val requestCaptor     = ArgumentCaptor.forClass(classOf[CertificateSubmissionRequest])
+
+      when(sessionRepository.claimCertificateSubmissionToken(eqTo(userAnswersId), eqTo("token")))
+        .thenReturn(Future.successful(true))
+      when(connector.submit(any())(using any()))
+        .thenReturn(Future.successful(CertificateSubmissionResponse("CRT0123456789")))
+      when(sessionRepository.clear(eqTo(userAnswersId))).thenReturn(Future.successful(true))
+
+      val service = new CertificateSubmissionService(connector, sessionRepository)
+
+      val result = service
+        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .futureValue
+
+      result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
+      verify(connector).submit(requestCaptor.capture())(using any())
+      verify(sessionRepository).clear(userAnswersId)
+
+      val request = requestCaptor.getValue
+      request.subscriptionId mustBe "SAOSUB123456789"
+      request.submitterName.value mustBe "Proxy Person"
+      request.SAOName mustBe "Senior Officer"
+      request.SAOEmail mustBe "sao@example.com"
+      request.remarks.value mustBe "Certificate remarks"
+
+      val company = request.companies.head
+      company.crn.value mustBe "AB123456"
+      company.utr mustBe "1234567890"
+      company.name mustBe "Example Ltd"
+      company.accPeriodEnd mustBe "2026-03-31"
+      company.status mustBe "COMPLIANT"
+      company.`type` mustBe "LTD"
+      company.isCorporationTaxQualified mustBe true
+      company.isVatQualified mustBe false
+      company.isPayeQualified mustBe false
+      company.isInsurancePremiumTaxQualified mustBe false
+      company.isStampDutyLandTaxQualified mustBe false
+      company.isStampDutyReserveTaxQualified mustBe false
+      company.isPetroleumRevenueTaxQualified mustBe false
+      company.isCustomsDutiesQualified mustBe false
+      company.isExciseDutiesQualified mustBe false
+      company.isBankLevyQualified mustBe false
+    }
+
+    "must not call the connector when the token has already been used" in {
+      val connector         = mock[CertificateSubmissionConnector]
+      val sessionRepository = mock[SessionRepository]
+
+      when(sessionRepository.claimCertificateSubmissionToken(eqTo(userAnswersId), eqTo("token")))
+        .thenReturn(Future.successful(false))
+
+      val service = new CertificateSubmissionService(connector, sessionRepository)
+
+      val result = service
+        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .futureValue
+
+      result mustBe CertificateSubmissionResult.Duplicate
+      verify(connector, never()).submit(any())(using any())
+      verify(sessionRepository, never()).clear(any())
+    }
+
+    "must retain Mongo data when the connector fails" in {
+      val connector         = mock[CertificateSubmissionConnector]
+      val sessionRepository = mock[SessionRepository]
+
+      when(sessionRepository.claimCertificateSubmissionToken(eqTo(userAnswersId), eqTo("token")))
+        .thenReturn(Future.successful(true))
+      when(connector.submit(any())(using any()))
+        .thenReturn(Future.failed(new RuntimeException("boom")))
+
+      val service = new CertificateSubmissionService(connector, sessionRepository)
+
+      val result = service
+        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .futureValue
+
+      result mustBe CertificateSubmissionResult.Failed
+      verify(sessionRepository, never()).clear(any())
+    }
+
+    "must return MissingData when required answers are absent" in {
+      val connector         = mock[CertificateSubmissionConnector]
+      val sessionRepository = mock[SessionRepository]
+      val service           = new CertificateSubmissionService(connector, sessionRepository)
+
+      val result = service
+        .submit(userAnswersId, "SAOSUB123456789", emptyUserAnswers, "token")
+        .futureValue
+
+      result mustBe CertificateSubmissionResult.MissingData
+      verify(sessionRepository, never()).claimCertificateSubmissionToken(any(), any())
+      verify(connector, never()).submit(any())(using any())
+    }
+  }
+
+  private def completeUserAnswers: UserAnswers =
+    emptyUserAnswers
+      .set(CertificateSaoFullNamePage, "Senior Officer")
+      .success
+      .value
+      .set(CertificateSaoEmailPage, "sao@example.com")
+      .success
+      .value
+      .set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.StandIn)
+      .success
+      .value
+      .set(CertificateDeclarationStandInPage, CertificateDeclarationStandIn("Proxy Person", "Senior Officer"))
+      .success
+      .value
+      .set(CertificateAdditionalInformationPage, Some("Certificate remarks"))
+      .success
+      .value
+      .set(CertificateUploadTemplateTablePage, UploadTemplateTableData(Seq(parsedRow), Seq.empty))
+      .success
+      .value
+
+  private def parsedRow: ParsedSubmissionRow =
+    ParsedSubmissionRow(
+      notification = NotificationFields(
+        companyName = "Example Ltd",
+        companyUtr = CompanyUtr("1234567890"),
+        companyCrn = Some(CompanyCrn("AB123456")),
+        companyType = CompanyType.LTD,
+        companyStatus = CompanyStatus.Active,
+        financialYearEndDate = LocalDate.of(2026, 3, 31)
+      ),
+      certificate = CertificateFields(
+        corporationTax = true,
+        valueAddedTax = false,
+        paye = false,
+        insurancePremiumTax = false,
+        stampDutyLandTax = false,
+        stampDutyReserveTax = false,
+        petroleumRevenueTax = false,
+        customsDuties = false,
+        exciseDuties = false,
+        bankLevy = false,
+        certificateType = Some(CertificateType.Qualified),
+        additionalInformation = None
+      )
+    )
+}

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -55,7 +55,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
@@ -63,7 +63,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       verify(sessionRepository).clear(userAnswersId)
 
       val request = requestCaptor.getValue
-      request.subscriptionId mustBe "SAOSUB123456789"
+      request.subscriptionId mustBe testSaoSubscriptionId
       request.submitterName.value mustBe "Proxy Person"
       request.saoName mustBe "Senior Officer"
       request.saoEmail mustBe "sao@example.com"
@@ -98,7 +98,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Duplicate
@@ -118,7 +118,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, "SAOSUB123456789", completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Failed
@@ -131,7 +131,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service           = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, "SAOSUB123456789", emptyUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, emptyUserAnswers, "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.MissingData

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -24,6 +24,7 @@ import models.upload.*
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.{never, verify, when}
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatestplus.mockito.MockitoSugar.mock
 import pages.certificate.*
 import play.api.libs.json.Json
@@ -34,6 +35,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.{ExecutionContext, Future}
 
 import java.time.LocalDate
+
+import CertificateSubmissionServiceSpec.*
 
 class CertificateSubmissionServiceSpec extends SpecBase {
 
@@ -56,7 +59,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
@@ -104,7 +107,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Duplicate
@@ -124,7 +127,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Failed
@@ -144,7 +147,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers, "token")
+        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
@@ -165,8 +168,11 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       verify(connector, never()).submit(any())(using any())
     }
   }
+}
 
-  private def completeUserAnswers: UserAnswers =
+object CertificateSubmissionServiceSpec {
+
+  def completeUserAnswers(emptyUserAnswers: UserAnswers): UserAnswers =
     emptyUserAnswers
       .set(CertificateSaoFullNamePage, "Senior Officer")
       .success
@@ -187,7 +193,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       .success
       .value
 
-  private def parsedRow: ParsedSubmissionRow =
+  val parsedRow: ParsedSubmissionRow =
     ParsedSubmissionRow(
       notification = NotificationFields(
         companyName = "Example Ltd",

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatestplus.mockito.MockitoSugar.mock
 import pages.certificate.*
+import play.api.libs.json.Json
 import repositories.SessionRepository
 import services.CertificateSubmissionService.CertificateSubmissionResult
 import uk.gov.hmrc.http.HeaderCarrier
@@ -41,7 +42,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
 
   "CertificateSubmissionService" - {
 
-    "must build the certificate payload, call the connector, clear Mongo, and return the certificate ref" in {
+    "must build the certificate payload, call the connector, wipe the Mongo data, and return the certificate ref" in {
       val connector         = mock[CertificateSubmissionConnector]
       val sessionRepository = mock[SessionRepository]
       val requestCaptor     = ArgumentCaptor.forClass(classOf[CertificateSubmissionRequest])
@@ -50,7 +51,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
         .thenReturn(Future.successful(true))
       when(connector.submit(any())(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResponse("CRT0123456789")))
-      when(sessionRepository.clear(eqTo(userAnswersId))).thenReturn(Future.successful(true))
+      when(sessionRepository.set(any())).thenReturn(Future.successful(true))
 
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
@@ -60,7 +61,12 @@ class CertificateSubmissionServiceSpec extends SpecBase {
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
       verify(connector).submit(requestCaptor.capture())(using any())
-      verify(sessionRepository).clear(userAnswersId)
+
+      val userAnswersCaptor = ArgumentCaptor.forClass(classOf[UserAnswers])
+      verify(sessionRepository).set(userAnswersCaptor.capture())
+      userAnswersCaptor.getValue.id mustBe userAnswersId
+      userAnswersCaptor.getValue.data mustBe Json.obj()
+      verify(sessionRepository, never()).clear(any())
 
       val request = requestCaptor.getValue
       request.subscriptionId mustBe testSaoSubscriptionId
@@ -103,7 +109,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
 
       result mustBe CertificateSubmissionResult.Duplicate
       verify(connector, never()).submit(any())(using any())
-      verify(sessionRepository, never()).clear(any())
+      verify(sessionRepository, never()).set(any())
     }
 
     "must retain Mongo data when the connector fails" in {
@@ -122,7 +128,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
         .futureValue
 
       result mustBe CertificateSubmissionResult.Failed
-      verify(sessionRepository, never()).clear(any())
+      verify(sessionRepository, never()).set(any())
     }
 
     "must return MissingData when required answers are absent" in {

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -65,8 +65,8 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val request = requestCaptor.getValue
       request.subscriptionId mustBe "SAOSUB123456789"
       request.submitterName.value mustBe "Proxy Person"
-      request.SAOName mustBe "Senior Officer"
-      request.SAOEmail mustBe "sao@example.com"
+      request.saoName mustBe "Senior Officer"
+      request.saoEmail mustBe "sao@example.com"
       request.remarks.value mustBe "Certificate remarks"
 
       val company = request.companies.head

--- a/test/services/NotificationSubmitServiceSpec.scala
+++ b/test/services/NotificationSubmitServiceSpec.scala
@@ -33,11 +33,10 @@ import play.api.test.Helpers.*
 import repositories.SessionRepository
 import services.NotificationSubmitService.toNotification
 import services.NotificationSubmitServiceSpec.*
-import uk.gov.hmrc.domain.SaUtrGenerator
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import utils.TestDataGenerator
 
 import scala.concurrent.Future
-import scala.util.Random
 
 import java.time.LocalDate
 
@@ -239,18 +238,8 @@ object NotificationSubmitServiceSpec {
   val exampleCompanyName             = "example company name"
   val exampleAccPeriodEnd: LocalDate = LocalDate.of(2001, 1, 1)
 
-  private def generateCrn = {
-    val num = Random.nextInt(1000000)
-    f"$num%08d"
-  }
-
-  private def generateUtr = {
-    val seed = Random.nextInt(1000000)
-    SaUtrGenerator(seed).nextSaUtr.toString
-  }
-
-  lazy val exampleCrn = generateCrn
-  lazy val exampleUtr = generateUtr
+  lazy val exampleCrn = TestDataGenerator.generateCrn
+  lazy val exampleUtr = TestDataGenerator.generateUtr
 
   val exampleTableData: UploadTemplateTableData = UploadTemplateTableData(
     rows = Seq(

--- a/test/views/certificate/CertificateCheckYourAnswersViewSpec.scala
+++ b/test/views/certificate/CertificateCheckYourAnswersViewSpec.scala
@@ -30,7 +30,8 @@ import CertificateCheckYourAnswersViewSpec.*
 
 class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckYourAnswersView] {
 
-  private def generateView(summaryList: SummaryList): Document = Jsoup.parse(SUT(summaryList).toString)
+  private def generateView(summaryList: SummaryList): Document =
+    Jsoup.parse(SUT(summaryList, certificateSubmissionToken).toString)
 
   "CertificateCheckYourAnswersView" - {
     "empty summary list must result in no table rows" - {
@@ -76,6 +77,14 @@ class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckY
         action = certificateRoutes.CertificateCheckYourAnswersController.onSubmit(),
         buttonText = pageButtonText
       )
+
+      "must include a certificate submission token" in {
+        doc.select("input[type=hidden][name=certificateSubmissionToken]").attr("value") mustBe certificateSubmissionToken
+      }
+
+      "must prevent double click on submit" in {
+        doc.select("button[type=submit]").attr("data-prevent-double-click") mustBe "true"
+      }
     }
 
     "non-empty summary list must result in a table with rows" - {
@@ -234,15 +243,16 @@ class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckY
 }
 
 object CertificateCheckYourAnswersViewSpec {
-  val pageHeading           = "Check your answers"
-  val pageTitle             = "Check your answers"
-  val pageCaption           = "Submit a certificate"
-  val pageButtonText        = "Confirm and submit"
-  val testKey1              = "testKey"
-  val testValue1            = "nonEmptyString"
-  val testActionMessage1    = "dummyMessage"
-  val testActionUrl1        = "dummyUrl"
-  val testActionHiddenText1 = "dummyVisuallyHiddenText"
-  val testKey2              = "testKey2"
-  val testValue2            = "nonEmptyString2"
+  val pageHeading                = "Check your answers"
+  val pageTitle                  = "Check your answers"
+  val pageCaption                = "Submit a certificate"
+  val pageButtonText             = "Confirm and submit"
+  val certificateSubmissionToken = "test-token"
+  val testKey1                   = "testKey"
+  val testValue1                 = "nonEmptyString"
+  val testActionMessage1         = "dummyMessage"
+  val testActionUrl1             = "dummyUrl"
+  val testActionHiddenText1      = "dummyVisuallyHiddenText"
+  val testKey2                   = "testKey2"
+  val testValue2                 = "nonEmptyString2"
 }

--- a/test/views/certificate/CertificateCheckYourAnswersViewSpec.scala
+++ b/test/views/certificate/CertificateCheckYourAnswersViewSpec.scala
@@ -79,7 +79,9 @@ class CertificateCheckYourAnswersViewSpec extends ViewSpecBase[CertificateCheckY
       )
 
       "must include a certificate submission token" in {
-        doc.select("input[type=hidden][name=certificateSubmissionToken]").attr("value") mustBe certificateSubmissionToken
+        doc
+          .select("input[type=hidden][name=certificateSubmissionToken]")
+          .attr("value") mustBe certificateSubmissionToken
       }
 
       "must prevent double click on submit" in {


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
*  Added Certificate CYA submission to the protected service, including payload mapping, SAO subscription ID handling, duplicate-submit protection, Mongo cleanup on success, confirmation redirect, failure handling and tests

## Jira ticket(s):
* https://jira.tools.tax.service.gov.uk/browse/SAOD-897

## Checklist
* [ ] Have you consulted with a QA?
    * [X] Tick if you expect this work could break the existing Acceptance Test
* [X] Is the branch up to date with main?
* [X] Have you added tests for any changed functionality?
* [X] Have you run the unit test?
* [X] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [X] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below


 This work will need A/T updates / manual testing for these scenarios: 
  1. Successful submit: 201 from protected service, Mongo cleared, redirect to confirmation.
  2. Payload includes all tax regime flags, including false values.
  3. Failure response: show 500 page, Mongo not cleared.
  4. Double click submit: only one protected-service call.
  5. Same token resubmission: second submit does not call protected service.
  6. Confirmation page shows returned certificate ID.
  
