### PR TITLE
fix unescaped content

### DIFF
--- a/app/views/certificate/CertificateReviewQualifiedView.scala.html
+++ b/app/views/certificate/CertificateReviewQualifiedView.scala.html
@@ -35,7 +35,7 @@
 
     <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph2WithLink", certificateRoutes.CertificateUploadFormController.onPageLoad()))</p>
 
-    <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph3", saoName, qualifiedCompanies.size))</p>
+    <p class="govuk-body">@Html(messages("certificateReviewQualified.paragraph3", HtmlFormat.escape(saoName), qualifiedCompanies.size))</p>
 
     @for(qualifiedCompany <- qualifiedCompanies) {
         <dl class="govuk-summary-list">

--- a/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
+++ b/app/views/certificate/CertificateReviewUnqualifiedView.scala.html
@@ -35,7 +35,7 @@
 
     <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph2WithLink", certificateRoutes.CertificateUploadFormController.onPageLoad()))</p>
 
-    <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph3", saoName, unqualifiedCompanies.size))</p>
+    <p class="govuk-body">@Html(messages("certificateReviewUnqualified.paragraph3", HtmlFormat.escape(saoName), unqualifiedCompanies.size))</p>
 
     @for(unqualifiedCompany <- unqualifiedCompanies) {
         <dl class="govuk-summary-list">

--- a/test/views/certificate/CertificateReviewQualifiedViewSpec.scala
+++ b/test/views/certificate/CertificateReviewQualifiedViewSpec.scala
@@ -24,8 +24,8 @@ import org.jsoup.nodes.Document
 import views.html.certificate.CertificateReviewQualifiedView
 
 import java.time.LocalDate
-
 import CertificateReviewQualifiedViewSpec.*
+import base.ViewSpecBase.excludeHelpLinkAndErrorMessageParagraphsSelector
 
 class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQualifiedView] {
 
@@ -105,7 +105,7 @@ class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQ
       )
     }
 
-    "When rows are and a different sao name are passed to the view must render populated table with differnt sao name" - {
+    "When rows are and a different sao name are passed to the view must render populated table with different sao name" - {
       val doc: Document = generateView(secondSaoName, qualifiedCompanies, 2)
 
       doc.createTestsWithStandardPageElements(
@@ -136,6 +136,15 @@ class CertificateReviewQualifiedViewSpec extends ViewSpecBase[CertificateReviewQ
       doc.createTestsWithSubmissionButton(
         action = certificateRoutes.CertificateReviewQualifiedController.onSubmit(),
         buttonText = "Continue"
+      )
+    }
+
+    "The content of SAO's name is properly escaped" in {
+      val unescapedText = "<script>alert(123)</script>"
+      val doc: Document = generateView(unescapedText, qualifiedCompanies, 2)
+
+      doc.select(excludeHelpLinkAndErrorMessageParagraphsSelector).eachText().toArray.toSeq.mkString(",") must include(
+        unescapedText
       )
     }
   }

--- a/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
+++ b/test/views/certificate/CertificateReviewUnqualifiedViewSpec.scala
@@ -25,8 +25,9 @@ import org.jsoup.nodes.Document
 import views.html.certificate.CertificateReviewUnqualifiedView
 
 import java.time.LocalDate
-
 import CertificateReviewUnqualifiedViewSpec.*
+import base.ViewSpecBase.excludeHelpLinkAndErrorMessageParagraphsSelector
+
 class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateReviewUnqualifiedView] {
   private def generateView(
       saoName: String,
@@ -105,6 +106,15 @@ class CertificateReviewUnqualifiedViewSpec extends ViewSpecBase[CertificateRevie
 
       doc.createTestsWithUnqualifiedCompanyDescriptionList(Seq())
 
+    }
+
+    "The content of SAO's name is properly escaped" in {
+      val unescapedText = "<script>alert(123)</script>"
+      val doc: Document = generateView(unescapedText, unqualifiedCompanies, 2)
+
+      doc.select(excludeHelpLinkAndErrorMessageParagraphsSelector).eachText().toArray.toSeq.mkString(",") must include(
+        unescapedText
+      )
     }
   }
   extension (doc: Document) {


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Fix: Escape the SAO name shown on the delcaration page

## Jira ticket(s):
* as part of the sanity check [SAOD-927](https://jira.tools.tax.service.gov.uk/browse/SAOD-927)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
