### PR TITLE
SAOD-985 read subscription from mongo

### DIFF
--- a/app/controllers/SubmissionTypeController.scala
+++ b/app/controllers/SubmissionTypeController.scala
@@ -19,7 +19,6 @@ package controllers
 import controllers.actions.*
 import forms.SubmissionTypeFormProvider
 import models.NormalMode
-import models.UserAnswers
 import navigation.Navigator
 import pages.SubmissionTypePage
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -45,19 +44,10 @@ class SubmissionTypeController @Inject() (
 )(using ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
-  def onPageLoad(): Action[AnyContent] = (identify andThen getData).async { implicit request =>
+  def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     val form         = formProvider()
-    val preparedForm = request.userAnswers.fold(form)(answers => answers.get(SubmissionTypePage).fold(form)(form.fill))
-    for {
-      userAnswers <- sessionRepository.get(request.userId)
-      result      <- userAnswers match {
-        case Some(answers) => Future.successful(Ok(view(preparedForm)))
-        case None          =>
-          sessionRepository
-            .set(UserAnswers(request.userId))
-            .map(_ => Ok(view(preparedForm)))
-      }
-    } yield result
+    val preparedForm = request.userAnswers.get(SubmissionTypePage).fold(form)(form.fill)
+    Ok(view(preparedForm))
   }
 
   def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>

--- a/app/controllers/notification/NotificationTaskListController.scala
+++ b/app/controllers/notification/NotificationTaskListController.scala
@@ -18,15 +18,13 @@ package controllers.notification
 
 import config.AppConfig
 import controllers.actions.*
-import models.UserAnswers
 import models.notification.NotificationStage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.notification.NotificationTaskListView
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 import javax.inject.Inject
 
@@ -34,25 +32,16 @@ class NotificationTaskListController @Inject() (
     override val messagesApi: MessagesApi,
     identify: IdentifierAction,
     getData: DataRetrievalAction,
+    requireData: DataRequiredAction,
     val controllerComponents: MessagesControllerComponents,
     view: NotificationTaskListView,
-    sessionRepository: SessionRepository,
     appConfig: AppConfig
 )(using ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData) async { implicit request =>
-    for {
-      userAnswers <- sessionRepository.get(request.userId)
-      result      <- userAnswers match {
-        case Some(answers) => Future.successful(Ok(view(NotificationStage.taskListStage(answers))))
-        case None          =>
-          sessionRepository
-            .set(UserAnswers(request.userId))
-            .map(_ => Ok(view(NotificationStage.ProvideSaoDetails)))
-      }
-    } yield result
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Ok(view(NotificationStage.taskListStage(request.userAnswers)))
   }
 
   def onComplete: Action[AnyContent] = identify { implicit request =>

--- a/app/models/SaoSubscription.scala
+++ b/app/models/SaoSubscription.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+final case class Contact(
+    name: String,
+    email: String,
+    language: String,
+    status: String
+)
+
+object Contact {
+  given OFormat[Contact] = Json.format
+}
+
+final case class NominatedCompany(name: String, crn: String, utr: String)
+
+object NominatedCompany {
+  given OFormat[NominatedCompany] = Json.format
+}
+
+final case class SaoSubscription(
+    etmpSafeId: String,
+    nominatedCompany: NominatedCompany,
+    contacts: List[Contact]
+)
+
+object SaoSubscription {
+  given OFormat[SaoSubscription] = Json.format[SaoSubscription]
+}

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -26,6 +26,7 @@ import java.time.Instant
 
 final case class UserAnswers(
     id: String,
+    subscription: SaoSubscription,
     data: JsObject = Json.obj(),
     lastUpdated: Instant = Instant.now
 ) {
@@ -75,6 +76,7 @@ object UserAnswers {
 
     (
       (__ \ "_id").read[String] and
+        (__ \ "subscription").read[SaoSubscription] and
         (__ \ "data").read[JsObject] and
         (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
     )(UserAnswers.apply _)
@@ -86,9 +88,10 @@ object UserAnswers {
 
     (
       (__ \ "_id").write[String] and
+        (__ \ "subscription").write[SaoSubscription] and
         (__ \ "data").write[JsObject] and
         (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
-    )(ua => (ua.id, ua.data, ua.lastUpdated))
+    )(ua => (ua.id, ua.subscription, ua.data, ua.lastUpdated))
   }
 
   given format: OFormat[UserAnswers] = OFormat(reads, writes)

--- a/it/test/AuthActionISpec.scala
+++ b/it/test/AuthActionISpec.scala
@@ -14,16 +14,32 @@
  * limitations under the License.
  */
 
+import AuthActionISpec.*
 import config.AppConfig
-import org.jsoup.Jsoup
+import controllers.actions.IdentifierAction
 import play.api.http.{HeaderNames, Status}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Results
 import support.MockAuthHelper.authSession
 import support.{ISpecBase, MockAuthHelper, SessionCookieBaker}
 
 class AuthActionISpec extends ISpecBase {
 
-  val appConfig = app.injector.instanceOf[AppConfig]
-  val targetUrl = s"$baseUrl/senior-accounting-officer/submission/notification/start"
+  override def applicationBuilder: GuiceApplicationBuilder =
+    GuiceApplicationBuilder()
+      .appRoutes { app =>
+        val identifierAction = app.injector.instanceOf[IdentifierAction]
+
+        { case ("GET", `testPath`) =>
+          identifierAction { request =>
+            Results.Ok(testSuccessBody(request.userId))
+          }
+        }
+      }
+
+  def appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  def targetUrl = s"$baseUrl$testPath"
 
   "An endpoint with Auth Action" when {
     "Auth is missing" must {
@@ -81,4 +97,11 @@ class AuthActionISpec extends ISpecBase {
     }
   }
 
+}
+
+object AuthActionISpec {
+  val testPath = "/test-identifier-action"
+
+  def testSuccessBody(userId: String) =
+    s"Action Passed Successfully $userId"
 }

--- a/it/test/repositories/SessionRepositoryISpec.scala
+++ b/it/test/repositories/SessionRepositoryISpec.scala
@@ -18,7 +18,7 @@ package repositories
 
 import config.AppConfig
 import models.upscan.{FileUploadState, UploadJourney, UploadStatus}
-import models.UserAnswers
+import models.*
 import org.mockito.Mockito.when
 import org.mongodb.scala.model.Filters
 import org.scalactic.source.Position
@@ -51,7 +51,16 @@ class SessionRepositoryISpec
   private val instant          = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
 
-  private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
+  private val subscription = SaoSubscription(
+    etmpSafeId = "etmpSafeId",
+    nominatedCompany = NominatedCompany(
+      name = "companyName",
+      crn = "companyCrn",
+      utr = "companyUtr"
+    ),
+    contacts = List(Contact("name", "email", "language", "status"))
+  )
+  private val userAnswers = UserAnswers("id", subscription, Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
 
   private val mockAppConfig = mock[AppConfig]
   when(mockAppConfig.cacheTtl) thenReturn 1L
@@ -157,7 +166,7 @@ class SessionRepositoryISpec
 
       "must update the upload status in user answers and refresh lastUpdated" in {
 
-        val userAnswersWithUpload = UserAnswers("id")
+        val userAnswersWithUpload = UserAnswers("id", subscription)
           .set(NotificationUploadStatePage, FileUploadState("upscan-ref", UploadStatus.InProgress))
           .get
           .copy(lastUpdated = Instant.ofEpochSecond(1))
@@ -184,7 +193,7 @@ class SessionRepositoryISpec
 
       "must update the upload status in user answers and refresh lastUpdated" in {
 
-        val userAnswersWithUpload = UserAnswers("id")
+        val userAnswersWithUpload = UserAnswers("id", subscription)
           .set(CertificateUploadStatePage, FileUploadState("upscan-ref", UploadStatus.InProgress))
           .get
           .copy(lastUpdated = Instant.ofEpochSecond(1))
@@ -211,7 +220,9 @@ class SessionRepositoryISpec
 
       "must return false" in {
 
-        repository.updateUploadStatus(UploadJourney.Notification, "missing-ref", UploadStatus.Quarantined).futureValue mustBe false
+        repository
+          .updateUploadStatus(UploadJourney.Notification, "missing-ref", UploadStatus.Quarantined)
+          .futureValue mustBe false
       }
     }
 

--- a/it/test/support/ISpecBase.scala
+++ b/it/test/support/ISpecBase.scala
@@ -67,8 +67,10 @@ abstract class ISpecBase
     "play.ws.followRedirects" -> "false"
   ) ++ additionalConfigs
 
-  override def fakeApplication(): Application =
-    GuiceApplicationBuilder()
+  protected def applicationBuilder: GuiceApplicationBuilder = GuiceApplicationBuilder()
+
+  final override def fakeApplication(): Application =
+    applicationBuilder
       .configure(configs)
       .build()
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,7 +17,7 @@
 package base
 
 import controllers.actions.*
-import models.UserAnswers
+import models.*
 import models.upload.UploadTemplateTableData
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
@@ -42,8 +42,34 @@ trait SpecBase
     with ScalaFutures
     with IntegrationPatience {
 
-  val userAnswersId: String         = "id"
-  def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId)
+  val userAnswersId: String = "id"
+  val etmpSafeId            = "etmpSafeId"
+  val companyCrn            = "companyCrn"
+  val companyName           = "companyName"
+  val companyUtr            = "companyUtr"
+  val contact1Name          = "Contact 1 Name"
+  val contact1Email         = "1@test.com"
+  val contact1Language      = "en"
+  val contact1Status        = "valid"
+  val contact2Name          = "Contact 2 Name"
+  val contact2Email         = "2@test.com"
+  val contact2Language      = "cy"
+  val contact2Status        = "unreachable"
+
+  val subscription: SaoSubscription = SaoSubscription(
+    etmpSafeId = etmpSafeId,
+    nominatedCompany = NominatedCompany(
+      name = companyName,
+      crn = companyCrn,
+      utr = companyUtr
+    ),
+    contacts = List(
+      Contact(name = contact1Name, email = contact1Email, language = contact1Language, status = contact1Status),
+      Contact(name = contact2Name, email = contact2Email, language = contact2Language, status = contact2Status)
+    )
+  )
+
+  def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId, subscription)
 
   def completedSaoDetailsAnswers: UserAnswers =
     emptyUserAnswers

--- a/test/controllers/CombinedCertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/CombinedCertificateDeclarationSaoControllerSpec.scala
@@ -45,15 +45,16 @@ class CombinedCertificateDeclarationSaoControllerSpec extends SpecBase with Mock
   lazy val combinedCertificateDeclarationSaoRoute: String =
     routes.CombinedCertificateDeclarationSaoController.onPageLoad(NormalMode).url
 
-  val userAnswers: UserAnswers = UserAnswers(
-    userAnswersId,
-    Json.obj(
-      CombinedCertificateDeclarationSaoPage.toString -> Json.obj(
-        "sao"   -> "value 1",
-        "proxy" -> "value 2"
+  val userAnswers: UserAnswers = {
+    emptyUserAnswers.copy(data =
+      Json.obj(
+        CombinedCertificateDeclarationSaoPage.toString -> Json.obj(
+          "sao"   -> "value 1",
+          "proxy" -> "value 2"
+        )
       )
     )
-  )
+  }
 
   "CombinedCertificateDeclarationSao Controller" - {
 

--- a/test/controllers/CombinedWhoSubmitsCertificateControllerSpec.scala
+++ b/test/controllers/CombinedWhoSubmitsCertificateControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.CombinedWhoSubmitsCertificateFormProvider
-import models.{CombinedWhoSubmitsCertificate, NormalMode, UserAnswers}
+import models.{CombinedWhoSubmitsCertificate, NormalMode}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -65,7 +65,7 @@ class CombinedWhoSubmitsCertificateControllerSpec extends SpecBase with MockitoS
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers =
-        UserAnswers(userAnswersId)
+        emptyUserAnswers
           .set(CombinedWhoSubmitsCertificatePage, CombinedWhoSubmitsCertificate.values.head)
           .success
           .value

--- a/test/controllers/IsThisTheSaoOnCertificateControllerSpec.scala
+++ b/test/controllers/IsThisTheSaoOnCertificateControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.IsThisTheSaoOnCertificateFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -64,7 +64,7 @@ class IsThisTheSaoOnCertificateControllerSpec extends SpecBase with MockitoSugar
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(IsThisTheSaoOnCertificatePage, true).success.value
+      val userAnswers = emptyUserAnswers.set(IsThisTheSaoOnCertificatePage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/SaoEmailCommunicationChoiceControllerSpec.scala
+++ b/test/controllers/SaoEmailCommunicationChoiceControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.SaoEmailCommunicationChoiceFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -64,7 +64,7 @@ class SaoEmailCommunicationChoiceControllerSpec extends SpecBase with MockitoSug
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(SaoEmailCommunicationChoicePage, true).success.value
+      val userAnswers = emptyUserAnswers.set(SaoEmailCommunicationChoicePage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/SaoEmailControllerSpec.scala
+++ b/test/controllers/SaoEmailControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.SaoEmailFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -63,7 +63,7 @@ class SaoEmailControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(SaoEmailPage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(SaoEmailPage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/SaoNameControllerSpec.scala
+++ b/test/controllers/SaoNameControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.SaoNameFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -63,7 +63,7 @@ class SaoNameControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(SaoNamePage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(SaoNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/SubmissionTypeControllerSpec.scala
+++ b/test/controllers/SubmissionTypeControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import forms.SubmissionTypeFormProvider
-import models.{SubmissionType, UserAnswers}
+import models.SubmissionType
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -63,7 +63,7 @@ class SubmissionTypeControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(SubmissionTypePage, SubmissionType.values.head).success.value
+      val userAnswers = emptyUserAnswers.set(SubmissionTypePage, SubmissionType.values.head).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -125,22 +125,6 @@ class SubmissionTypeControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual BAD_REQUEST
         contentAsString(result) mustEqual view(boundForm)(using request, messages(application)).toString
-      }
-    }
-
-    "must return OK and the correct view for a GET if no existing data is found" in {
-
-      val application = applicationBuilder(userAnswers = None).build()
-
-      running(application) {
-        val request = FakeRequest(GET, submissionTypeRoute)
-
-        val result = route(application, request).value
-
-        val view = application.injector.instanceOf[SubmissionTypeView]
-
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form)(using request, messages(application)).toString
       }
     }
 

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -17,7 +17,6 @@
 package controllers.actions
 
 import base.SpecBase
-import models.UserAnswers
 import models.requests.{IdentifierRequest, OptionalDataRequest}
 import org.mockito.Mockito.*
 import org.scalatestplus.mockito.MockitoSugar
@@ -54,7 +53,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar {
       "must build a userAnswers object and add it to the request" in {
 
         val sessionRepository = mock[SessionRepository]
-        when(sessionRepository.get("id")) thenReturn Future(Some(UserAnswers("id")))
+        when(sessionRepository.get("id")) thenReturn Future(Some(emptyUserAnswers))
         val action = new Harness(sessionRepository)
 
         val result = action.callTransform(new IdentifierRequest(FakeRequest(), "id")).futureValue

--- a/test/controllers/certificate/CertificateDeclarationSaoControllerSpec.scala
+++ b/test/controllers/certificate/CertificateDeclarationSaoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import controllers.routes
 import forms.certificate.CertificateDeclarationSaoFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -66,7 +66,7 @@ class CertificateDeclarationSaoControllerSpec extends SpecBase with MockitoSugar
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(CertificateDeclarationSaoPage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(CertificateDeclarationSaoPage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/certificate/CertificateDeclarationStandInControllerSpec.scala
+++ b/test/controllers/certificate/CertificateDeclarationStandInControllerSpec.scala
@@ -49,17 +49,17 @@ class CertificateDeclarationStandInControllerSpec extends SpecBase with MockitoS
   lazy val certificateDeclarationStandInRoute: String =
     certificateRoutes.CertificateDeclarationStandInController.onPageLoad(NormalMode).url
 
-  val userAnswers: UserAnswers = UserAnswers(
-    userAnswersId,
-    Json.obj(
-      CERTIFICATE_PATH -> Json.obj(
-        CertificateDeclarationStandInPage.toString -> Json.obj(
-          "StandInName" -> "value 1",
-          "SaoName"     -> "value 2"
+  val userAnswers: UserAnswers =
+    emptyUserAnswers.copy(data =
+      Json.obj(
+        CERTIFICATE_PATH -> Json.obj(
+          CertificateDeclarationStandInPage.toString -> Json.obj(
+            "StandInName" -> "value 1",
+            "SaoName"     -> "value 2"
+          )
         )
       )
     )
-  )
 
   "CertificateDeclarationStandIn Controller" - {
 

--- a/test/controllers/certificate/CertificateSaoEmailControllerSpec.scala
+++ b/test/controllers/certificate/CertificateSaoEmailControllerSpec.scala
@@ -47,7 +47,7 @@ class CertificateSaoEmailControllerSpec extends SpecBase with MockitoSugar {
 
   lazy val certificateSaoEmailRoute: String = certificateRoutes.CertificateSaoEmailController.onPageLoad(NormalMode).url
 
-  val userAnswers: UserAnswers = UserAnswers(userAnswersId)
+  val userAnswers: UserAnswers = emptyUserAnswers
     .set(CertificateSaoFullNamePage, saoName)
     .success
     .value

--- a/test/controllers/certificate/CertificateSaoFullNameControllerSpec.scala
+++ b/test/controllers/certificate/CertificateSaoFullNameControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import controllers.routes
 import forms.certificate.CertificateSaoFullNameFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -66,7 +66,7 @@ class CertificateSaoFullNameControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(CertificateSaoFullNamePage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(CertificateSaoFullNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/certificate/CertificateWhoIsSubmittingControllerSpec.scala
+++ b/test/controllers/certificate/CertificateWhoIsSubmittingControllerSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import controllers.certificate.routes as certificateRoutes
 import controllers.routes
 import forms.certificate.CertificateWhoIsSubmittingFormProvider
+import models.NormalMode
 import models.certificate.CertificateWhoIsSubmitting
-import models.{NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -67,7 +67,7 @@ class CertificateWhoIsSubmittingControllerSpec extends SpecBase with MockitoSuga
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId)
+      val userAnswers = emptyUserAnswers
         .set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.values.head)
         .success
         .value

--- a/test/controllers/notification/MoreSaoSubmitNotificationFullNameControllerSpec.scala
+++ b/test/controllers/notification/MoreSaoSubmitNotificationFullNameControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
 import forms.notification.NotificationMultiSaoLastOfficerNameFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -66,7 +66,7 @@ class NotificationMultiSaoLastOfficerNameControllerSpec extends SpecBase with Mo
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(NotificationMultiSaoLastOfficerNamePage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(NotificationMultiSaoLastOfficerNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/notification/NotificationMoreSaoAreAllAddedControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreSaoAreAllAddedControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
 import forms.notification.NotificationMultiSaoAreAllAddedFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -72,7 +72,7 @@ class NotificationMultiSaoAreAllAddedControllerSpec extends SpecBase with Mockit
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers =
-        UserAnswers(userAnswersId).set(NotificationMultiSaoAreAllAddedPage(saoIndex), true).success.value
+        emptyUserAnswers.set(NotificationMultiSaoAreAllAddedPage(saoIndex), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/notification/NotificationMoreThanOneSaoControllerSpec.scala
+++ b/test/controllers/notification/NotificationMoreThanOneSaoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
 import forms.notification.NotificationMoreThanOneSaoFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -64,7 +64,7 @@ class NotificationMoreThanOneSaoControllerSpec extends SpecBase with MockitoSuga
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(NotificationMoreThanOneSaoPage, true).success.value
+      val userAnswers = emptyUserAnswers.set(NotificationMoreThanOneSaoPage, true).success.value
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       running(application) {

--- a/test/controllers/notification/NotificationMultiSaoLastOfficerStartDateControllerSpec.scala
+++ b/test/controllers/notification/NotificationMultiSaoLastOfficerStartDateControllerSpec.scala
@@ -53,7 +53,7 @@ class NotificationMultiSaoLastOfficerStartDateControllerSpec extends SpecBase wi
   lazy val notificationMultiSaoLastOfficerStartDateRoute: String =
     notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode).url
 
-  val userAnswers: UserAnswers = UserAnswers(userAnswersId)
+  val userAnswers: UserAnswers = emptyUserAnswers
     .set(NotificationMultiSaoLastOfficerNamePage, saoName)
     .success
     .value
@@ -142,7 +142,7 @@ class NotificationMultiSaoLastOfficerStartDateControllerSpec extends SpecBase wi
     "must return a Bad Request and errors when invalid data is submitted" in {
 
       val userAnswers =
-        UserAnswers(userAnswersId)
+        emptyUserAnswers
           .set(NotificationMultiSaoLastOfficerNamePage, saoName)
           .success
           .value

--- a/test/controllers/notification/OneSaoSubmitNotificationFullNameControllerSpec.scala
+++ b/test/controllers/notification/OneSaoSubmitNotificationFullNameControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.notification.routes as notificationRoutes
 import controllers.routes
 import forms.notification.NotificationSingleSaoOfficerNameFormProvider
-import models.{NormalMode, UserAnswers}
+import models.NormalMode
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -66,7 +66,7 @@ class NotificationSingleSaoOfficerNameControllerSpec extends SpecBase with Mocki
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = UserAnswers(userAnswersId).set(NotificationSingleSaoOfficerNamePage, "answer").success.value
+      val userAnswers = emptyUserAnswers.set(NotificationSingleSaoOfficerNamePage, "answer").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -40,7 +40,7 @@ class NavigatorSpec extends SpecBase {
       "must throw an not-implemented error for an unspecified configuration" in {
         case object UnknownPage extends Page
         intercept[NotImplementedError] {
-          navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id"))
+          navigator.nextPage(UnknownPage, NormalMode, emptyUserAnswers)
         }
       }
 
@@ -48,7 +48,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationAdditionalInformationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.ConfirmYourNotificationController.onPageLoad()
       }
 
@@ -56,7 +56,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           ConfirmYourNotificationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationCheckYourAnswersController.onPageLoad()
       }
 
@@ -64,7 +64,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           ConfirmYourNotificationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationCheckYourAnswersController.onPageLoad()
       }
 
@@ -72,7 +72,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           IsThisTheSaoOnCertificatePage,
           NormalMode,
-          UserAnswers("id").set(IsThisTheSaoOnCertificatePage, true).get
+          emptyUserAnswers.set(IsThisTheSaoOnCertificatePage, true).get
         ) mustBe routes.SaoEmailController.onPageLoad(NormalMode)
       }
 
@@ -80,7 +80,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           IsThisTheSaoOnCertificatePage,
           NormalMode,
-          UserAnswers("id").set(IsThisTheSaoOnCertificatePage, false).get
+          emptyUserAnswers.set(IsThisTheSaoOnCertificatePage, false).get
         ) mustBe routes.SaoNameController.onPageLoad(NormalMode)
       }
 
@@ -89,7 +89,7 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(
             IsThisTheSaoOnCertificatePage,
             NormalMode,
-            UserAnswers("id")
+            emptyUserAnswers
           )
         }
       }
@@ -98,7 +98,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoNamePage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.SaoEmailController.onPageLoad(NormalMode)
       }
 
@@ -106,7 +106,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoEmailPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.SaoEmailCommunicationChoiceController.onPageLoad(NormalMode)
       }
 
@@ -114,7 +114,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoEmailCommunicationChoicePage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -122,7 +122,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CombinedCertificateCheckYourAnswersPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedWhoSubmitsCertificateController.onPageLoad(NormalMode)
       }
 
@@ -130,7 +130,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CombinedWhoSubmitsCertificatePage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.QualifiedCompaniesController.onPageLoad()
       }
 
@@ -138,7 +138,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           QualifiedCompaniesPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.UnqualifiedCompaniesController.onPageLoad()
       }
 
@@ -146,7 +146,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           UnqualifiedCompaniesPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateDeclarationSaoController.onPageLoad(NormalMode)
       }
 
@@ -154,7 +154,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CombinedCertificateDeclarationSaoPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateConfirmationController.onPageLoad()
       }
 
@@ -162,7 +162,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationConfirmationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationTaskListController.onComplete()
       }
 
@@ -170,7 +170,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMoreThanOneSaoPage,
           NormalMode,
-          UserAnswers("id").set(NotificationMoreThanOneSaoPage, false).success.value
+          emptyUserAnswers.set(NotificationMoreThanOneSaoPage, false).success.value
         ) mustBe notificationRoutes.NotificationSingleSaoOfficerNameController.onPageLoad(NormalMode)
       }
 
@@ -178,7 +178,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMoreThanOneSaoPage,
           NormalMode,
-          UserAnswers("id").set(NotificationMoreThanOneSaoPage, true).success.value
+          emptyUserAnswers.set(NotificationMoreThanOneSaoPage, true).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoLastOfficerNameController.onPageLoad(NormalMode)
       }
 
@@ -186,7 +186,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoLastOfficerNamePage,
           NormalMode,
-          UserAnswers("id").set(NotificationMoreThanOneSaoPage, true).success.value
+          emptyUserAnswers.set(NotificationMoreThanOneSaoPage, true).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoLastOfficerStartDateController.onPageLoad(NormalMode)
       }
 
@@ -194,7 +194,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoLastOfficerStartDatePage,
           NormalMode,
-          UserAnswers("id").set(NotificationMultiSaoLastOfficerStartDatePage, LocalDate.of(2026, 5, 1)).success.value
+          emptyUserAnswers.set(NotificationMultiSaoLastOfficerStartDatePage, LocalDate.of(2026, 5, 1)).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode)
       }
 
@@ -202,7 +202,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerNamePage(0),
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerStartDateController.onPageLoad(NormalMode, 0)
       }
 
@@ -210,7 +210,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerStartDatePage(0),
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerEndDateController.onPageLoad(NormalMode)
       }
 
@@ -218,7 +218,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoPreviousOfficerEndDatePage(0),
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationMultiSaoAreAllAddedController.onPageLoad(NormalMode)
       }
 
@@ -227,7 +227,7 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(
             NotificationMultiSaoAreAllAddedPage(0),
             NormalMode,
-            UserAnswers("id")
+            emptyUserAnswers
           )
         }
       }
