### PR TITLE
Use enums for Company Status & Type in the protected service requests

### DIFF
--- a/app/models/certificate/CertificateSubmissionRequest.scala
+++ b/app/models/certificate/CertificateSubmissionRequest.scala
@@ -16,6 +16,7 @@
 
 package models.certificate
 
+import models.upload.{CompanyStatus, CompanyType}
 import play.api.libs.json.{Json, OFormat}
 
 final case class CertificateSubmissionRequest(
@@ -35,8 +36,8 @@ final case class CertificateSubmissionCompany(
     utr: String,
     name: String,
     accPeriodEnd: String,
-    status: String,
-    `type`: String,
+    status: CompanyStatus,
+    `type`: CompanyType,
     isCorporationTaxQualified: Boolean,
     isVatQualified: Boolean,
     isPayeQualified: Boolean,

--- a/app/models/notification/Company.scala
+++ b/app/models/notification/Company.scala
@@ -16,6 +16,7 @@
 
 package models.notification
 
+import models.upload.{CompanyStatus, CompanyType}
 import play.api.libs.json.{Json, OFormat}
 
 final case class Company(
@@ -23,8 +24,8 @@ final case class Company(
     utr: String,
     name: String,
     accPeriodEnd: String,
-    status: String,
-    `type`: String
+    status: CompanyStatus,
+    `type`: CompanyType
 )
 
 object Company {

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -19,7 +19,7 @@ package services
 import connectors.CertificateSubmissionConnector
 import models.UserAnswers
 import models.certificate.*
-import models.upload.{CompanyStatus, ParsedSubmissionRow}
+import models.upload.ParsedSubmissionRow
 import pages.certificate.*
 import play.api.Logging
 import play.api.libs.json.Json
@@ -103,8 +103,8 @@ class CertificateSubmissionService @Inject() (
       utr = row.notification.companyUtr.value,
       name = row.notification.companyName,
       accPeriodEnd = row.notification.financialYearEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
-      status = status(row.notification.companyStatus),
-      `type` = row.notification.companyType.toString,
+      status = row.notification.companyStatus,
+      `type` = row.notification.companyType,
       isCorporationTaxQualified = row.certificate.corporationTax,
       isVatQualified = row.certificate.valueAddedTax,
       isPayeQualified = row.certificate.paye,
@@ -117,13 +117,6 @@ class CertificateSubmissionService @Inject() (
       isBankLevyQualified = row.certificate.bankLevy
     )
 
-  private def status(companyStatus: CompanyStatus): String =
-    companyStatus match {
-      case CompanyStatus.Active         => "ACTIVE"
-      case CompanyStatus.Dormant        => "DORMANT"
-      case CompanyStatus.Administration => "ADMINISTRATION"
-      case CompanyStatus.Liquidation    => "LIQUIDATION"
-    }
 }
 
 object CertificateSubmissionService {

--- a/app/services/NotificationSubmitService.scala
+++ b/app/services/NotificationSubmitService.scala
@@ -123,8 +123,8 @@ object NotificationSubmitService {
             utr = company.companyUtr.value,
             name = company.companyName,
             accPeriodEnd = company.financialYearEndDate.toString,
-            status = company.companyStatus.toString,
-            `type` = company.companyType.toString
+            status = company.companyStatus,
+            `type` = company.companyType
           )
         )
         .toList

--- a/it/test/connectors/ProtectedServiceConnectorISpec.scala
+++ b/it/test/connectors/ProtectedServiceConnectorISpec.scala
@@ -18,6 +18,7 @@ package connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import connectors.ProtectedServiceConnectorISpec.*
+
 import java.net.URI
 import models.notification.NotificationRequest
 import play.api.http.Status.CREATED
@@ -26,6 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpResponse
 import models.notification.Company
 import models.notification.Sao
+import models.upload.{CompanyStatus, CompanyType}
 import play.api.libs.json.Json
 
 class ProtectedServiceConnectorISpec extends ISpecBase {
@@ -61,8 +63,8 @@ class ProtectedServiceConnectorISpec extends ISpecBase {
                   utr = "0000000000",
                   name = "String",
                   accPeriodEnd = "2000-01-01",
-                  status = "String",
-                  `type` = "LTD"
+                  status = CompanyStatus.Active,
+                  `type` = CompanyType.LTD
                 )
               ),
               saos = List(

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -17,6 +17,7 @@
 package models.certificate
 
 import base.SpecBase
+import models.upload.{CompanyStatus, CompanyType}
 import play.api.libs.json.*
 
 import CertificateSubmissionRequestFormatSpec.*
@@ -96,8 +97,8 @@ object CertificateSubmissionRequestFormatSpec {
       utr = "1234567890",
       name = "Example Ltd",
       accPeriodEnd = "2026-03-31",
-      status = "COMPLIANT",
-      `type` = "LTD",
+      status = CompanyStatus.Active,
+      `type` = CompanyType.LTD,
       isCorporationTaxQualified = true,
       isVatQualified = false,
       isPayeQualified = false,
@@ -116,7 +117,7 @@ object CertificateSubmissionRequestFormatSpec {
       |  "utr": "1234567890",
       |  "name": "Example Ltd",
       |  "accPeriodEnd": "2026-03-31",
-      |  "status": "COMPLIANT",
+      |  "status": "Active",
       |  "type": "LTD",
       |  "isCorporationTaxQualified": true,
       |  "isVatQualified": false,
@@ -151,7 +152,7 @@ object CertificateSubmissionRequestFormatSpec {
       |      "utr": "1234567890",
       |      "name": "Example Ltd",
       |      "accPeriodEnd": "2026-03-31",
-      |      "status": "COMPLIANT",
+      |      "status": "Active",
       |      "type": "LTD",
       |      "isCorporationTaxQualified": true,
       |      "isVatQualified": false,

--- a/test/services/CertificateSubmissionServiceSpec.scala
+++ b/test/services/CertificateSubmissionServiceSpec.scala
@@ -82,8 +82,8 @@ class CertificateSubmissionServiceSpec extends SpecBase {
       company.utr mustBe "1234567890"
       company.name mustBe "Example Ltd"
       company.accPeriodEnd mustBe "2026-03-31"
-      company.status mustBe "ACTIVE"
-      company.`type` mustBe "LTD"
+      company.status mustBe CompanyStatus.Active
+      company.`type` mustBe CompanyType.LTD
       company.isCorporationTaxQualified mustBe true
       company.isVatQualified mustBe false
       company.isPayeQualified mustBe false

--- a/test/services/NotificationSubmitServiceSpec.scala
+++ b/test/services/NotificationSubmitServiceSpec.scala
@@ -160,8 +160,8 @@ class NotificationSubmitServiceSpec extends SpecBase with GuiceOneAppPerSuite {
             accPeriodEnd = exampleAccPeriodEnd.toString,
             crn = Some(exampleCrn),
             utr = exampleUtr,
-            status = "Active",
-            `type` = "LTD"
+            status = CompanyStatus.Active,
+            `type` = CompanyType.LTD
           )
         ),
         remarks = Some(exampleAdditionalInformation)
@@ -199,8 +199,8 @@ class NotificationSubmitServiceSpec extends SpecBase with GuiceOneAppPerSuite {
             accPeriodEnd = exampleAccPeriodEnd.toString,
             crn = Some(exampleCrn),
             utr = exampleUtr,
-            status = "Active",
-            `type` = "LTD"
+            status = CompanyStatus.Active,
+            `type` = CompanyType.LTD
           )
         ),
         remarks = Some(exampleAdditionalInformation)


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* changing company status and type to enums in the requests we send to protected service
  * certificate enum values have been altered to match notification

## Jira ticket(s):
* part of the sanity checks
  * [SAOD-926](https://jira.tools.tax.service.gov.uk/browse/SAOD-926)
  * [SAOD-927](https://jira.tools.tax.service.gov.uk/browse/SAOD-927)

## Checklist
* [ ] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`? must be on poc/validation-2
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [x] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
    * corresponding enum changes for the protected service on this [PR](https://github.com/hmrc/senior-accounting-officer/pull/88)
