### PR TITLE
noJira/test only route to view what's stored on object store

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -62,7 +62,7 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
       Json.obj(
         "resourceType"     -> "object-store",
         "resourceLocation" -> "senior-accounting-officer",
-        "actions"          -> Json.arr("READ", "WRITE")
+        "actions"          -> Json.arr("READ", "WRITE", "DELETE")
       )
     )
   )

--- a/app/controllers/testonly/InternalAuthTestOnlyController.scala
+++ b/app/controllers/testonly/InternalAuthTestOnlyController.scala
@@ -19,7 +19,6 @@ package controllers.testonly
 import connectors.InternalAuthTestOnlyConnector
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.ExecutionContext
 
@@ -32,8 +31,6 @@ class InternalAuthTestOnlyController @Inject() (
     extends FrontendController(mcc) {
 
   def grantSaoObjectStoreAccess(): Action[AnyContent] = Action.async { implicit request =>
-    given hc: uk.gov.hmrc.http.HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-
     connector.grantSaoObjectStoreAccess().map { response =>
       Status(response.status)(response.body)
     }

--- a/app/controllers/testonly/ObjectStoreViewerController.scala
+++ b/app/controllers/testonly/ObjectStoreViewerController.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testonly
+
+import connectors.InternalAuthTestOnlyConnector
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import play.api.Logging
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.objectstore.client.play.Implicits.*
+import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.testonly.ObjectStoreView
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import javax.inject.Inject
+
+class ObjectStoreViewerController @Inject() (
+    objectStoreClient: PlayObjectStoreClient,
+    connector: InternalAuthTestOnlyConnector,
+    cc: MessagesControllerComponents,
+    view: ObjectStoreView
+)(using ExecutionContext, Materializer)
+    extends FrontendController(cc)
+    with Logging {
+
+  def listDirectory(stubInternalAuth: Boolean): Action[AnyContent] = Action.async { implicit request =>
+    objectStoreClient
+      .listObjects(
+        Path.Directory("/"),
+        owner = "senior-accounting-officer"
+      )
+      .map { objectSummaries =>
+        Ok(view(objectSummaries.objectSummaries))
+      }
+      .recoverWith {
+        case e @ UpstreamErrorResponse(_, status @ (401 | 403), _, _) if stubInternalAuth =>
+          logger.warn(s"objectStoreClient.listObjects failed with $status, attempting to stub")
+          connector
+            .grantSaoObjectStoreAccess()
+            .map(_ =>
+              Redirect(
+                controllers.testonly.routes.ObjectStoreViewerController.listDirectory(stubInternalAuth = false)
+              )
+            )
+      }
+  }
+
+  def download(location: String, fileName: String): Action[AnyContent] = Action.async { implicit request =>
+    val fileLocation = Path.Directory(location.replaceFirst("^senior-accounting-officer", "")).file(fileName)
+    objectStoreClient
+      .getObject[Source[ByteString, NotUsed]](
+        fileLocation,
+        owner = "senior-accounting-officer"
+      )
+      .map {
+        case Some(obj) =>
+          Ok.chunked(
+            obj.content,
+            inline = false,
+            fileName = Some(fileName)
+          )
+        case None =>
+          logger.warn(s"GET ${fileLocation.asUri} not found")
+          NotFound
+      }
+      .recover { case NonFatal(e) =>
+        logger.warn(s"GET ${fileLocation.asUri} failed ${e.getMessage}")
+        NotFound
+      }
+  }
+
+  def delete(location: String, fileName: String): Action[AnyContent] = Action.async { implicit request =>
+    val fileLocation = Path.Directory(location.replaceFirst("^senior-accounting-officer", "")).file(fileName)
+    objectStoreClient
+      .deleteObject(
+        fileLocation,
+        owner = "senior-accounting-officer"
+      )
+      .map { _ => Redirect(routes.ObjectStoreViewerController.listDirectory()) }
+      .recover { case NonFatal(e) =>
+        logger.warn(s"DELETE ${fileLocation.asUri} failed ${e.getMessage}")
+        NotFound
+      }
+  }
+
+}

--- a/app/views/testonly/ObjectStoreView.scala.html
+++ b/app/views/testonly/ObjectStoreView.scala.html
@@ -1,0 +1,63 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.objectstore.client.ObjectSummary
+
+@this(
+  layout: templates.Layout,
+)
+@(list: List[ObjectSummary])(using request: Request[?], messages: Messages)
+
+@layout(pageTitle = titleNoForm("Object Store Viewer"), showBackLink = false){
+
+    <h1>Object Store</h1>
+    <dl class="govuk-summary-list">
+        @list.map(entry)
+    </dl>
+}
+
+@entry(metadata: ObjectSummary) = {
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+            @metadata.location.fileName
+        </dt>
+        <dd class="govuk-summary-list__value">
+            <p class="govuk-body">/@metadata.location.directory.value/</p>
+            <p class="govuk-body">@metadata.contentLength</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+            <ul class="govuk-summary-list__actions-list">
+                <li class="govuk-summary-list__actions-list-item">
+                    <a class="govuk-link"
+                      href="@controllers.testonly.routes.ObjectStoreViewerController.download(
+                          metadata.location.directory.value,
+                          metadata.location.fileName
+                      )"
+                    >Download<span class="govuk-visually-hidden"> file</span></a>
+                </li>
+                <li class="govuk-summary-list__actions-list-item">
+                    <a class="govuk-link"
+                    href="@controllers.testonly.routes.ObjectStoreViewerController.delete(
+                        metadata.location.directory.value,
+                        metadata.location.fileName
+                    )"
+                    >Delete<span class="govuk-visually-hidden"> file</span></a>
+                </li>
+            </ul>
+        </dd>
+    </div>
+
+}

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -24,7 +24,10 @@ GET         /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf
 POST        /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf              controllers.testonly.TestPdfController.onSubmit()
 GET         /senior-accounting-officer/submission/test-only/pdf/open-html-to-pdf/example      controllers.testonly.TestPdfController.example(rows:Int ?= 10)
 
-+ nocsrf
++nocsrf
 POST        /senior-accounting-officer/submission/test-only/internal-auth/object-store        controllers.testonly.InternalAuthTestOnlyController.grantSaoObjectStoreAccess()
 
 GET         /senior-accounting-officer/submission/test-only/documentum-package/:submissionId/:fileName        controllers.testonly.DocumentumPackageTestOnlyController.download(submissionId, fileName)
+GET         /senior-accounting-officer/submission/test-only/object-store/list                                 controllers.testonly.ObjectStoreViewerController.listDirectory(stubInternalAuth:Boolean ?= true)
+GET         /senior-accounting-officer/submission/test-only/object-store/download                             controllers.testonly.ObjectStoreViewerController.download(location:String, fileName:String)
+GET         /senior-accounting-officer/submission/test-only/object-store/delete                               controllers.testonly.ObjectStoreViewerController.delete(location:String, fileName:String)

--- a/it/test/connectors/InternalAuthTestOnlyConnectorISpec.scala
+++ b/it/test/connectors/InternalAuthTestOnlyConnectorISpec.scala
@@ -63,7 +63,7 @@ object InternalAuthTestOnlyConnectorISpec {
       Json.obj(
         "resourceType" -> "object-store",
         "resourceLocation" -> "senior-accounting-officer",
-        "actions" -> Json.arr("READ", "WRITE")
+        "actions" -> Json.arr("READ", "WRITE", "DELETE")
       )
     )
   )


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* added a test only route to view what's on object store
  * if internal auth fails then it will attempt to stub it once

## Jira ticket(s):
* no jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [ ] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