@@ -236,7 +236,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoAreAllAddedPage(0),
           NormalMode,
-          UserAnswers("id").set(NotificationMultiSaoAreAllAddedPage(0), true).success.value
+          emptyUserAnswers.set(NotificationMultiSaoAreAllAddedPage(0), true).success.value
         ) mustBe notificationRoutes.NotificationTaskListController.onPageLoad()
       }
 
@@ -244,7 +244,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationMultiSaoAreAllAddedPage(0),
           NormalMode,
-          UserAnswers("id").set(NotificationMultiSaoAreAllAddedPage(0), false).success.value
+          emptyUserAnswers.set(NotificationMultiSaoAreAllAddedPage(0), false).success.value
         ) mustBe notificationRoutes.NotificationMultiSaoPreviousOfficerNameController.onPageLoad(NormalMode, 1)
       }
 
@@ -252,13 +252,13 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationSingleSaoOfficerNamePage,
           NormalMode,
-          UserAnswers("id").set(NotificationSingleSaoOfficerNamePage, "Firstname Lastname").success.value
+          emptyUserAnswers.set(NotificationSingleSaoOfficerNamePage, "Firstname Lastname").success.value
         ) mustBe notificationRoutes.NotificationTaskListController.onPageLoad()
       }
 
       "when on UploadTemplateTablePage with no parsing errors, must go to notification start page" in {
         val userAnswers =
-          UserAnswers("id")
+          emptyUserAnswers
             .set(UploadTemplateTablePage, UploadTemplateTableData(rows = Seq.empty, errors = Seq.empty))
             .success
             .value
@@ -272,7 +272,7 @@ class NavigatorSpec extends SpecBase {
 
       "when on UploadTemplateTablePage with parsing errors, must go to upload form page" in {
         val userAnswers =
-          UserAnswers("id")
+          emptyUserAnswers
             .set(
               UploadTemplateTablePage,
               UploadTemplateTableData(
@@ -292,7 +292,7 @@ class NavigatorSpec extends SpecBase {
 
       "when on UploadTemplateTableErrorPage  must go to upload form page" in {
         val userAnswers =
-          UserAnswers("id")
+          emptyUserAnswers
             .set(
               UploadTemplateTablePage,
               UploadTemplateTableData(
@@ -314,7 +314,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           UploadTemplateTablePage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.JourneyRecoveryController.onPageLoad()
       }
 
@@ -324,7 +324,7 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(
             SubmissionTypePage,
             NormalMode,
-            UserAnswers("id").set(SubmissionTypePage, SubmissionType.Notification).get
+            emptyUserAnswers.set(SubmissionTypePage, SubmissionType.Notification).get
           ) mustBe notificationRoutes.NotificationTaskListController.onPageLoad()
         }
 
@@ -332,7 +332,7 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(
             SubmissionTypePage,
             NormalMode,
-            UserAnswers("id").set(SubmissionTypePage, SubmissionType.Certificate).get
+            emptyUserAnswers.set(SubmissionTypePage, SubmissionType.Certificate).get
           ) mustBe certificateRoutes.CertificateTaskListController.onPageLoad(
             CertificateTaskListStage.ProvideSaoDetailsStage
           )
@@ -343,7 +343,7 @@ class NavigatorSpec extends SpecBase {
             navigator.nextPage(
               SubmissionTypePage,
               NormalMode,
-              UserAnswers("id").set(SubmissionTypePage, SubmissionType.Combined).get
+              emptyUserAnswers.set(SubmissionTypePage, SubmissionType.Combined).get
             )
           }
         }
@@ -355,7 +355,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateSaoFullNamePage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateSaoEmailController.onPageLoad(NormalMode)
       }
 
@@ -363,7 +363,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateSaoEmailPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateTaskListController.onPageLoad(
           CertificateTaskListStage.UploadSubmissionTemplateStage
         )
@@ -371,7 +371,7 @@ class NavigatorSpec extends SpecBase {
 
       "when on CertificateUploadTemplateTableErrorPage with no parsing errors, must go to upload form page" in {
         val userAnswers =
-          UserAnswers("id")
+          emptyUserAnswers
             .set(CertificateUploadTemplateTablePage, UploadTemplateTableData(rows = Seq.empty, errors = Seq.empty))
             .success
             .value
@@ -385,7 +385,7 @@ class NavigatorSpec extends SpecBase {
 
       "when on CertificateUploadTemplateTableErrorPage with parsing errors, must go to upload form page" in {
         val userAnswers =
-          UserAnswers("id")
+          emptyUserAnswers
             .set(
               CertificateUploadTemplateTablePage,
               UploadTemplateTableData(
@@ -407,7 +407,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateUploadTemplateTableErrorPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.JourneyRecoveryController.onPageLoad()
       }
 
@@ -415,7 +415,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateReviewQualifiedPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateReviewUnqualifiedController.onPageLoad()
       }
 
@@ -423,7 +423,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateReviewUnqualifiedPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateTaskListController.onPageLoad(
           CertificateTaskListStage.SubmitCertificateStage
         )
@@ -433,7 +433,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateAdditionalInformationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateWhoIsSubmittingController.onPageLoad(NormalMode)
       }
 
@@ -441,7 +441,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateWhoIsSubmittingPage,
           NormalMode,
-          UserAnswers("id").set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.Sao).get
+          emptyUserAnswers.set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.Sao).get
         ) mustBe certificateRoutes.CertificateDeclarationSaoController.onPageLoad(NormalMode)
       }
 
@@ -449,7 +449,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateWhoIsSubmittingPage,
           NormalMode,
-          UserAnswers("id").set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.StandIn).get
+          emptyUserAnswers.set(CertificateWhoIsSubmittingPage, CertificateWhoIsSubmitting.StandIn).get
         ) mustBe certificateRoutes.CertificateDeclarationStandInController.onPageLoad(NormalMode)
       }
 
@@ -457,7 +457,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateDeclarationSaoPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -465,7 +465,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateDeclarationStandInPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -473,7 +473,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateConfirmationPage,
           NormalMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateTaskListController.onPageLoad(CertificateTaskListStage.Complete)
       }
     }
