### PR TITLE
SAOD-1012: Added pdf download feature

### DIFF
--- a/app/controllers/DownloadPdfController.scala
+++ b/app/controllers/DownloadPdfController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ErrorHandler
+import controllers.actions.*
+import models.SubmissionDocumentType
+import play.api.Logging
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.*
+import services.ObjectStoreService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class DownloadPdfController @Inject() (
+    override val messagesApi: MessagesApi,
+    identify: IdentifierAction,
+    val controllerComponents: MessagesControllerComponents,
+    objectStoreService: ObjectStoreService,
+    errorHandler: ErrorHandler
+)(using ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport
+    with Logging {
+
+  def notification(notificationReference: String): Action[AnyContent] =
+    download(notificationReference, SubmissionDocumentType.Notification)
+
+  def certificate(certificateReference: String): Action[AnyContent] =
+    download(certificateReference, SubmissionDocumentType.Certificate)
+
+  private def download(reference: String, documentType: SubmissionDocumentType): Action[AnyContent] =
+    identify.async { implicit request =>
+      objectStoreService.downloadSubmissionPdf(request.saoSubscriptionId, reference, documentType).flatMap {
+        case Some(pdf) =>
+          Future.successful(
+            Ok.streamed(
+              content = pdf.content,
+              contentLength = Some(pdf.metadata.contentLength),
+              contentType = Some(pdf.metadata.contentType)
+            ).withHeaders(
+              Results
+                .contentDispositionHeader(inline = false, name = Some(documentType.pdfFileName(reference)))
+                .toList*
+            )
+          )
+        case None =>
+          logger.info(s"[DownloadPdf][NotFound] no $documentType pdf in object store for reference $reference")
+          notFound
+      }
+    }
+
+  private def notFound(using request: RequestHeader): Future[Result] =
+    errorHandler.notFoundTemplate.map(NotFound(_))
+}

--- a/app/controllers/certificate/CertificateConfirmationController.scala
+++ b/app/controllers/certificate/CertificateConfirmationController.scala
@@ -45,13 +45,14 @@ class CertificateConfirmationController @Inject() (
 
   def onPageLoad(certificateReference: String): Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>
-      objectStoreService.isCertificatePdfAvailable(certificateReference).map { isPdfAvailable =>
-        Ok(
-          view(
-            certificateReference = certificateReference,
-            displayPdfLink = isPdfAvailable
+      objectStoreService.isCertificatePdfAvailable(request.saoSubscriptionId, certificateReference).map {
+        isPdfAvailable =>
+          Ok(
+            view(
+              certificateReference = certificateReference,
+              displayPdfLink = isPdfAvailable
+            )
           )
-        )
       }
     }
 

--- a/app/controllers/notification/NotificationConfirmationController.scala
+++ b/app/controllers/notification/NotificationConfirmationController.scala
@@ -45,13 +45,14 @@ class NotificationConfirmationController @Inject() (
 
   def onPageLoad(notificationReference: String): Action[AnyContent] =
     (identify andThen getData andThen requireData).async { implicit request =>
-      objectStoreService.isNotificationPdfAvailable(notificationReference).map { isPdfAvailable =>
-        Ok(
-          view(
-            notificationReference = notificationReference,
-            displayPdfLink = isPdfAvailable
+      objectStoreService.isNotificationPdfAvailable(request.saoSubscriptionId, notificationReference).map {
+        isPdfAvailable =>
+          Ok(
+            view(
+              notificationReference = notificationReference,
+              displayPdfLink = isPdfAvailable
+            )
           )
-        )
       }
     }
 

--- a/app/models/SubmissionDocumentType.scala
+++ b/app/models/SubmissionDocumentType.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+enum SubmissionDocumentType(val documentName: String) {
+  case Notification extends SubmissionDocumentType("Notification")
+  case Certificate  extends SubmissionDocumentType("Certificate")
+
+  def pdfFileName(reference: String): String = s"${reference}_SAO_$documentName.pdf"
+}

--- a/app/services/ObjectStoreService.scala
+++ b/app/services/ObjectStoreService.scala
@@ -16,16 +16,19 @@
 
 package services
 
+import models.SubmissionDocumentType
 import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
 import play.api.Logging
 import services.ObjectStoreService.*
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.objectstore.client.Object as ObjectStoreObject
 import uk.gov.hmrc.objectstore.client.ObjectSummary
 import uk.gov.hmrc.objectstore.client.Path
 import uk.gov.hmrc.objectstore.client.play.Implicits.*
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import utils.SubscriptionIdHash
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -35,38 +38,56 @@ import javax.inject.Inject
 
 class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(using ec: ExecutionContext)
     extends Logging {
-  def isNotificationPdfAvailable(notificationReference: String)(using hc: HeaderCarrier): Future[Boolean] = {
-    objectStoreClient
-      .listObjects(
-        path = Path.Directory(s"/$objectStoreOwner/$notificationReference/"),
-        owner = objectStoreOwner
-      )
-      .map {
-        _.objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
-          fileName == s"${notificationReference}_SAO_Notification.pdf"
-        }
-      }
-      .recoverWith { case NonFatal(e) =>
-        logger.warn("[OBJECT_STORE][ListObjects]", e)
-        Future.successful(false)
-      }
-  }
+  def isNotificationPdfAvailable(saoSubscriptionId: String, notificationReference: String)(using
+      hc: HeaderCarrier
+  ): Future[Boolean] =
+    isPdfAvailable(saoSubscriptionId, notificationReference, SubmissionDocumentType.Notification)
 
-  def isCertificatePdfAvailable(certificateReference: String)(using hc: HeaderCarrier): Future[Boolean] = {
-    objectStoreClient
-      .listObjects(
-        path = Path.Directory(s"/$objectStoreOwner/$certificateReference/"),
-        owner = objectStoreOwner
-      )
-      .map {
-        _.objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
-          fileName == s"${certificateReference}_SAO_Certificate.pdf"
+  def isCertificatePdfAvailable(saoSubscriptionId: String, certificateReference: String)(using
+      hc: HeaderCarrier
+  ): Future[Boolean] =
+    isPdfAvailable(saoSubscriptionId, certificateReference, SubmissionDocumentType.Certificate)
+
+  def downloadSubmissionPdf(saoSubscriptionId: String, reference: String, documentType: SubmissionDocumentType)(using
+      hc: HeaderCarrier
+  ): Future[Option[ObjectStoreObject[Source[ByteString, NotUsed]]]] =
+    if !isWellFormedReference(reference) then {
+      logger.warn("[OBJECT_STORE][GetObject] rejected a reference that is not well formed")
+      Future.successful(None)
+    } else {
+      objectStoreClient
+        .getObject[Source[ByteString, NotUsed]](
+          path = submissionDirectory(saoSubscriptionId).file(documentType.pdfFileName(reference)),
+          owner = objectStoreOwner
+        )
+        .recoverWith { case NonFatal(e) =>
+          logger.warn("[OBJECT_STORE][GetObject]", e)
+          Future.failed(e)
         }
-      }
-      .recoverWith { case NonFatal(e) =>
-        logger.warn("[OBJECT_STORE][ListObjects]", e)
-        Future.successful(false)
-      }
+    }
+
+  private def isPdfAvailable(saoSubscriptionId: String, reference: String, documentType: SubmissionDocumentType)(using
+      hc: HeaderCarrier
+  ): Future[Boolean] = {
+    if !isWellFormedReference(reference) then {
+      logger.warn("[OBJECT_STORE][ListObjects] rejected a reference that is not well formed")
+      Future.successful(false)
+    } else {
+      objectStoreClient
+        .listObjects(
+          path = submissionDirectory(saoSubscriptionId),
+          owner = objectStoreOwner
+        )
+        .map {
+          _.objectSummaries.exists { case ObjectSummary(Path.File(_, fileName), _, _) =>
+            fileName == documentType.pdfFileName(reference)
+          }
+        }
+        .recoverWith { case NonFatal(e) =>
+          logger.warn("[OBJECT_STORE][ListObjects]", e)
+          Future.successful(false)
+        }
+    }
   }
 
   def downloadDocumentumPackage(submissionId: String, fileName: String)(using
@@ -82,8 +103,16 @@ class ObjectStoreService @Inject() (objectStoreClient: PlayObjectStoreClient)(us
         logger.warn("[OBJECT_STORE][getObject]", e)
         Future.successful(None)
       }
+
+  private def isWellFormedReference(reference: String): Boolean =
+    referenceFormat.matches(reference)
+
+  private def submissionDirectory(saoSubscriptionId: String): Path.Directory =
+    Path.Directory(s"/$objectStoreOwner/${SubscriptionIdHash.hex(saoSubscriptionId)}/")
 }
 
 object ObjectStoreService {
   val objectStoreOwner = "senior-accounting-officer"
+
+  private val referenceFormat = "^[A-Za-z0-9]{1,64}$".r
 }

--- a/app/utils/SubscriptionIdHash.scala
+++ b/app/utils/SubscriptionIdHash.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+object SubscriptionIdHash {
+
+  def hex(saoSubscriptionId: String): String =
+    MessageDigest
+      .getInstance("MD5")
+      .digest(saoSubscriptionId.getBytes(StandardCharsets.UTF_8))
+      .map(byte => String.format("%02x", Byte.box(byte)))
+      .mkString
+}

--- a/app/views/certificate/CertificateConfirmationView.scala.html
+++ b/app/views/certificate/CertificateConfirmationView.scala.html
@@ -49,7 +49,7 @@
             @if(displayPdfLink) {
                 <li>
                     <span>
-                        <a class="govuk-link" id="download-pdf-link" href="#">
+                        <a class="govuk-link" id="download-pdf-link" href="@controllers.routes.DownloadPdfController.certificate(certificateReference)">
                             @messages("certificateConfirmation.downloadPdf")
                         </a>
                         @messages("certificateConfirmation.list1.item1")

--- a/app/views/notification/NotificationConfirmationView.scala.html
+++ b/app/views/notification/NotificationConfirmationView.scala.html
@@ -47,7 +47,7 @@
         @if(displayPdfLink) {
             <li>
                 <span>
-                    <a class="govuk-link" id="download-pdf-link" href="#">
+                    <a class="govuk-link" id="download-pdf-link" href="@controllers.routes.DownloadPdfController.notification(notificationReference)">
                         @messages("notificationConfirmation.downloadPdf")
                     </a>
                     @messages("notificationConfirmation.list1.item1")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -80,6 +80,8 @@ POST        /notification/check-your-answers                                    
 GET         /notification/confirmation                                                controllers.notification.NotificationConfirmationController.onPageLoad(notificationIdReferenceNumber: String)
 POST        /notification/confirmation                                                controllers.notification.NotificationConfirmationController.onSubmit()
 
+GET         /notification/download                                                    controllers.DownloadPdfController.notification(notificationReference: String)
+
 GET         /notification/confirm-your-notification                                   controllers.notification.ConfirmYourNotificationController.onPageLoad()
 POST        /notification/confirm-your-notification                                   controllers.notification.ConfirmYourNotificationController.onSubmit()
 
@@ -139,6 +141,8 @@ POST        /certificateCheckYourAnswers                                        
 
 GET         /certificate-confirmation                                                 controllers.certificate.CertificateConfirmationController.onPageLoad(certificateIdReferenceNumber: String)
 POST        /certificate-confirmation                                                 controllers.certificate.CertificateConfirmationController.onSubmit()
+
+GET         /certificate/download                                                     controllers.DownloadPdfController.certificate(certificateReference: String)
 
 ##############################
 # combined journey routes

--- a/test/controllers/DownloadPdfControllerSpec.scala
+++ b/test/controllers/DownloadPdfControllerSpec.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import config.ErrorHandler
+import controllers.DownloadPdfControllerSpec.*
+import models.SubmissionDocumentType
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import org.mockito.ArgumentMatchers.{any, eq as meq}
+import org.mockito.Mockito.{reset, verify, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.Application
+import play.api.http.HeaderNames
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.ObjectStoreService
+import uk.gov.hmrc.objectstore.client.Md5Hash
+import uk.gov.hmrc.objectstore.client.Object as ObjectStoreObject
+import uk.gov.hmrc.objectstore.client.ObjectMetadata
+import uk.gov.hmrc.objectstore.client.Path
+
+import scala.concurrent.Future
+
+import java.time.Instant
+
+class DownloadPdfControllerSpec extends SpecBase with BeforeAndAfterEach {
+
+  private val mockObjectStoreService = mock[ObjectStoreService]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockObjectStoreService)
+  }
+
+  private def application: Application =
+    applicationBuilder()
+      .overrides(bind[ObjectStoreService].toInstance(mockObjectStoreService))
+      .build()
+
+  private def storedPdf(reference: String, documentType: SubmissionDocumentType) =
+    ObjectStoreObject(
+      Path.Directory(s"/senior-accounting-officer/$reference/").file(documentType.pdfFileName(reference)),
+      Source.single(ByteString(pdfContent)),
+      ObjectMetadata("application/pdf", pdfContent.length.toLong, Md5Hash("hash"), Instant.now(), Map.empty)
+    )
+
+  private def stubDownload(result: Future[Option[ObjectStoreObject[Source[ByteString, NotUsed]]]]): Unit =
+    when(mockObjectStoreService.downloadSubmissionPdf(any(), any(), any())(using any())).thenReturn(result)
+
+  "DownloadPdfController" - {
+    "notification" - {
+      "must stream the pdf as an attachment when it is in object store" in {
+        stubDownload(Future.successful(Some(storedPdf(notificationReference, SubmissionDocumentType.Notification))))
+
+        val app = application
+        running(app) {
+          given Materializer = app.materializer
+
+          val request = FakeRequest(GET, routes.DownloadPdfController.notification(notificationReference).url)
+          val result  = route(app, request).value
+
+          status(result) mustEqual OK
+          contentType(result).value mustEqual "application/pdf"
+          header(HeaderNames.CONTENT_DISPOSITION, result).value mustEqual
+            s"attachment; filename=\"${notificationReference}_SAO_Notification.pdf\""
+          result.futureValue.body.contentLength.value mustEqual pdfContent.length.toLong
+          contentAsString(result) mustEqual pdfContent
+
+          verify(mockObjectStoreService).downloadSubmissionPdf(
+            meq(testSaoSubscriptionId),
+            meq(notificationReference),
+            meq(SubmissionDocumentType.Notification)
+          )(using any())
+        }
+      }
+
+      "must return NOT_FOUND and an error page when the pdf is not in object store" in {
+        stubDownload(Future.successful(None))
+
+        val app = application
+        running(app) {
+          val request = FakeRequest(GET, routes.DownloadPdfController.notification(notificationReference).url)
+          val result  = route(app, request).value
+
+          status(result) mustEqual NOT_FOUND
+          contentType(result).value mustEqual "text/html"
+          contentAsString(result) mustEqual
+            app.injector.instanceOf[ErrorHandler].notFoundTemplate(request).futureValue.toString
+        }
+      }
+
+      "must not swallow an object store failure" in {
+        val expectedException = RuntimeException("some exception")
+        stubDownload(Future.failed(expectedException))
+
+        val app = application
+        running(app) {
+          val request = FakeRequest(GET, routes.DownloadPdfController.notification(notificationReference).url)
+          val result  = route(app, request).value
+
+          result.failed.futureValue mustBe expectedException
+        }
+      }
+    }
+
+    "certificate" - {
+      "must stream the pdf as an attachment when it is in object store" in {
+        stubDownload(Future.successful(Some(storedPdf(certificateReference, SubmissionDocumentType.Certificate))))
+
+        val app = application
+        running(app) {
+          given Materializer = app.materializer
+
+          val request = FakeRequest(GET, routes.DownloadPdfController.certificate(certificateReference).url)
+          val result  = route(app, request).value
+
+          status(result) mustEqual OK
+          contentType(result).value mustEqual "application/pdf"
+          header(HeaderNames.CONTENT_DISPOSITION, result).value mustEqual
+            s"attachment; filename=\"${certificateReference}_SAO_Certificate.pdf\""
+          result.futureValue.body.contentLength.value mustEqual pdfContent.length.toLong
+          contentAsString(result) mustEqual pdfContent
+
+          verify(mockObjectStoreService).downloadSubmissionPdf(
+            meq(testSaoSubscriptionId),
+            meq(certificateReference),
+            meq(SubmissionDocumentType.Certificate)
+          )(using any())
+        }
+      }
+
+      "must return NOT_FOUND and an error page when the pdf is not in object store" in {
+        stubDownload(Future.successful(None))
+
+        val app = application
+        running(app) {
+          val request = FakeRequest(GET, routes.DownloadPdfController.certificate(certificateReference).url)
+          val result  = route(app, request).value
+
+          status(result) mustEqual NOT_FOUND
+          contentType(result).value mustEqual "text/html"
+        }
+      }
+
+    }
+  }
+}
+
+object DownloadPdfControllerSpec {
+  val notificationReference = "NOT0123456789"
+  val certificateReference  = "CRT0001234567"
+  val pdfContent            = "a-pdf-document"
+}

--- a/test/controllers/certificate/CertificateConfirmationControllerSpec.scala
+++ b/test/controllers/certificate/CertificateConfirmationControllerSpec.scala
@@ -45,7 +45,7 @@ class CertificateConfirmationControllerSpec extends SpecBase {
 
         val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreService.isCertificatePdfAvailable(any())(using any())
+          mockObjectStoreService.isCertificatePdfAvailable(any(), any())(using any())
         )
           .thenReturn(Future.successful(false))
 
@@ -70,7 +70,7 @@ class CertificateConfirmationControllerSpec extends SpecBase {
 
         val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreService.isCertificatePdfAvailable(any())(using any())
+          mockObjectStoreService.isCertificatePdfAvailable(any(), any())(using any())
         )
           .thenReturn(Future.successful(true))
 

--- a/test/controllers/notification/NotificationConfirmationControllerSpec.scala
+++ b/test/controllers/notification/NotificationConfirmationControllerSpec.scala
@@ -46,7 +46,7 @@ class NotificationConfirmationControllerSpec extends SpecBase {
 
         val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreService.isNotificationPdfAvailable(any())(using any())
+          mockObjectStoreService.isNotificationPdfAvailable(any(), any())(using any())
         )
           .thenReturn(Future.successful(false))
 
@@ -74,7 +74,7 @@ class NotificationConfirmationControllerSpec extends SpecBase {
 
         val mockObjectStoreService = mock[ObjectStoreService]
         when(
-          mockObjectStoreService.isNotificationPdfAvailable(any())(using any())
+          mockObjectStoreService.isNotificationPdfAvailable(any(), any())(using any())
         )
           .thenReturn(Future.successful(true))
 

--- a/test/models/SubmissionDocumentTypeSpec.scala
+++ b/test/models/SubmissionDocumentTypeSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class SubmissionDocumentTypeSpec extends AnyFreeSpec with Matchers {
+
+  "SubmissionDocumentType" - {
+    "pdfFileName" - {
+      "must build the notification file name stored by the backend" in {
+        SubmissionDocumentType.Notification.pdfFileName("NOT0123456789") mustBe
+          "NOT0123456789_SAO_Notification.pdf"
+      }
+
+      "must build the certificate file name stored by the backend" in {
+        SubmissionDocumentType.Certificate.pdfFileName("CRT0001234567") mustBe
+          "CRT0001234567_SAO_Certificate.pdf"
+      }
+    }
+  }
+}

--- a/test/services/ObjectStoreServiceSpec.scala
+++ b/test/services/ObjectStoreServiceSpec.scala
@@ -17,6 +17,7 @@
 package services
 
 import base.SpecBase
+import models.SubmissionDocumentType
 import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
@@ -37,6 +38,7 @@ import uk.gov.hmrc.objectstore.client.ObjectMetadata
 import uk.gov.hmrc.objectstore.client.ObjectSummary
 import uk.gov.hmrc.objectstore.client.Path
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
+import utils.SubscriptionIdHash
 
 import scala.concurrent.Future
 
@@ -72,7 +74,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
       )
         .thenReturn(Future.failed(RuntimeException("some exception")))
 
-      val result = SUT.isNotificationPdfAvailable(notificationReference)
+      val result = SUT.isNotificationPdfAvailable(saoSubscriptionId, notificationReference)
 
       result.futureValue mustBe false
     }
@@ -88,7 +90,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
       )
         .thenReturn(Future.successful(ObjectListing(Nil)))
 
-      val result = SUT.isNotificationPdfAvailable(notificationReference)
+      val result = SUT.isNotificationPdfAvailable(saoSubscriptionId, notificationReference)
 
       result.futureValue mustBe false
     }
@@ -120,7 +122,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
           )
         )
 
-      val result = SUT.isNotificationPdfAvailable(notificationReference)
+      val result = SUT.isNotificationPdfAvailable(saoSubscriptionId, notificationReference)
 
       result.futureValue mustBe false
     }
@@ -152,7 +154,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
           )
         )
 
