### PR TITLE
Only display download notification pdf link when pdf available in object store

### DIFF
--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -15,6 +15,7 @@
  */
 
 package controllers.notification
+import controllers.notification.NotificationConfirmationController.*
 
 import controllers.actions.*
 import models.NormalMode
@@ -27,6 +28,10 @@ import views.html.notification.NotificationConfirmationView
 
 import javax.inject.Inject
 
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import uk.gov.hmrc.objectstore.client.Path
+import scala.concurrent.ExecutionContext
+
 class NotificationConfirmationController @Inject() (
     override val messagesApi: MessagesApi,
     identify: IdentifierAction,
@@ -34,20 +39,33 @@ class NotificationConfirmationController @Inject() (
     requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
     view: NotificationConfirmationView,
-    navigator: Navigator
-) extends FrontendBaseController
+    navigator: Navigator,
+    objectStoreClient: PlayObjectStoreClient
+)(using ec: ExecutionContext)
+    extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(notificationIdReferenceNumber: String): Action[AnyContent] =
-    (identify andThen getData andThen requireData) { implicit request =>
-      // TODO: install object store scala package
-      // TODO: check the file exists on object store
-      // TODO: pass boolean to display the link or not. will be changed when downloading file implemented
-      Ok(view(notificationIdReferenceNumber))
+  def onPageLoad(notificationReference: String): Action[AnyContent] =
+    (identify andThen getData andThen requireData).async { implicit request =>
+      objectStoreClient
+        .listObjects(
+          path = Path.Directory(s"/$objectStoreOwner/$notificationReference/"),
+          owner = objectStoreOwner
+        )
+        .map { objectListing =>
+          objectListing.objectSummaries match {
+            case Nil => Ok(view(notificationReference, displayLink = false))
+            case _   => Ok(view(notificationReference, displayLink = true))
+          }
+        }
     }
 
   def onSubmit(): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
       Redirect(navigator.nextPage(NotificationConfirmationPage, NormalMode, request.userAnswers))
     }
+}
+
+object NotificationConfirmationController {
+  val objectStoreOwner = "senior-accounting-officer"
 }

--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -53,8 +53,8 @@ class NotificationConfirmationController @Inject() (
         )
         .map { objectListing =>
           objectListing.objectSummaries match {
-            case Nil => Ok(view(notificationReference, displayLink = false))
-            case _   => Ok(view(notificationReference, displayLink = true))
+            case Nil => Ok(view(notificationReference, displayPdfLink = false))
+            case _   => Ok(view(notificationReference, displayPdfLink = true))
           }
         }
     }

--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -15,15 +15,14 @@
  */
 
 package controllers.notification
+
 import controllers.actions.*
-import controllers.notification.NotificationConfirmationController.*
 import models.NormalMode
 import navigation.Navigator
 import pages.notification.NotificationConfirmationPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.objectstore.client.Path
-import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import services.ObjectStoreService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.notification.NotificationConfirmationView
 
@@ -39,32 +38,25 @@ class NotificationConfirmationController @Inject() (
     val controllerComponents: MessagesControllerComponents,
     view: NotificationConfirmationView,
     navigator: Navigator,
-    objectStoreClient: PlayObjectStoreClient
+    objectStoreService: ObjectStoreService
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
 
   def onPageLoad(notificationReference: String): Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>
-      objectStoreClient
-        .listObjects(
-          path = Path.Directory(s"/$objectStoreOwner/$notificationReference/"),
-          owner = objectStoreOwner
+      objectStoreService.isNotificationPdfAvailable(notificationReference).map { isPdfAvailable =>
+        Ok(
+          view(
+            notificationReference = notificationReference,
+            displayPdfLink = isPdfAvailable
+          )
         )
-        .map { objectListing =>
-          objectListing.objectSummaries match {
-            case Nil => Ok(view(notificationReference, displayPdfLink = false))
-            case _   => Ok(view(notificationReference, displayPdfLink = true))
-          }
-        }
+      }
     }
 
   def onSubmit(): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
       Redirect(navigator.nextPage(NotificationConfirmationPage, NormalMode, request.userAnswers))
     }
-}
-
-object NotificationConfirmationController {
-  val objectStoreOwner = "senior-accounting-officer"
 }

--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -40,6 +40,9 @@ class NotificationConfirmationController @Inject() (
 
   def onPageLoad(notificationIdReferenceNumber: String): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
+      // TODO: install object store scala package
+      // TODO: check the file exists on object store
+      // TODO: pass boolean to display the link or not. will be changed when downloading file implemented
       Ok(view(notificationIdReferenceNumber))
     }
 

