### PR TITLE
bug fix: so that a connectivity issue with object store would not fail the confirmation page

### DIFF
--- a/app/controllers/testonly/ObjectStoreViewerController.scala
+++ b/app/controllers/testonly/ObjectStoreViewerController.scala
@@ -32,6 +32,7 @@ import views.html.testonly.ObjectStoreView
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+
 import javax.inject.Inject
 
 class ObjectStoreViewerController @Inject() (

--- a/app/services/ObjectStoreService.scala
+++ b/app/services/ObjectStoreService.scala
@@ -19,6 +19,7 @@ package services
 import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
+import play.api.Logging
 import services.ObjectStoreService.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.objectstore.client.ObjectSummary
@@ -28,10 +29,12 @@ import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 import javax.inject.Inject
 
-class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(using ec: ExecutionContext) {
+class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(using ec: ExecutionContext)
+    extends Logging {
   def isNotificationPdfAvailable(notificationReference: String)(using hc: HeaderCarrier): Future[Boolean] = {
     objectStoreClient
       .listObjects(
@@ -39,11 +42,13 @@ class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(us
         owner = objectStoreOwner
       )
       .map {
-        _.objectSummaries.exists {
-          case ObjectSummary(Path.File(_, fileName), _, _) =>
-            fileName == s"${notificationReference}_SAO_Notification.pdf"
-          case _ => false
+        _.objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
+          fileName == s"${notificationReference}_SAO_Notification.pdf"
         }
+      }
+      .recoverWith { case NonFatal(e) =>
+        logger.warn("[OBJECT_STORE][ListObjects]", e)
+        Future.successful(false)
       }
   }
 
@@ -54,11 +59,13 @@ class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(us
         owner = objectStoreOwner
       )
       .map {
-        _.objectSummaries.exists {
-          case ObjectSummary(Path.File(_, fileName), _, _) =>
-            fileName == s"${certificateReference}_SAO_Certificate.pdf"
-          case _ => false
+        _.objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
+          fileName == s"${certificateReference}_SAO_Certificate.pdf"
         }
+      }
+      .recoverWith { case NonFatal(e) =>
+        logger.warn("[OBJECT_STORE][ListObjects]", e)
+        Future.successful(false)
       }
   }
 
@@ -71,6 +78,10 @@ class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(us
         owner = objectStoreOwner
       )
       .map(_.map(_.content))
+      .recoverWith { case NonFatal(e) =>
+        logger.warn("[OBJECT_STORE][getObject]", e)
+        Future.successful(None)
+      }
 }
 
 object ObjectStoreService {

--- a/test/services/ObjectStoreServiceSpec.scala
+++ b/test/services/ObjectStoreServiceSpec.scala
@@ -61,6 +61,22 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
   }
 
   "isNotificationPdfAvailable" - {
+    "when connection to object store fails must return false" in {
+      when(
+        mockObjectStoreClient.listObjects(
+          path = any(),
+          owner = any()
+        )(using
+          any()
+        )
+      )
+        .thenReturn(Future.failed(RuntimeException("some exception")))
+
+      val result = SUT.isNotificationPdfAvailable(notificationReference)
+
+      result.futureValue mustBe false
+    }
+
     "when no objects are found in object store must return false" in {
       when(
         mockObjectStoreClient.listObjects(
@@ -143,6 +159,22 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
   }
 
   "isCertificatePdfAvailable" - {
+    "when connection to object store fails must return false" in {
+      when(
+        mockObjectStoreClient.listObjects(
+          path = any(),
+          owner = any()
+        )(using
+          any()
+        )
+      )
+        .thenReturn(Future.failed(RuntimeException("some exception")))
+
+      val result = SUT.isCertificatePdfAvailable(certificateReference)
+
+      result.futureValue mustBe false
+    }
+
     "when no objects are found in object store must return false" in {
       when(
         mockObjectStoreClient.listObjects(
@@ -225,6 +257,22 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
   }
 
   "downloadDocumentumPackage" - {
+    "when connection to object store fails must return Future.succssful(None)" in {
+      when(
+        mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](
+          path = any(),
+          owner = any()
+        )(using
+          any(),
+          any()
+        )
+      ).thenReturn(Future.failed(RuntimeException("some exception")))
+
+      val result = SUT.downloadDocumentumPackage(notificationReference, documentumPackageFileName)
+
+      result.futureValue mustBe None
+    }
+
     "must download the zip from the SDES object-store path" in {
       val expectedPath = Path
         .Directory(s"/senior-accounting-officer/sdes/$notificationReference/")


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* recover the object store calls so that they won't result in a failed future due to connectivity reasons but instead recover in a pure manner
   * this should then fix the issue when we see server error page on confirmation page due to connection to object store is not working, the behaviour is is to simply not show the download PDF link

## Jira ticket(s):
* no jira

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