-      val result = SUT.isNotificationPdfAvailable(notificationReference)
+      val result = SUT.isNotificationPdfAvailable(saoSubscriptionId, notificationReference)
 
       result.futureValue mustBe true
     }
@@ -170,7 +172,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
       )
         .thenReturn(Future.failed(RuntimeException("some exception")))
 
-      val result = SUT.isCertificatePdfAvailable(certificateReference)
+      val result = SUT.isCertificatePdfAvailable(saoSubscriptionId, certificateReference)
 
       result.futureValue mustBe false
     }
@@ -186,7 +188,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
       )
         .thenReturn(Future.successful(ObjectListing(Nil)))
 
-      val result = SUT.isCertificatePdfAvailable(certificateReference)
+      val result = SUT.isCertificatePdfAvailable(saoSubscriptionId, certificateReference)
 
       result.futureValue mustBe false
     }
@@ -218,7 +220,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
           )
         )
 
-      val result = SUT.isCertificatePdfAvailable(certificateReference)
+      val result = SUT.isCertificatePdfAvailable(saoSubscriptionId, certificateReference)
 
       result.futureValue mustBe false
     }
@@ -250,7 +252,7 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
           )
         )
 
-      val result = SUT.isCertificatePdfAvailable(certificateReference)
+      val result = SUT.isCertificatePdfAvailable(saoSubscriptionId, certificateReference)
 
       result.futureValue mustBe true
     }