--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -15,22 +15,21 @@
  */
 
 package controllers.notification
-import controllers.notification.NotificationConfirmationController.*
-
 import controllers.actions.*
+import controllers.notification.NotificationConfirmationController.*
 import models.NormalMode
 import navigation.Navigator
 import pages.notification.NotificationConfirmationPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.notification.NotificationConfirmationView
 
-import javax.inject.Inject
-
-import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
-import uk.gov.hmrc.objectstore.client.Path
 import scala.concurrent.ExecutionContext
+
+import javax.inject.Inject
 
 class NotificationConfirmationController @Inject() (
     override val messagesApi: MessagesApi,

--- a/app/services/ObjectStoreService.scala
+++ b/app/services/ObjectStoreService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import services.ObjectStoreService.*
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.objectstore.client.ObjectSummary
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import javax.inject.Inject
+
+class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(using ec: ExecutionContext) {
+  def isNotificationPdfAvailable(notificationReference: String)(using hc: HeaderCarrier): Future[Boolean] = {
+    objectStoreClient
+      .listObjects(
+        path = Path.Directory(s"/$objectStoreOwner/$notificationReference/"),
+        owner = objectStoreOwner
+      )
+      .map { objectListing =>
+        objectListing.objectSummaries match {
+          case objectSummaries if objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
+                fileName == s"${notificationReference}_SAO_Notification.pdf"
+              } =>
+            true
+          case _ => false
+        }
+      }
+  }
+}
+
+object ObjectStoreService {
+  val objectStoreOwner = "senior-accounting-officer"
+}

--- a/app/views/notification/NotificationConfirmationView.scala.html
+++ b/app/views/notification/NotificationConfirmationView.scala.html
@@ -25,7 +25,7 @@
     appConfig: AppConfig
 )
 
-@(notificationIdReferenceNumber: String)(using request: Request[?], messages: Messages)
+@(notificationReference: String, displayLink: Boolean)(using request: Request[?], messages: Messages)
 
 @layout(showBackLink = false, pageTitle = titleNoForm(messages("notificationConfirmation.title"))) {
 
@@ -36,7 +36,7 @@
         <div class="govuk-panel__body">
             @messages("notificationConfirmation.reference.text")
             <br>
-            <strong data-test-id="notification-reference-number">@notificationIdReferenceNumber</strong>
+            <strong data-test-id="notification-reference-number">@notificationReference</strong>
         </div>
     </div>
 
@@ -44,14 +44,16 @@
     <p class="govuk-body">@messages("notificationConfirmation.paragraph2")</p>
 
     <ul class="govuk-list govuk-list--bullet">
-        <li>
-            <span>
-                <a class="govuk-link" id="download-pdf-link" href="#">
-                    @messages("notificationConfirmation.downloadPdf")
-                </a>
-                @messages("notificationConfirmation.list1.item1")
-            </span>
-        </li>
+        @if(displayLink) {
+            <li>
+                <span>
+                    <a class="govuk-link" id="download-pdf-link" href="#">
+                        @messages("notificationConfirmation.downloadPdf")
+                    </a>
+                    @messages("notificationConfirmation.list1.item1")
+                </span>
+            </li>
+        }
         <li>
             <span>
                 <a class="govuk-link" id="print-page-link" href="#">

--- a/app/views/notification/NotificationConfirmationView.scala.html
+++ b/app/views/notification/NotificationConfirmationView.scala.html
@@ -25,7 +25,7 @@
     appConfig: AppConfig
 )
 
