### PR TITLE
SAOD-1029 for noti & cert, use subscriptionId from auth

### DIFF
--- a/app/connectors/CertificateSubmissionConnector.scala
+++ b/app/connectors/CertificateSubmissionConnector.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.http.client.HttpClientV2
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import java.util.UUID
 import javax.inject.Inject
 
 class CertificateSubmissionConnector @Inject() (
@@ -38,6 +39,7 @@ class CertificateSubmissionConnector @Inject() (
     httpClient
       .post(url"${appConfig.protectedServiceUrl}/senior-accounting-officer/certificate")
       .withBody(Json.toJson(request))
+      .setHeader("correlationId" -> UUID.randomUUID().toString)
       .execute[HttpResponse]
       .map {
         case response if response.status == CREATED =>

--- a/app/connectors/ProtectedServiceConnector.scala
+++ b/app/connectors/ProtectedServiceConnector.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.http.client.HttpClientV2
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import java.util.UUID
 import javax.inject.Inject
 
 class ProtectedServiceConnector @Inject() (appConfig: AppConfig, httpClient: HttpClientV2)(using
@@ -38,6 +39,7 @@ class ProtectedServiceConnector @Inject() (appConfig: AppConfig, httpClient: Htt
     httpClient
       .post(url"${appConfig.protectedServiceUrl}/senior-accounting-officer/notification")
       .withBody(Json.toJson(request))
+      .setHeader("correlationId" -> UUID.randomUUID().toString)
       .execute[HttpResponse]
   }
 }

--- a/app/controllers/certificate/CertificateCheckYourAnswersController.scala
+++ b/app/controllers/certificate/CertificateCheckYourAnswersController.scala
@@ -67,7 +67,7 @@ class CertificateCheckYourAnswersController @Inject() (
         Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))
       case Some(token) =>
         certificateSubmissionService
-          .submit(request.userId, request.saoSubscriptionId, request.userAnswers, token)
+          .submit(request.userId, request.userAnswers, token)
           .flatMap {
             case CertificateSubmissionResult.Submitted(certificateRef) =>
               Future.successful(

--- a/app/models/certificate/CertificateSubmissionRequest.scala
+++ b/app/models/certificate/CertificateSubmissionRequest.scala
@@ -19,7 +19,6 @@ package models.certificate
 import play.api.libs.json.{Json, OFormat}
 
 final case class CertificateSubmissionRequest(
-    subscriptionId: String,
     submitterName: Option[String],
     saoName: String,
     saoEmail: String,

--- a/app/models/notification/NotificationRequest.scala
+++ b/app/models/notification/NotificationRequest.scala
@@ -20,7 +20,6 @@ import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 
 final case class NotificationRequest(
-    subscriptionId: String,
     companies: List[Company],
     saos: List[Sao],
     remarks: Option[String]

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -41,11 +41,10 @@ class CertificateSubmissionService @Inject() (
 
   def submit(
       userId: String,
-      saoSubscriptionId: String,
       userAnswers: UserAnswers,
       token: String
   )(using HeaderCarrier): Future[CertificateSubmissionResult] =
-    buildRequest(saoSubscriptionId, userAnswers) match {
+    buildRequest(userAnswers) match {
       case Left(error) =>
         logger.warn(s"Certificate submission could not be built: $error")
         Future.successful(CertificateSubmissionResult.MissingData)
@@ -74,7 +73,6 @@ class CertificateSubmissionService @Inject() (
     }
 
   private def buildRequest(
-      saoSubscriptionId: String,
       userAnswers: UserAnswers
   ): Either[String, CertificateSubmissionRequest] =
     for {
@@ -84,7 +82,6 @@ class CertificateSubmissionService @Inject() (
       companies = tableData.rows.map(toCompany)
       _ <- Either.cond(companies.nonEmpty, (), "missing companies")
     } yield CertificateSubmissionRequest(
-      subscriptionId = saoSubscriptionId,
       submitterName = submitterName(userAnswers),
       saoName = saoName,
       saoEmail = saoEmail,

--- a/app/services/NotificationSubmitService.scala
+++ b/app/services/NotificationSubmitService.scala
@@ -47,9 +47,7 @@ class NotificationSubmitService @Inject() (
             val notificationReference = Json.parse(response.body).as[NotificationResponse].notificationRef
             sessionRepository
               .set(userAnswers.copy(data = Json.obj()))
-              .map { case _ =>
-                Right(notificationReference)
-              }
+              .map(_ => Right(notificationReference))
           }
           case _ => Future.successful(Left(NotificationSubmissionError.HttpError(response)))
         }
@@ -59,12 +57,9 @@ class NotificationSubmitService @Inject() (
 
 object NotificationSubmitService {
 
-  val hardCodedSubscriptionId = "123" // TODO: remove when the subscription id is available
-
   extension (userAnswers: UserAnswers) {
     def toNotification: NotificationRequest = {
       NotificationRequest(
-        subscriptionId = hardCodedSubscriptionId,
         remarks = userAnswers.getNullable(NotificationAdditionalInformationPage),
         saos = userAnswers.toSaos,
         companies = userAnswers.toCompanies

--- a/it/test/connectors/ProtectedServiceConnectorISpec.scala
+++ b/it/test/connectors/ProtectedServiceConnectorISpec.scala
@@ -55,7 +55,6 @@ class ProtectedServiceConnectorISpec extends ISpecBase {
         SUT
           .postNotification(
             NotificationRequest(
-              subscriptionId = subscriptionId,
               companies = List(
                 Company(
                   crn = None,
@@ -92,5 +91,4 @@ class ProtectedServiceConnectorISpec extends ISpecBase {
 
 object ProtectedServiceConnectorISpec {
   val testBody       = Json.obj("notificationRef" -> "NOT0123456789").toString
-  val subscriptionId = "123"
 }

--- a/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/certificate/CertificateCheckYourAnswersControllerSpec.scala
@@ -84,7 +84,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
       val mockSubmissionService = mock[CertificateSubmissionService]
       val certificateRef        = "CRT0123456789"
 
-      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Submitted(certificateRef)))
 
       val application =
@@ -109,7 +109,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must fail when submission fails so the error handler can render the 500 page" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Failed))
 
       val application =
@@ -131,7 +131,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must redirect to Journey Recovery when required submission data is missing" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.MissingData))
 
       val application =
@@ -154,7 +154,7 @@ class CertificateCheckYourAnswersControllerSpec extends SpecBase with MockitoSug
     "must redirect back to check your answers when the submission token has already been used" in {
       val mockSubmissionService = mock[CertificateSubmissionService]
 
-      when(mockSubmissionService.submit(meq("id"), meq(testSaoSubscriptionId), any(), meq("token"))(using any()))
+      when(mockSubmissionService.submit(meq("id"), any(), meq("token"))(using any()))
         .thenReturn(Future.successful(CertificateSubmissionResult.Duplicate))
 
       val application =

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -23,8 +23,8 @@ import CertificateSubmissionRequestFormatSpec.*
 
 class CertificateSubmissionRequestFormatSpec extends SpecBase {
 
-  private val request     = certificateSubmissionRequest(testSaoSubscriptionId)
-  private val requestJson = certificateSubmissionRequestJson(testSaoSubscriptionId)
+  private val request     = certificateSubmissionRequest
+  private val requestJson = certificateSubmissionRequestJson
 
   "CertificateSubmissionRequest" - {
 
@@ -48,10 +48,12 @@ class CertificateSubmissionRequestFormatSpec extends SpecBase {
       json.validate[CertificateSubmissionRequest] mustBe JsSuccess(requestWithoutOptionalValues)
     }
 
-    "must fail to read when a required field is missing" in {
-      val result = requestJson.as[JsObject].-("subscriptionId").validate[CertificateSubmissionRequest]
+    for name <- Seq("saoName", "saoEmail", "companies") yield {
+      s"must fail to read when a required '$name' field is missing" in {
+        val result = requestJson.as[JsObject].-(name).validate[CertificateSubmissionRequest]
 
-      result mustBe a[JsError]
+        result mustBe a[JsError]
+      }
     }
   }
 
@@ -129,9 +131,8 @@ object CertificateSubmissionRequestFormatSpec {
       |}""".stripMargin
   )
 
-  def certificateSubmissionRequest(testSaoSubscriptionId: String): CertificateSubmissionRequest =
+  def certificateSubmissionRequest: CertificateSubmissionRequest =
     CertificateSubmissionRequest(
-      subscriptionId = testSaoSubscriptionId,
       submitterName = Some("Proxy Person"),
       saoName = "Senior Officer",
       saoEmail = "sao@example.com",
@@ -139,9 +140,8 @@ object CertificateSubmissionRequestFormatSpec {
       remarks = Some("Certificate remarks")
     )
 
-  def certificateSubmissionRequestJson(testSaoSubscriptionId: String): JsValue = Json.parse(
+  def certificateSubmissionRequestJson: JsValue = Json.parse(
     s"""{
-      |  "subscriptionId": "$testSaoSubscriptionId",
       |  "submitterName": "Proxy Person",
       |  "saoName": "Senior Officer",
       |  "saoEmail": "sao@example.com",

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -59,7 +59,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
+        .submit(userAnswersId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
@@ -72,7 +72,6 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       verify(sessionRepository, never()).clear(any())
 
       val request = requestCaptor.getValue
-      request.subscriptionId mustBe testSaoSubscriptionId
       request.submitterName.value mustBe "Proxy Person"
       request.saoName mustBe "Senior Officer"
       request.saoEmail mustBe "sao@example.com"
@@ -107,7 +106,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
+        .submit(userAnswersId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Duplicate
@@ -127,7 +126,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
+        .submit(userAnswersId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Failed
@@ -147,7 +146,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, completeUserAnswers(emptyUserAnswers), "token")
+        .submit(userAnswersId, completeUserAnswers(emptyUserAnswers), "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.Submitted("CRT0123456789")
@@ -160,7 +159,7 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       val service           = new CertificateSubmissionService(connector, sessionRepository)
 
       val result = service
-        .submit(userAnswersId, testSaoSubscriptionId, emptyUserAnswers, "token")
+        .submit(userAnswersId, emptyUserAnswers, "token")
         .futureValue
 
       result mustBe CertificateSubmissionResult.MissingData

--- a/test/services/NotificationSubmitServiceSpec.scala
+++ b/test/services/NotificationSubmitServiceSpec.scala
@@ -153,7 +153,6 @@ class NotificationSubmitServiceSpec extends SpecBase with GuiceOneAppPerSuite {
       val userAnswers = buildUserAnswers(false)
 
       val expected = NotificationRequest(
-        subscriptionId = hardCodedSubscriptionId,
         saos = List(Sao(name = exampleSao1Name, fromDate = None, email = None, toDate = None)),
         companies = List(
           Company(
@@ -177,7 +176,6 @@ class NotificationSubmitServiceSpec extends SpecBase with GuiceOneAppPerSuite {
       val userAnswers = buildUserAnswers(true)
 
       val expected = NotificationRequest(
-        subscriptionId = hardCodedSubscriptionId,
         saos = List(
           Sao(
             name = exampleSao2Name,
@@ -222,7 +220,6 @@ object NotificationSubmitServiceSpec {
   val exampleNotificationReference       = "appleBananaCitrue"
   val expectedHttpFailureMessage: String = s"Notification submit HTTP call failed with code ${INTERNAL_SERVER_ERROR}"
 
-  val hardCodedSubscriptionId         = "123"
   val exampleAdditionalInformation    = "example additional information"
   val exampleSao1Name                 = "Firstname Lastname I"
   val exampleSao2Name                 = "Firstname Lastname II"


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* removed subscription id from notification & certificate requests (it'll now be taken from auth instead)

## Jira ticket(s):
* [SAOD-1029](https://jira.tools.tax.service.gov.uk/browse/SAOD-1029)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
    * [protected service PR](https://github.com/hmrc/senior-accounting-officer/pull/67)