@@ -484,7 +484,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           NotificationAdditionalInformationPage,
           CheckMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe notificationRoutes.NotificationCheckYourAnswersController.onPageLoad()
       }
 
@@ -492,7 +492,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoNamePage,
           CheckMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -500,7 +500,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           CertificateAdditionalInformationPage,
           CheckMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe certificateRoutes.CertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -508,7 +508,7 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoEmailPage,
           CheckMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateCheckYourAnswersController.onPageLoad()
       }
 
@@ -516,14 +516,14 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(
           SaoEmailCommunicationChoicePage,
           CheckMode,
-          UserAnswers("id")
+          emptyUserAnswers
         ) mustBe routes.CombinedCertificateCheckYourAnswersController.onPageLoad()
       }
 
       "must throw an not-implemented error for an unspecified configuration" in {
         case object UnknownPage extends Page
         intercept[NotImplementedError] {
-          navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id"))
+          navigator.nextPage(UnknownPage, CheckMode, emptyUserAnswers)
         }
       }
 

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -291,15 +291,15 @@ class UpscanServiceSpec extends SpecBase with GuiceOneAppPerSuite with BeforeAnd
       verify(mockUploadTemplateCsvParser, times(0)).parse(any(), any[Messages])
     }
   }
+
+  def userAnswersWithUploadStatus(journey: UploadJourney, status: UploadStatus): UserAnswers =
+    emptyUserAnswers
+      .set(journey.page, FileUploadState(testFileReference, status))
+      .get
 }
 
 object UpscanServiceSpec {
   val testDownloadUrl: String   = "/test/url"
   val testFileContent: String   = Random.nextString(10)
   val testFileReference: String = Random.nextString(10)
-
-  def userAnswersWithUploadStatus(journey: UploadJourney, status: UploadStatus): UserAnswers =
-    UserAnswers("id")
-      .set(journey.page, FileUploadState(testFileReference, status))
-      .get
 }


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* will Read subscription from Mongo (added by [SAOD-985/hub-calling-get-subscription](https://github.com/hmrc/senior-accounting-officer-acceptance-tests/pull/105))
* removed the two hacks we've previously put in place in order to create a dummy version of what the above now do

## Jira ticket(s):
* [SAOD-985](http://jira.tools.tax.service.gov.uk/browse/SAOD-985)

## Checklist
* [ ] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
    * [SAOD-985/test-data-update](https://github.com/hmrc/senior-accounting-officer-stubs/pull/61) must be merged first
    the following must be merged together with this PR
    * [SAOD-985/calling-get-subscription](https://github.com/hmrc/senior-accounting-officer-hub-frontend/pull/24)
    * [SAOD-985/hub-calling-get-subscription](https://github.com/hmrc/senior-accounting-officer-acceptance-tests/pull/105)