-@(notificationReference: String, displayLink: Boolean)(using request: Request[?], messages: Messages)
+@(notificationReference: String, displayPdfLink: Boolean)(using request: Request[?], messages: Messages)
 
 @layout(showBackLink = false, pageTitle = titleNoForm(messages("notificationConfirmation.title"))) {
 
@@ -44,7 +44,7 @@
     <p class="govuk-body">@messages("notificationConfirmation.paragraph2")</p>
 
     <ul class="govuk-list govuk-list--bullet">
-        @if(displayLink) {
+        @if(displayPdfLink) {
             <li>
                 <span>
                     <a class="govuk-link" id="download-pdf-link" href="#">

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalaVersion := "3.3.6"
 
 lazy val microservice = (project in file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
-  .settings(inConfig(Test)(testSettings)*)
+  .settings(inConfig(Test)(testSettings) *)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(ThisBuild / useSuperShell := false)
   .settings(
@@ -52,8 +52,8 @@ lazy val microservice = (project in file("."))
       "https://open.artefacts.tax.service.gov.uk/maven2"
     )
   )
-  .settings(CodeCoverageSettings.settings*)
-  .settings(scalafixSettings*)
+  .settings(CodeCoverageSettings.settings *)
+  .settings(scalafixSettings *)
 
 lazy val testSettings: Seq[Def.Setting[?]] = Seq(
   fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -46,11 +46,7 @@ lazy val microservice = (project in file("."))
     retrieveManaged          := true,
     pipelineStages           := Seq(digest, gzip),
     Assets / pipelineStages  := Seq(concat),
-    PlayKeys.playDefaultPort := 10058,
-    resolvers += MavenRepository( // needed for object-store-client
-      "HMRC-open-artefacts-maven2",
-      "https://open.artefacts.tax.service.gov.uk/maven2"
-    )
+    PlayKeys.playDefaultPort := 10058
   )
   .settings(CodeCoverageSettings.settings *)
   .settings(scalafixSettings *)

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalaVersion := "3.3.6"
 
 lazy val microservice = (project in file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
-  .settings(inConfig(Test)(testSettings) *)
+  .settings(inConfig(Test)(testSettings)*)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(ThisBuild / useSuperShell := false)
   .settings(
@@ -46,10 +46,14 @@ lazy val microservice = (project in file("."))
     retrieveManaged          := true,
     pipelineStages           := Seq(digest, gzip),
     Assets / pipelineStages  := Seq(concat),
-    PlayKeys.playDefaultPort := 10058
+    PlayKeys.playDefaultPort := 10058,
+    resolvers += MavenRepository( // needed for object-store-client
+      "HMRC-open-artefacts-maven2",
+      "https://open.artefacts.tax.service.gov.uk/maven2"
+    )
   )
-  .settings(CodeCoverageSettings.settings *)
-  .settings(scalafixSettings *)
+  .settings(CodeCoverageSettings.settings*)
+  .settings(scalafixSettings*)
 
 lazy val testSettings: Seq[Def.Setting[?]] = Seq(
   fork := true,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,6 +21,7 @@ play.filters.enabled += play.filters.csp.CSPFilter
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
+play.modules.enabled += "uk.gov.hmrc.objectstore.client.play.modules.ObjectStoreModule"
 
 # Custom error handler
 play.http.errorHandler = "config.ErrorHandler"
@@ -74,6 +75,9 @@ internal-auth {
   token = "1234"
 }
 
+object-store {
+  default-retention-period = "1-week"
+}
 
 host = "http://localhost:10058"
 serviceId = "senior-accounting-officer-submission-frontend"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -23,10 +23,11 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion,
-    "org.scalatestplus" %% "scalacheck-1-18"         % "3.2.19.0",
-    "uk.gov.hmrc"       %% "domain-test-play-30"     % "13.0.0"
+    "uk.gov.hmrc"             %% "bootstrap-test-play-30"      % bootstrapVersion,
+    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"     % hmrcMongoVersion,
+    "org.scalatestplus"       %% "scalacheck-1-18"             % "3.2.19.0",
+    "uk.gov.hmrc"             %% "domain-test-play-30"         % "13.0.0",
+    "uk.gov.hmrc.objectstore" %% "object-store-client-play-30" % "2.6.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,13 +12,14 @@ object AppDependencies {
   private val scalaCsvVersion  = "2.0.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"            %% "play-frontend-hmrc-play-30" % hmrcPlayFrontend,
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-play-30"         % hmrcMongoVersion,
-    "org.apache.poi"          % "poi"                        % poiVersion,
-    "org.apache.poi"          % "poi-ooxml"                  % poiVersion,
-    "com.github.tototoshi"   %% "scala-csv"                  % scalaCsvVersion,
-    "io.github.openhtmltopdf" % "openhtmltopdf-pdfbox"       % "1.1.37"
+    "uk.gov.hmrc"             %% "bootstrap-frontend-play-30"  % bootstrapVersion,
+    "uk.gov.hmrc"             %% "play-frontend-hmrc-play-30"  % hmrcPlayFrontend,
+    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-30"          % hmrcMongoVersion,
+    "org.apache.poi"           % "poi"                         % poiVersion,
+    "org.apache.poi"           % "poi-ooxml"                   % poiVersion,
+    "com.github.tototoshi"    %% "scala-csv"                   % scalaCsvVersion,
+    "io.github.openhtmltopdf"  % "openhtmltopdf-pdfbox"        % "1.1.37",
+    "uk.gov.hmrc.objectstore" %% "object-store-client-play-30" % "2.6.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -23,11 +23,10 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"      % bootstrapVersion,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"     % hmrcMongoVersion,
-    "org.scalatestplus"       %% "scalacheck-1-18"             % "3.2.19.0",
-    "uk.gov.hmrc"             %% "domain-test-play-30"         % "13.0.0",
-    "uk.gov.hmrc.objectstore" %% "object-store-client-play-30" % "2.6.0"
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion,
+    "org.scalatestplus" %% "scalacheck-1-18"         % "3.2.19.0",
+    "uk.gov.hmrc"       %% "domain-test-play-30"     % "13.0.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -20,20 +20,22 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
 import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.http.HeaderNames
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import views.html.notification.NotificationConfirmationView
-import org.scalatestplus.mockito.MockitoSugar.mock
-import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
-import org.mockito.ArgumentMatchers.{any, eq as meq}
-import org.mockito.Mockito.{verify, when}
-import uk.gov.hmrc.objectstore.client.Path
-import scala.concurrent.Future
 import uk.gov.hmrc.objectstore.client.ObjectListing
 import uk.gov.hmrc.objectstore.client.ObjectSummary
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import views.html.notification.NotificationConfirmationView
+
+import scala.concurrent.Future
+
 import java.time.Instant
 
 class NotificationConfirmationControllerSpec extends SpecBase {

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -33,6 +33,7 @@ import uk.gov.hmrc.objectstore.client.ObjectSummary
 import uk.gov.hmrc.objectstore.client.Path
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import views.html.notification.NotificationConfirmationView
+import services.ObjectStoreService
 
 import scala.concurrent.Future
 
@@ -47,21 +48,16 @@ class NotificationConfirmationControllerSpec extends SpecBase {
   "NotificationConfirmation Controller" - {
 
     "onPageLoad" - {
-      "must return OK and a view with no link displayed when object store finds no files" in {
+      "must return OK and a view with no link displayed when pdf is not available" in {
 
-        val mockObjectStoreClient = mock[PlayObjectStoreClient]
+        val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreClient.listObjects(
-            path = any(),
-            owner = any()
-          )(using
-            any()
-          )
+          mockObjectStoreService.isNotificationPdfAvailable(any())(using any())
         )
-          .thenReturn(Future.successful(ObjectListing(Nil)))
+          .thenReturn(Future.successful(false))
 
         val application = applicationBuilder(userAnswers = Some(completedNotificationReviewAnswers))
-          .overrides(bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient))
+          .overrides(bind[ObjectStoreService].toInstance(mockObjectStoreService))
           .build()
 
         running(application) {
@@ -80,25 +76,16 @@ class NotificationConfirmationControllerSpec extends SpecBase {
         }
       }
 
-      "must return OK and a view with a link displayed when object store finds some files" in {
+      "must return OK and a view with a link displayed when pdf is available" in {
 
-        val mockObjectStoreClient = mock[PlayObjectStoreClient]
+        val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreClient.listObjects(
-            path = any(),
-            owner = any()
-          )(using
-            any()
-          )
+          mockObjectStoreService.isNotificationPdfAvailable(any())(using any())
         )
-          .thenReturn(
-            Future.successful(
-              ObjectListing(List(ObjectSummary(Path.File(Path.Directory("directory"), "fileName"), 0, Instant.now())))
-            )
-          )
+          .thenReturn(Future.successful(true))
 
         val application = applicationBuilder(userAnswers = Some(completedNotificationReviewAnswers))
-          .overrides(bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient))
+          .overrides(bind[ObjectStoreService].toInstance(mockObjectStoreService))
           .build()
 
         running(application) {

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -26,6 +26,15 @@ import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import views.html.notification.NotificationConfirmationView
+import org.scalatestplus.mockito.MockitoSugar.mock
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import org.mockito.ArgumentMatchers.{any, eq as meq}
+import org.mockito.Mockito.{verify, when}
+import uk.gov.hmrc.objectstore.client.Path
+import scala.concurrent.Future
+import uk.gov.hmrc.objectstore.client.ObjectListing
+import uk.gov.hmrc.objectstore.client.ObjectSummary
+import java.time.Instant
 
 class NotificationConfirmationControllerSpec extends SpecBase {
 
@@ -35,38 +44,90 @@ class NotificationConfirmationControllerSpec extends SpecBase {
 
   "NotificationConfirmation Controller" - {
 
-    "must return OK and the correct view for a GET" in {
+    "onPageLoad" - {
+      "must return OK and a view with no link displayed when object store finds no files" in {
 
-      val application = applicationBuilder(userAnswers = Some(completedNotificationReviewAnswers)).build()
+        val mockObjectStoreClient = mock[PlayObjectStoreClient]
+        when(
+          mockObjectStoreClient.listObjects(
+            path = any(),
+            owner = any()
+          )(using
+            any()
+          )
+        )
+          .thenReturn(Future.successful(ObjectListing(Nil)))
 
-      running(application) {
-        val request =
-          FakeRequest(GET, notificationRoutes.NotificationConfirmationController.onPageLoad(hardCodedNotRef).url)
+        val application = applicationBuilder(userAnswers = Some(completedNotificationReviewAnswers))
+          .overrides(bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient))
+          .build()
 
-        val result = route(application, request).value
+        running(application) {
+          val request =
+            FakeRequest(GET, notificationRoutes.NotificationConfirmationController.onPageLoad(hardCodedNotRef).url)
 
-        val view = application.injector.instanceOf[NotificationConfirmationView]
+          val result = route(application, request).value
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(hardCodedNotRef, false)(using
-          request,
-          messages(application)
-        ).toString
+          val view = application.injector.instanceOf[NotificationConfirmationView]
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(hardCodedNotRef, false)(using
+            request,
+            messages(application)
+          ).toString
+        }
       }
-    }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+      "must return OK and a view with a link displayed when object store finds some files" in {
 
-      val application = applicationBuilder(userAnswers = None).build()
+        val mockObjectStoreClient = mock[PlayObjectStoreClient]
+        when(
+          mockObjectStoreClient.listObjects(
+            path = any(),
+            owner = any()
+          )(using
+            any()
+          )
+        )
+          .thenReturn(
+            Future.successful(
+              ObjectListing(List(ObjectSummary(Path.File(Path.Directory("directory"), "fileName"), 0, Instant.now())))
+            )
+          )
 
-      running(application) {
-        val request =
-          FakeRequest(GET, notificationRoutes.NotificationConfirmationController.onPageLoad(hardCodedNotRef).url)
+        val application = applicationBuilder(userAnswers = Some(completedNotificationReviewAnswers))
+          .overrides(bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient))
+          .build()
 
-        val result = route(application, request).value
+        running(application) {
+          val request =
+            FakeRequest(GET, notificationRoutes.NotificationConfirmationController.onPageLoad(hardCodedNotRef).url)
 
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+          val result = route(application, request).value
+
+          val view = application.injector.instanceOf[NotificationConfirmationView]
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(hardCodedNotRef, true)(using
+            request,
+            messages(application)
+          ).toString
+        }
+      }
+
+      "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+        val application = applicationBuilder(userAnswers = None).build()
+
+        running(application) {
+          val request =
+            FakeRequest(GET, notificationRoutes.NotificationConfirmationController.onPageLoad(hardCodedNotRef).url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+        }
       }
     }
 

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -28,16 +28,10 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import uk.gov.hmrc.objectstore.client.ObjectListing
-import uk.gov.hmrc.objectstore.client.ObjectSummary
-import uk.gov.hmrc.objectstore.client.Path
-import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
-import views.html.notification.NotificationConfirmationView
 import services.ObjectStoreService
+import views.html.notification.NotificationConfirmationView
 
 import scala.concurrent.Future
-
-import java.time.Instant
 
 class NotificationConfirmationControllerSpec extends SpecBase {
 

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -48,7 +48,7 @@ class NotificationConfirmationControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[NotificationConfirmationView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(hardCodedNotRef)(using
+        contentAsString(result) mustEqual view(hardCodedNotRef, false)(using
           request,
           messages(application)
         ).toString

--- a/test/services/ObjectStoreServiceSpec.scala
+++ b/test/services/ObjectStoreServiceSpec.scala
@@ -17,21 +17,23 @@
 package services
 
 import base.SpecBase
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
-import org.mockito.Mockito.*
-import org.scalatestplus.mockito.MockitoSugar.mock
 import org.mockito.ArgumentMatchers.any
-import scala.concurrent.Future
-import uk.gov.hmrc.objectstore.client.ObjectListing
-import play.api.inject.bind
+import org.mockito.Mockito.*
 import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import services.ObjectStoreServiceSpec.*
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.objectstore.client.ObjectListing
 import uk.gov.hmrc.objectstore.client.ObjectSummary
 import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+
+import scala.concurrent.Future
+
 import java.time.Instant
 
 class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with BeforeAndAfterEach {
@@ -46,7 +48,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
     )
     .build()
 
-  def SUT = app.injector.instanceOf[ObjectStoreService]
+  def SUT: ObjectStoreService = app.injector.instanceOf[ObjectStoreService]
 
   override def beforeEach(): Unit = {
     reset(mockObjectStoreClient)

--- a/test/services/ObjectStoreServiceSpec.scala
+++ b/test/services/ObjectStoreServiceSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import org.mockito.Mockito.*
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.mockito.ArgumentMatchers.any
+import scala.concurrent.Future
+import uk.gov.hmrc.objectstore.client.ObjectListing
+import play.api.inject.bind
+import org.scalatest.BeforeAndAfterEach
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import services.ObjectStoreServiceSpec.*
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.objectstore.client.ObjectSummary
+import uk.gov.hmrc.objectstore.client.Path
+import java.time.Instant
+
+class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with BeforeAndAfterEach {
+
+  given HeaderCarrier = HeaderCarrier()
+
+  val mockObjectStoreClient: PlayObjectStoreClient = mock[PlayObjectStoreClient]
+
+  override lazy val app: Application = GuiceApplicationBuilder()
+    .overrides(
+      bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient)
+    )
+    .build()
+
+  def SUT = app.injector.instanceOf[ObjectStoreService]
+
+  override def beforeEach(): Unit = {
+    reset(mockObjectStoreClient)
+  }
+
+  "when no objects are found in object store must return false" in {
+    when(
+      mockObjectStoreClient.listObjects(
+        path = any(),
+        owner = any()
+      )(using
+        any()
+      )
+    )
+      .thenReturn(Future.successful(ObjectListing(Nil)))
+
+    val result = SUT.isNotificationPdfAvailable(notificationReference)
+
+    result.futureValue mustBe false
+  }
+
+  "when objects are found in object store without a pdf must return false" in {
+    when(
+      mockObjectStoreClient.listObjects(
+        path = any(),
+        owner = any()
+      )(using
+        any()
+      )
+    )
+      .thenReturn(
+        Future.successful(
+          ObjectListing(
+            List(
+              ObjectSummary(
+                Path
+                  .File(
+                    Path.Directory(s"senior-accounting-officer/$notificationReference"),
+                    s"${notificationReference}_SAO_Notification.txt"
+                  ),
+                0,
+                Instant.now()
+              )
+            )
+          )
+        )
+      )
+
+    val result = SUT.isNotificationPdfAvailable(notificationReference)
+
+    result.futureValue mustBe false
+  }
+
+  "when objects are found in object store with a pdf must return true" in {
+    when(
+      mockObjectStoreClient.listObjects(
+        path = any(),
+        owner = any()
+      )(using
+        any()
+      )
+    )
+      .thenReturn(
+        Future.successful(
+          ObjectListing(
+            List(
+              ObjectSummary(
+                Path
+                  .File(
+                    Path.Directory(s"senior-accounting-officer/$notificationReference"),
+                    s"${notificationReference}_SAO_Notification.pdf"
+                  ),
+                0,
+                Instant.now()
+              )
+            )
+          )
+        )
+      )
+
+    val result = SUT.isNotificationPdfAvailable(notificationReference)
+
+    result.futureValue mustBe true
+  }
+}
+
+object ObjectStoreServiceSpec {
+  val notificationReference = "NOT0123456789"
+}

--- a/test/views/notification/NotificationConfirmationViewSpec.scala
+++ b/test/views/notification/NotificationConfirmationViewSpec.scala
@@ -27,13 +27,14 @@ import NotificationConfirmationViewSpec.*
 
 class NotificationConfirmationViewSpec extends ViewSpecBase[NotificationConfirmationView] {
 
-  private def generateView(displayLink: Boolean): Document = Jsoup.parse(SUT(testReferenceNumber, displayLink).toString)
+  private def generateView(displayPdfLink: Boolean): Document =
+    Jsoup.parse(SUT(testReferenceNumber, displayPdfLink).toString)
 
   "NotificationConfirmationView" - {
-    "when displayLink is true" - {
-      val displayLink = true
+    "when displayPdfLink is true" - {
+      val displayPdfLink = true
       AppConfig.setValue("hub-frontend.host", hubUrl)
-      val doc: Document = generateView(displayLink)
+      val doc: Document = generateView(displayPdfLink)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,
@@ -104,10 +105,10 @@ class NotificationConfirmationViewSpec extends ViewSpecBase[NotificationConfirma
       )
     }
 
-    "when displayLink is false" - {
-      val displayLink = false
+    "when displayPdfLink is false" - {
+      val displayPdfLink = false
       AppConfig.setValue("hub-frontend.host", hubUrl)
-      val doc: Document = generateView(displayLink)
+      val doc: Document = generateView(displayPdfLink)
 
       doc.createTestsWithStandardPageElements(
         pageTitle = pageTitle,

--- a/test/views/notification/NotificationConfirmationViewSpec.scala
+++ b/test/views/notification/NotificationConfirmationViewSpec.scala
@@ -27,79 +27,144 @@ import NotificationConfirmationViewSpec.*
 
 class NotificationConfirmationViewSpec extends ViewSpecBase[NotificationConfirmationView] {
 
-  private def generateView(): Document = Jsoup.parse(SUT(testReferenceNumber, false).toString)
+  private def generateView(displayLink: Boolean): Document = Jsoup.parse(SUT(testReferenceNumber, displayLink).toString)
 
   "NotificationConfirmationView" - {
-    AppConfig.setValue("hub-frontend.host", hubUrl)
-    val doc: Document = generateView()
+    "when displayLink is true" - {
+      val displayLink = true
+      AppConfig.setValue("hub-frontend.host", hubUrl)
+      val doc: Document = generateView(displayLink)
 
-    doc.createTestsWithStandardPageElements(
-      pageTitle = pageTitle,
-      pageHeading = pageHeading,
-      showBackLink = false,
-      showIsThisPageNotWorkingProperlyLink = true,
-      hasError = false
-    )
+      doc.createTestsWithStandardPageElements(
+        pageTitle = pageTitle,
+        pageHeading = pageHeading,
+        showBackLink = false,
+        showIsThisPageNotWorkingProperlyLink = true,
+        hasError = false
+      )
 
-    "with a confirmation panel that" - {
-      "must have the correct title" - {
-        doc.getConfirmationPanel.getPanelTitle.createTestWithText(text = panelTitle)
+      "with a confirmation panel that" - {
+        "must have the correct title" - {
+          doc.getConfirmationPanel.getPanelTitle.createTestWithText(text = panelTitle)
+        }
+
+        "must have the correct body" - {
+          doc.getConfirmationPanel.getPanelBody.createTestWithText(text = panelBody)
+        }
+
+        "must have the reference number in bold" in {
+          val strongTags = doc.getConfirmationPanel.getPanelBody.select("strong")
+          strongTags.size() mustBe 1
+          strongTags.get(0).text() mustBe testReferenceNumber
+        }
       }
 
-      "must have the correct body" - {
-        doc.getConfirmationPanel.getPanelBody.createTestWithText(text = panelBody)
-      }
+      doc.createTestsWithParagraphs(
+        pageParagraphs
+      )
 
-      "must have the reference number in bold" in {
-        val strongTags = doc.getConfirmationPanel.getPanelBody.select("strong")
-        strongTags.size() mustBe 1
-        strongTags.get(0).text() mustBe testReferenceNumber
-      }
+      doc.createTestsWithBulletPoints(
+        pageListItemsWhenLinkDisplayed
+      )
+
+      doc.getMainContent
+        .select("li span")
+        .get(0)
+        .createTestWithText(pageListItemsWhenLinkDisplayed(0))
+
+      doc.getMainContent
+        .select("li span")
+        .get(1)
+        .createTestWithText(pageListItemsWhenLinkDisplayed(1))
+
+      doc.getMainContent
+        .select("li span a")
+        .get(0)
+        .createTestWithLink(
+          linkText = pageDownload,
+          destinationUrl = "#"
+        )
+
+      doc.getMainContent
+        .select("li span a")
+        .get(1)
+        .createTestWithLink(
+          linkText = pagePrint,
+          destinationUrl = "#"
+        )
+
+      doc.createTestsForSubHeadings(
+        pageSubheadings
+      )
+
+      doc.createTestsWithOrWithoutError(hasError = false)
+      doc.createTestsWithSubmissionButton(
+        action = notificationRoutes.NotificationConfirmationController.onSubmit(),
+        buttonText = "Continue"
+      )
     }
 
-    doc.createTestsWithParagraphs(
-      pageParagraphs
-    )
+    "when displayLink is false" - {
+      val displayLink = false
+      AppConfig.setValue("hub-frontend.host", hubUrl)
+      val doc: Document = generateView(displayLink)
 
-    doc.createTestsWithBulletPoints(
-      pageListItems
-    )
-
-    doc.getMainContent
-      .select("li span")
-      .get(0)
-      .createTestWithText(pageListItems(0))
-
-    doc.getMainContent
-      .select("li span")
-      .get(1)
-      .createTestWithText(pageListItems(1))
-
-    doc.getMainContent
-      .select("li span a")
-      .get(0)
-      .createTestWithLink(
-        linkText = pageDownload,
-        destinationUrl = "#"
+      doc.createTestsWithStandardPageElements(
+        pageTitle = pageTitle,
+        pageHeading = pageHeading,
+        showBackLink = false,
+        showIsThisPageNotWorkingProperlyLink = true,
+        hasError = false
       )
 
-    doc.getMainContent
-      .select("li span a")
-      .get(1)
-      .createTestWithLink(
-        linkText = pagePrint,
-        destinationUrl = "#"
+      "with a confirmation panel that" - {
+        "must have the correct title" - {
+          doc.getConfirmationPanel.getPanelTitle.createTestWithText(text = panelTitle)
+        }
+
+        "must have the correct body" - {
+          doc.getConfirmationPanel.getPanelBody.createTestWithText(text = panelBody)
+        }
+
+        "must have the reference number in bold" in {
+          val strongTags = doc.getConfirmationPanel.getPanelBody.select("strong")
+          strongTags.size() mustBe 1
+          strongTags.get(0).text() mustBe testReferenceNumber
+        }
+      }
+
+      doc.createTestsWithParagraphs(
+        pageParagraphs
       )
 
-    doc.createTestsForSubHeadings(
-      pageSubheadings
-    )
+      doc.createTestsWithBulletPoints(
+        pageListItemsWhenLinkNotDisplayed
+      )
 
-    doc.createTestsWithOrWithoutError(hasError = false)
-    doc.createTestsWithSubmissionButton(
-      action = notificationRoutes.NotificationConfirmationController.onSubmit(),
-      buttonText = "Continue"
-    )
+      doc.getMainContent
+        .select("li span")
+        .get(0)
+        .createTestWithText(pageListItemsWhenLinkNotDisplayed(0))
+
+      doc.getMainContent
+        .select("li span a")
+        .get(0)
+        .createTestWithLink(
+          linkText = pagePrint,
+          destinationUrl = "#"
+        )
+
+      doc.createTestsForSubHeadings(
+        pageSubheadings
+      )
+
+      doc.createTestsWithOrWithoutError(hasError = false)
+      doc.createTestsWithSubmissionButton(
+        action = notificationRoutes.NotificationConfirmationController.onSubmit(),
+        buttonText = "Continue"
+      )
+    }
+
   }
 
   extension (target: => Document) {
@@ -127,13 +192,17 @@ object NotificationConfirmationViewSpec {
     "Your notification has been received by HMRC. A member of compliance staff may contact you if they need more information.",
     "You can now submit a Senior Accounting Officer certificate or another notification on behalf of another SAO in your group on your account homepage."
   )
-  val panelTitle                 = "Notification submitted"
-  val testReferenceNumber        = "SAONOT0123456789"
-  val panelBody: String          = s"Your reference number $testReferenceNumber"
-  val testDate                   = "17 January 2025 at 14:15am (GMT)"
-  val pageListItems: Seq[String] =
+  val panelTitle                                  = "Notification submitted"
+  val testReferenceNumber                         = "SAONOT0123456789"
+  val panelBody: String                           = s"Your reference number $testReferenceNumber"
+  val testDate                                    = "17 January 2025 at 14:15am (GMT)"
+  val pageListItemsWhenLinkDisplayed: Seq[String] =
     Seq(
       "Download a PDF - save a copy of all the answers you submitted now. You may not be able to download a PDF if you leave this page",
+      "Print this page - print a paper copy of this confirmation page"
+    )
+  val pageListItemsWhenLinkNotDisplayed: Seq[String] =
+    Seq(
       "Print this page - print a paper copy of this confirmation page"
     )
   val pageDownload                 = "Download a PDF"

--- a/test/views/notification/NotificationConfirmationViewSpec.scala
+++ b/test/views/notification/NotificationConfirmationViewSpec.scala
@@ -27,7 +27,7 @@ import NotificationConfirmationViewSpec.*
 
 class NotificationConfirmationViewSpec extends ViewSpecBase[NotificationConfirmationView] {
 
-  private def generateView(): Document = Jsoup.parse(SUT(testReferenceNumber).toString)
+  private def generateView(): Document = Jsoup.parse(SUT(testReferenceNumber, false).toString)
 
   "NotificationConfirmationView" - {
     AppConfig.setValue("hub-frontend.host", hubUrl)


### PR DESCRIPTION
## List the changes made in comparison to main:
* check object store to decide whether to show pdf download link

## Jira ticket(s):
* SAOD-837

## Checklist
* [ ] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [ ] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below