### PR TITLE
fixed certificate flow to add qualification statement

### DIFF
--- a/app/models/certificate/CertificateSubmissionRequest.scala
+++ b/app/models/certificate/CertificateSubmissionRequest.scala
@@ -47,7 +47,8 @@ final case class CertificateSubmissionCompany(
     isPetroleumRevenueTaxQualified: Boolean,
     isCustomsDutiesQualified: Boolean,
     isExciseDutiesQualified: Boolean,
-    isBankLevyQualified: Boolean
+    isBankLevyQualified: Boolean,
+    qualificationStatement: Option[String]
 )
 
 object CertificateSubmissionCompany {

--- a/app/services/CertificateSubmissionService.scala
+++ b/app/services/CertificateSubmissionService.scala
@@ -114,7 +114,8 @@ class CertificateSubmissionService @Inject() (
       isPetroleumRevenueTaxQualified = row.certificate.petroleumRevenueTax,
       isCustomsDutiesQualified = row.certificate.customsDuties,
       isExciseDutiesQualified = row.certificate.exciseDuties,
-      isBankLevyQualified = row.certificate.bankLevy
+      isBankLevyQualified = row.certificate.bankLevy,
+      qualificationStatement = row.certificate.additionalInformation
     )
 
 }

--- a/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
+++ b/test/models/certificate/CertificateSubmissionRequestFormatSpec.scala
@@ -108,7 +108,8 @@ object CertificateSubmissionRequestFormatSpec {
       isPetroleumRevenueTaxQualified = false,
       isCustomsDutiesQualified = false,
       isExciseDutiesQualified = false,
-      isBankLevyQualified = false
+      isBankLevyQualified = false,
+      qualificationStatement = Some("Test Statement")
     )
 
   val companyJson: JsValue = Json.parse(
@@ -128,7 +129,8 @@ object CertificateSubmissionRequestFormatSpec {
       |  "isPetroleumRevenueTaxQualified": false,
       |  "isCustomsDutiesQualified": false,
       |  "isExciseDutiesQualified": false,
-      |  "isBankLevyQualified": false
+      |  "isBankLevyQualified": false,
+      |  "qualificationStatement": "Test Statement"
       |}""".stripMargin
   )
 
@@ -163,7 +165,8 @@ object CertificateSubmissionRequestFormatSpec {
       |      "isPetroleumRevenueTaxQualified": false,
       |      "isCustomsDutiesQualified": false,
       |      "isExciseDutiesQualified": false,
-      |      "isBankLevyQualified": false
+      |      "isBankLevyQualified": false,
+      |      "qualificationStatement": "Test Statement"
       |    }
       |  ],
       |  "remarks": "Certificate remarks"


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* fix: previously we've not mapped additional information from the template to the certificate request

## Jira ticket(s):
* part of the sanity checks
  * [SAOD-927](https://jira.tools.tax.service.gov.uk/browse/SAOD-927)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