@@ -302,9 +304,134 @@ class ObjectStoreServiceSpec extends SpecBase with GuiceOneAppPerSuite with Befo
       )(using any(), any())
     }
   }
+
+  "downloadSubmissionPdf" - {
+    "must download the notification pdf from the path the backend stores it at" in {
+      val expectedPath = Path
+        .Directory(s"/senior-accounting-officer/$hashedSaoSubscriptionId/")
+        .file(s"${notificationReference}_SAO_Notification.pdf")
+      val storedObject = ObjectStoreObject(
+        expectedPath,
+        Source.single(ByteString("pdf-content")),
+        ObjectMetadata("application/pdf", 11, Md5Hash("hash"), Instant.now(), Map.empty)
+      )
+
+      when(
+        mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](
+          path = any(),
+          owner = any()
+        )(using
+          any(),
+          any()
+        )
+      ).thenReturn(Future.successful(Some(storedObject)))
+
+      val result =
+        SUT.downloadSubmissionPdf(saoSubscriptionId, notificationReference, SubmissionDocumentType.Notification)
+
+      result.futureValue mustBe Some(storedObject)
+      verify(mockObjectStoreClient).getObject[Source[ByteString, NotUsed]](
+        path = meq(expectedPath),
+        owner = meq(ObjectStoreService.objectStoreOwner)
+      )(using any(), any())
+    }
+
+    "must download the certificate pdf from the path the backend stores it at" in {
+      val expectedPath = Path
+        .Directory(s"/senior-accounting-officer/$hashedSaoSubscriptionId/")
+        .file(s"${certificateReference}_SAO_Certificate.pdf")
+      val storedObject = ObjectStoreObject(
+        expectedPath,
+        Source.single(ByteString("pdf-content")),
+        ObjectMetadata("application/pdf", 11, Md5Hash("hash"), Instant.now(), Map.empty)
+      )
+
+      when(
+        mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](
+          path = any(),
+          owner = any()
+        )(using
+          any(),
+          any()
+        )
+      ).thenReturn(Future.successful(Some(storedObject)))
+
+      val result =
+        SUT.downloadSubmissionPdf(saoSubscriptionId, certificateReference, SubmissionDocumentType.Certificate)
+
+      result.futureValue mustBe Some(storedObject)
+      verify(mockObjectStoreClient).getObject[Source[ByteString, NotUsed]](
+        path = meq(expectedPath),
+        owner = meq(ObjectStoreService.objectStoreOwner)
+      )(using any(), any())
+    }
+
+    "when the pdf is not in object store must return None" in {
+      when(
+        mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](
+          path = any(),
+          owner = any()
+        )(using
+          any(),
+          any()
+        )
+      ).thenReturn(Future.successful(None))
+
+      val result =
+        SUT.downloadSubmissionPdf(saoSubscriptionId, notificationReference, SubmissionDocumentType.Notification)
+
+      result.futureValue mustBe None
+    }
+
+    "when connection to object store fails must fail rather than report the pdf as missing" in {
+      val expectedException = RuntimeException("some exception")
+
+      when(
+        mockObjectStoreClient.getObject[Source[ByteString, NotUsed]](
+          path = any(),
+          owner = any()
+        )(using
+          any(),
+          any()
+        )
+      ).thenReturn(Future.failed(expectedException))
+
+      val result =
+        SUT.downloadSubmissionPdf(saoSubscriptionId, notificationReference, SubmissionDocumentType.Notification)
+
+      result.failed.futureValue mustBe expectedException
+    }
+
+    malformedReferences.foreach { reference =>
+      s"must return None without calling object store for the reference '$reference'" in {
+        val result = SUT.downloadSubmissionPdf(saoSubscriptionId, reference, SubmissionDocumentType.Notification)
+
+        result.futureValue mustBe None
+        verifyNoInteractions(mockObjectStoreClient)
+      }
+    }
+  }
+
+  "isNotificationPdfAvailable" - {
+    malformedReferences.foreach { reference =>
+      s"must return false without calling object store for the reference '$reference'" in {
+        val result = SUT.isNotificationPdfAvailable(saoSubscriptionId, reference)
+
+        result.futureValue mustBe false
+        verifyNoInteractions(mockObjectStoreClient)
+      }
+    }
+  }
 }
 
 object ObjectStoreServiceSpec {
+  val saoSubscriptionId                = "SAOSUB123456789"
+  val hashedSaoSubscriptionId: String  = SubscriptionIdHash.hex(saoSubscriptionId)
+  val malformedReferences: Seq[String] = Seq(
+    "../../other-service/secret",
+    "NOT 0123456789",
+    ""
+  )
   val notificationReference             = "NOT0123456789"
   val certificateReference              = "CERT123456789"
   val documentumPackageFileName: String =

--- a/test/utils/SubscriptionIdHashSpec.scala
+++ b/test/utils/SubscriptionIdHashSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class SubscriptionIdHashSpec extends AnyFreeSpec with Matchers {
+
+  "SubscriptionIdHash.hex" - {
+    "must match the shared cross repo vectors" in {
+      SubscriptionIdHash.hex("SAOSUB123456789") mustBe "6ac88a7cea0ce7c3e8c3827c9287b17b"
+      SubscriptionIdHash.hex("123") mustBe "202cb962ac59075b964b07152d234b70"
+      SubscriptionIdHash.hex("240") mustBe "335f5352088d7d9bf74191e006d8e24c"
+    }
+
+    "must be lower case hex of a fixed length" in {
+      val hashed = SubscriptionIdHash.hex("SAOSUB000000001")
+      hashed must have length 32
+      hashed mustBe hashed.toLowerCase
+      hashed must fullyMatch regex "[0-9a-f]{32}"
+    }
+  }
+}

--- a/test/views/certificate/CertificateConfirmationViewSpec.scala
+++ b/test/views/certificate/CertificateConfirmationViewSpec.scala
@@ -69,7 +69,7 @@ class CertificateConfirmationViewSpec extends ViewSpecBase[CertificateConfirmati
         .get(0)
         .createTestWithLink(
           linkText = pageDownload,
-          destinationUrl = "#"
+          destinationUrl = pageDownloadUrl
         )
 
       doc.getMainContent
@@ -161,7 +161,9 @@ object CertificateConfirmationViewSpec {
   val pageHeading = "Certificate submitted"
   val pageTitle   = "Certificate submitted"
 
-  val certificateRef    = "SAOCRT0123456789"
+  val certificateRef          = "SAOCRT0123456789"
+  val pageDownloadUrl: String =
+    s"/senior-accounting-officer/submission/certificate/download?certificateReference=$certificateRef"
   val panelTitle        = "Certificate submitted"
   val panelBody: String = s"Your reference number $certificateRef"
 

--- a/test/views/notification/NotificationConfirmationViewSpec.scala
+++ b/test/views/notification/NotificationConfirmationViewSpec.scala
@@ -83,7 +83,7 @@ class NotificationConfirmationViewSpec extends ViewSpecBase[NotificationConfirma
         .get(0)
         .createTestWithLink(
           linkText = pageDownload,
-          destinationUrl = "#"
+          destinationUrl = pageDownloadUrl
         )
 
       doc.getMainContent
@@ -206,7 +206,9 @@ object NotificationConfirmationViewSpec {
     Seq(
       "Print this page - print a paper copy of this confirmation page"
     )
-  val pageDownload                 = "Download a PDF"
+  val pageDownload            = "Download a PDF"
+  val pageDownloadUrl: String =
+    s"/senior-accounting-officer/submission/notification/download?notificationReference=$testReferenceNumber"
   val pagePrint                    = "Print this page"
   val pageSubheadings: Seq[String] = Seq("What happens next")
   val hubUrl                       = "testHubUrl"


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* download pdf link now works on the notification and certificate confirmation pages, streamed from object store
* the pdf is looked up using the subscription id from auth rather than the reference in the url
  * refs are sequential so before this you could get someone else's pdf by changing the number

## Jira ticket(s):
* [SAOD-1012](https://jira.tools.tax.service.gov.uk/browse/SAOD-1012)

## Checklist
* [ ] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * needs the senior-accounting-officer and acceptance-tests PRs
